### PR TITLE
Ensure framebuffer resizes one dimension at a time

### DIFF
--- a/Bonsai.Vision.Design/VisualizerCanvas.cs
+++ b/Bonsai.Vision.Design/VisualizerCanvas.cs
@@ -15,6 +15,8 @@ namespace Bonsai.Vision.Design
     {
         bool loaded;
         bool disposed;
+        bool resizing;
+        bool resizeWidth;
         static readonly object syncRoot = string.Intern("A1105A50-BBB0-4EC6-B8B2-B5EF38A9CC3E");
 
         /// <summary>
@@ -81,8 +83,30 @@ namespace Bonsai.Vision.Design
             lock (syncRoot)
             {
                 canvas.SwapBuffers();
+                if (resizing)
+                {
+                    resizing = false;
+                    resizeWidth = !resizeWidth;
+                    if (canvas.Size != Size)
+                    {
+                        OnResize(EventArgs.Empty);
+                    }
+                }
             }
             OnSwapBuffers(e);
+        }
+
+        protected override void OnResize(EventArgs e)
+        {
+            var partialResize = canvas.Width == Width || canvas.Height == Height;
+            if (!loaded || partialResize) canvas.Size = Size;
+            else
+            {
+                if (resizeWidth) canvas.Size = new Size(Width, canvas.Height);
+                else canvas.Size = new Size(canvas.Width, Height);
+                resizing = true;
+            }
+            base.OnResize(e);
         }
 
         /// <summary>

--- a/Bonsai.Vision.Design/VisualizerCanvas.cs
+++ b/Bonsai.Vision.Design/VisualizerCanvas.cs
@@ -48,7 +48,7 @@ namespace Bonsai.Vision.Design
             get { return canvas; }
         }
 
-        private void canvas_Load(object sender, EventArgs e)
+        private void canvas_HandleCreated(object sender, EventArgs e)
         {
             if (DesignMode) return;
             MakeCurrent();
@@ -60,6 +60,7 @@ namespace Bonsai.Vision.Design
             GL.Ortho(-1.0, 1.0, -1.0, 1.0, 0.0, 1.0);
 
             loaded = true;
+            canvas.Size = Size;
         }
 
         private void canvas_Resize(object sender, EventArgs e)

--- a/Bonsai.Vision.Design/VisualizerCanvas.cs
+++ b/Bonsai.Vision.Design/VisualizerCanvas.cs
@@ -96,6 +96,7 @@ namespace Bonsai.Vision.Design
             OnSwapBuffers(e);
         }
 
+        /// <inheritdoc/>
         protected override void OnResize(EventArgs e)
         {
             var partialResize = canvas.Width == Width || canvas.Height == Height;

--- a/Bonsai.Vision.Design/VisualizerCanvas.designer.cs
+++ b/Bonsai.Vision.Design/VisualizerCanvas.designer.cs
@@ -26,7 +26,7 @@
             this.canvas.Size = new System.Drawing.Size(320, 240);
             this.canvas.TabIndex = 1;
             this.canvas.VSync = false;
-            this.canvas.Load += new System.EventHandler(this.canvas_Load);
+            this.canvas.HandleCreated += new System.EventHandler(this.canvas_HandleCreated);
             this.canvas.Paint += new System.Windows.Forms.PaintEventHandler(this.canvas_Paint);
             this.canvas.Resize += new System.EventHandler(this.canvas_Resize);
             // 

--- a/Bonsai.Vision.Design/VisualizerCanvas.designer.cs
+++ b/Bonsai.Vision.Design/VisualizerCanvas.designer.cs
@@ -21,7 +21,6 @@
             // canvas
             // 
             this.canvas.BackColor = System.Drawing.Color.Black;
-            this.canvas.Dock = System.Windows.Forms.DockStyle.Fill;
             this.canvas.Location = new System.Drawing.Point(0, 0);
             this.canvas.Name = "canvas";
             this.canvas.Size = new System.Drawing.Size(320, 240);


### PR DESCRIPTION
Apparently resizing the GL control only horizontally or vertically prevents `SwapBuffers` from crashing, as described in https://github.com/ocornut/imgui/issues/3321. Building on top of this observation, this PR implements dynamic control resizing by changing only a single dimension per frame until the canvas is fully resized to its target size.

Fixes #913