### PR TITLE
Add built-in integration for community documentation

### DIFF
--- a/Bonsai.Configuration/ConfigurationHelper.cs
+++ b/Bonsai.Configuration/ConfigurationHelper.cs
@@ -80,29 +80,25 @@ namespace Bonsai.Configuration
             return packageMap;
         }
 
-        public static IEnumerable<PackageReference> GetAssemblyPackageReferences(
+        public static PackageReference GetAssemblyPackageReference(
             this PackageConfiguration configuration,
-            IEnumerable<string> assemblyNames,
+            string assemblyName,
             IDictionary<string, PackageReference> packageMap)
         {
-            var dependencies = new List<PackageReference>();
-            foreach (var assemblyName in assemblyNames)
+            var assemblyLocation = GetAssemblyLocation(configuration, assemblyName);
+            if (assemblyLocation != null)
             {
-                var assemblyLocation = GetAssemblyLocation(configuration, assemblyName);
-                if (assemblyLocation != null)
+                var pathElements = assemblyLocation.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                if (pathElements.Length > 1 && pathElements[0] == RepositoryPath)
                 {
-                    var pathElements = assemblyLocation.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-                    if (pathElements.Length > 1 && pathElements[0] == RepositoryPath)
+                    if (packageMap.TryGetValue(pathElements[1], out PackageReference package))
                     {
-                        if (packageMap.TryGetValue(pathElements[1], out PackageReference package))
-                        {
-                            dependencies.Add(package);
-                        }
+                        return package;
                     }
                 }
             }
 
-            return dependencies;
+            return null;
         }
 
         public static void SetAssemblyResolve(PackageConfiguration configuration)

--- a/Bonsai.Configuration/ScriptExtensions.cs
+++ b/Bonsai.Configuration/ScriptExtensions.cs
@@ -143,7 +143,9 @@ namespace Bonsai.Configuration
             var projectReferences = root.Descendants(PackageReferenceElement).ToArray();
             var lastReference = projectReferences.LastOrDefault();
 
-            var packageReferences = packageConfiguration.GetAssemblyPackageReferences(assemblyReferences, packageMap);
+            var packageReferences = assemblyReferences
+                .Select(assemblyName => packageConfiguration.GetAssemblyPackageReference(assemblyName, packageMap))
+                .Where(package => package != null);
             foreach (var reference in packageReferences)
             {
                 var includeAttribute = new XAttribute(PackageIncludeAttribute, reference.Id);

--- a/Bonsai.Editor/Bonsai.Editor.csproj
+++ b/Bonsai.Editor/Bonsai.Editor.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Rx-PlatformServices" Version="2.2.5" />
     <PackageReference Include="SvgNet" Version="2.2.2" />
+    <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.Design\Bonsai.Design.csproj" />

--- a/Bonsai.Editor/DocumentationHelper.cs
+++ b/Bonsai.Editor/DocumentationHelper.cs
@@ -25,7 +25,7 @@ namespace Bonsai.Editor
 
         static async Task<Uri> GetDocumentationAsync(string baseUrl, string uid)
         {
-            var lookup = await GetXRefMapAsync(baseUrl, "docs/", string.Empty);
+            var lookup = await GetXRefMapAsync(baseUrl.TrimEnd('/'), "/docs", string.Empty);
             return new Uri(lookup[uid]);
         }
 
@@ -53,7 +53,7 @@ namespace Bonsai.Editor
 
         static async Task<Dictionary<string, string>> GetXRefMapAsync(string baseUrl)
         {
-            var requestUrl = $"{baseUrl}xrefmap.yml";
+            var requestUrl = $"{baseUrl}/xrefmap.yml";
             var request = WebRequest.CreateHttp(requestUrl);
             request.CachePolicy = new RequestCachePolicy(RequestCacheLevel.Revalidate);
             using var response = await request.GetResponseAsync();
@@ -66,7 +66,7 @@ namespace Bonsai.Editor
             var xrefmap = deserializer.Deserialize<XRefMap>(reader);
             return xrefmap.References.ToDictionary(
                 reference => reference.Uid,
-                reference => $"{baseUrl}{reference.Href}");
+                reference => $"{baseUrl}/{reference.Href}");
         }
 
         class XRefMap

--- a/Bonsai.Editor/DocumentationHelper.cs
+++ b/Bonsai.Editor/DocumentationHelper.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Cache;
+using System.Threading.Tasks;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Bonsai.Editor
+{
+    static class DocumentationHelper
+    {
+        public static async Task<Uri> GetDocumentationAsync(this IDocumentationProvider provider, string assemblyName, string uid)
+        {
+            var baseUrl = provider.GetDocumentationUrl(assemblyName);
+            if (string.IsNullOrEmpty(baseUrl))
+            {
+                throw new ArgumentException($"No documentation found for the specified module.", nameof(assemblyName));
+            }
+
+            return await GetDocumentationAsync(baseUrl, uid);
+        }
+
+        static async Task<Uri> GetDocumentationAsync(string baseUrl, string uid)
+        {
+            var lookup = await GetXRefMapAsync(baseUrl, "docs-wip/", string.Empty);
+            return new Uri($"{baseUrl}docs-wip/{lookup[uid]}");
+        }
+
+        static async Task<Dictionary<string, string>> GetXRefMapAsync(string baseUrl, params string[] hrefs)
+        {
+            if (hrefs == null || hrefs.Length == 0)
+            {
+                throw new ArgumentException("No downstream URLs have been specified.", nameof(hrefs));
+            }
+
+            WebException lastException = default;
+            for (int i = 0; i < hrefs.Length; i++)
+            {
+                var requestUrl = $"{baseUrl}{hrefs[i]}xrefmap.yml";
+                try { return await GetXRefMapAsync(requestUrl); }
+                catch (WebException ex) when (ex.Response is HttpWebResponse httpResponse &&
+                                              httpResponse.StatusCode is HttpStatusCode.NotFound)
+                {
+                    lastException = ex;
+                    continue;
+                }
+            }
+
+            throw lastException;
+        }
+
+        static async Task<Dictionary<string, string>> GetXRefMapAsync(string requestUrl)
+        {
+            var request = WebRequest.CreateHttp(requestUrl);
+            request.CachePolicy = new RequestCachePolicy(RequestCacheLevel.Revalidate);
+            using var response = await request.GetResponseAsync();
+            var stream = response.GetResponseStream();
+            using var reader = new StreamReader(stream);
+            var deserializer = new DeserializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .IgnoreUnmatchedProperties()
+                .Build();
+            var xrefmap = deserializer.Deserialize<XRefMap>(reader);
+            return xrefmap.References.ToDictionary(
+                reference => reference.Uid,
+                reference => reference.Href);
+        }
+
+        class XRefMap
+        {
+            public bool? Sorted { get; set; }
+
+            public List<XRefSpec> References { get; set; }
+        }
+
+        class XRefSpec
+        {
+            public string Uid { get; set; }
+
+            public string Name { get; set; }
+
+            public string Href { get; set; }
+
+            public string CommentId { get; set; }
+
+            public string FullName { get; set; }
+
+            public string NameWithType { get; set; }
+
+            public bool? IsSpec { get; set; }
+        }
+    }
+}

--- a/Bonsai.Editor/DocumentationHelper.cs
+++ b/Bonsai.Editor/DocumentationHelper.cs
@@ -25,8 +25,8 @@ namespace Bonsai.Editor
 
         static async Task<Uri> GetDocumentationAsync(string baseUrl, string uid)
         {
-            var lookup = await GetXRefMapAsync(baseUrl, "docs-wip/", string.Empty);
-            return new Uri($"{baseUrl}docs-wip/{lookup[uid]}");
+            var lookup = await GetXRefMapAsync(baseUrl, "docs/", string.Empty);
+            return new Uri($"{baseUrl}docs/{lookup[uid]}");
         }
 
         static async Task<Dictionary<string, string>> GetXRefMapAsync(string baseUrl, params string[] hrefs)

--- a/Bonsai.Editor/DocumentationHelper.cs
+++ b/Bonsai.Editor/DocumentationHelper.cs
@@ -53,8 +53,10 @@ namespace Bonsai.Editor
 
         static async Task<Dictionary<string, string>> GetXRefMapAsync(string baseUrl)
         {
+            const int ReadWriteTimeout = 10000;
             var requestUrl = $"{baseUrl}/xrefmap.yml";
             var request = WebRequest.CreateHttp(requestUrl);
+            request.ReadWriteTimeout = ReadWriteTimeout;
             request.CachePolicy = new RequestCachePolicy(RequestCacheLevel.Revalidate);
             using var response = await request.GetResponseAsync();
             var stream = response.GetResponseStream();

--- a/Bonsai.Editor/EditorDialog.cs
+++ b/Bonsai.Editor/EditorDialog.cs
@@ -6,7 +6,12 @@ namespace Bonsai.Editor
 {
     static class EditorDialog
     {
-        public static void OpenUri(string url)
+        public static void OpenUrl(Uri url)
+        {
+            OpenUrl(url.AbsoluteUri);
+        }
+
+        public static void OpenUrl(string url)
         {
             var validUrl = Uri.TryCreate(url, UriKind.Absolute, out Uri result) &&
                 (result.Scheme == Uri.UriSchemeFile || result.Scheme == Uri.UriSchemeHttp || result.Scheme == Uri.UriSchemeHttps);
@@ -34,17 +39,17 @@ namespace Bonsai.Editor
 
         public static void ShowDocs()
         {
-            OpenUri("http://bonsai-rx.org/docs/editor/");
+            OpenUrl("http://bonsai-rx.org/docs/editor/");
         }
 
         public static void ShowForum()
         {
-            OpenUri("https://github.com/bonsai-rx/bonsai/discussions");
+            OpenUrl("https://github.com/bonsai-rx/bonsai/discussions");
         }
 
         public static void ShowReportBug()
         {
-            OpenUri("https://github.com/bonsai-rx/bonsai/issues");
+            OpenUrl("https://github.com/bonsai-rx/bonsai/issues");
         }
 
         public static void ShowAboutBox()

--- a/Bonsai.Editor/EditorDialog.cs
+++ b/Bonsai.Editor/EditorDialog.cs
@@ -39,7 +39,7 @@ namespace Bonsai.Editor
 
         public static void ShowDocs()
         {
-            OpenUrl("http://bonsai-rx.org/docs/articles/editor");
+            OpenUrl("https://bonsai-rx.org/docs/articles/editor");
         }
 
         public static void ShowForum()

--- a/Bonsai.Editor/EditorDialog.cs
+++ b/Bonsai.Editor/EditorDialog.cs
@@ -39,7 +39,7 @@ namespace Bonsai.Editor
 
         public static void ShowDocs()
         {
-            OpenUrl("http://bonsai-rx.org/docs/editor/");
+            OpenUrl("http://bonsai-rx.org/docs/articles/editor");
         }
 
         public static void ShowForum()

--- a/Bonsai.Editor/EditorForm.Designer.cs
+++ b/Bonsai.Editor/EditorForm.Designer.cs
@@ -133,6 +133,7 @@
             this.propertiesLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.propertiesLabel = new System.Windows.Forms.Label();
             this.toolboxContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.toolboxDocsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.insertAfterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.insertBeforeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.createBranchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -599,7 +600,7 @@
             // welcomeToolStripMenuItem
             // 
             this.welcomeToolStripMenuItem.Name = "welcomeToolStripMenuItem";
-            this.welcomeToolStripMenuItem.Size = new System.Drawing.Size(157, 22);
+            this.welcomeToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.welcomeToolStripMenuItem.Text = "&Welcome...";
             this.welcomeToolStripMenuItem.Click += new System.EventHandler(this.welcomeToolStripMenuItem_Click);
             // 
@@ -607,15 +608,16 @@
             // 
             this.docsToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("docsToolStripMenuItem.Image")));
             this.docsToolStripMenuItem.Name = "docsToolStripMenuItem";
-            this.docsToolStripMenuItem.Size = new System.Drawing.Size(157, 22);
-            this.docsToolStripMenuItem.Text = "&Documentation";
+            this.docsToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F1;
+            this.docsToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.docsToolStripMenuItem.Text = "&View Help";
             this.docsToolStripMenuItem.Click += new System.EventHandler(this.docsToolStripMenuItem_Click);
             // 
             // forumToolStripMenuItem
             // 
             this.forumToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("forumToolStripMenuItem.Image")));
             this.forumToolStripMenuItem.Name = "forumToolStripMenuItem";
-            this.forumToolStripMenuItem.Size = new System.Drawing.Size(157, 22);
+            this.forumToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.forumToolStripMenuItem.Text = "Bonsai &Forums";
             this.forumToolStripMenuItem.Click += new System.EventHandler(this.forumToolStripMenuItem_Click);
             // 
@@ -623,19 +625,19 @@
             // 
             this.reportBugToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("reportBugToolStripMenuItem.Image")));
             this.reportBugToolStripMenuItem.Name = "reportBugToolStripMenuItem";
-            this.reportBugToolStripMenuItem.Size = new System.Drawing.Size(157, 22);
+            this.reportBugToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.reportBugToolStripMenuItem.Text = "&Report a Bug";
             this.reportBugToolStripMenuItem.Click += new System.EventHandler(this.reportBugToolStripMenuItem_Click);
             // 
             // toolStripSeparator5
             // 
             this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(154, 6);
+            this.toolStripSeparator5.Size = new System.Drawing.Size(149, 6);
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(157, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.aboutToolStripMenuItem.Text = "&About...";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
@@ -1157,6 +1159,7 @@
             // toolboxContextMenuStrip
             // 
             this.toolboxContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolboxDocsToolStripMenuItem,
             this.insertAfterToolStripMenuItem,
             this.insertBeforeToolStripMenuItem,
             this.createBranchToolStripMenuItem,
@@ -1167,6 +1170,14 @@
             this.goToDefinitionToolStripMenuItem});
             this.toolboxContextMenuStrip.Name = "toolboxContextMenuStrip";
             this.toolboxContextMenuStrip.Size = new System.Drawing.Size(207, 202);
+            // 
+            // toolboxDocsToolStripMenuItem
+            // 
+            this.toolboxDocsToolStripMenuItem.Name = "toolboxDocsToolStripMenuItem";
+            this.toolboxDocsToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F1;
+            this.toolboxDocsToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.toolboxDocsToolStripMenuItem.Text = "View Help";
+            this.toolboxDocsToolStripMenuItem.Click += new System.EventHandler(this.docsToolStripMenuItem_Click);
             // 
             // insertAfterToolStripMenuItem
             // 
@@ -1248,7 +1259,7 @@
     "*.tiff)|*.tif;*.tiff|PNG (*.png)|*.png|SVG (*.svg)|*.svg";
             this.exportImageDialog.FilterIndex = 6;
             // 
-            // MainForm
+            // EditorForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
@@ -1261,7 +1272,7 @@
             this.KeyPreview = true;
             this.MainMenuStrip = this.menuStrip;
             this.MinimumSize = new System.Drawing.Size(600, 343);
-            this.Name = "MainForm";
+            this.Name = "EditorForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Bonsai";
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MainForm_KeyDown);
@@ -1414,6 +1425,7 @@
         private System.Windows.Forms.ToolStripMenuItem startWithoutDebuggingToolStripButtonMenuItem;
         private System.Windows.Forms.ContextMenuStrip statusContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem statusCopyToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem toolboxDocsToolStripMenuItem;
     }
 }
 

--- a/Bonsai.Editor/EditorForm.Designer.cs
+++ b/Bonsai.Editor/EditorForm.Designer.cs
@@ -1173,6 +1173,8 @@
             // 
             // toolboxDocsToolStripMenuItem
             // 
+            this.toolboxDocsToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("docsToolStripMenuItem.Image")));
+            this.toolboxDocsToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolboxDocsToolStripMenuItem.Name = "toolboxDocsToolStripMenuItem";
             this.toolboxDocsToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F1;
             this.toolboxDocsToolStripMenuItem.Size = new System.Drawing.Size(206, 22);

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2233,8 +2233,9 @@ namespace Bonsai.Editor
                 var path = include.Path;
                 const char AssemblySeparator = ':';
                 var separatorIndex = path.IndexOf(AssemblySeparator);
-                if (separatorIndex >= 0 && !Path.IsPathRooted(path))
+                if (separatorIndex >= 0 && !Path.IsPathRooted(path) && path.EndsWith(BonsaiExtension))
                 {
+                    path = Path.ChangeExtension(path, null);
                     var nameElements = path.Split(new[] { AssemblySeparator }, 2);
                     if (!string.IsNullOrEmpty(nameElements[0]))
                     {

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2224,6 +2224,31 @@ namespace Bonsai.Editor
 
         #region Help Menu
 
+        private async Task OpenDocumentationAsync(ExpressionBuilder builder)
+        {
+            var selectedElement = ExpressionBuilder.GetWorkflowElement(builder);
+            if (selectedElement is IncludeWorkflowBuilder include &&
+                !string.IsNullOrEmpty(include.Path))
+            {
+                var path = include.Path;
+                const char AssemblySeparator = ':';
+                var separatorIndex = path.IndexOf(AssemblySeparator);
+                if (separatorIndex >= 0 && !Path.IsPathRooted(path))
+                {
+                    var nameElements = path.Split(new[] { AssemblySeparator }, 2);
+                    if (!string.IsNullOrEmpty(nameElements[0]))
+                    {
+                        var assemblyName = nameElements[0];
+                        var resourceName = string.Join(ExpressionHelper.MemberSeparator, nameElements);
+                        await OpenDocumentationAsync(assemblyName, resourceName);
+                        return;
+                    }
+                }
+            }
+
+            await OpenDocumentationAsync(selectedElement.GetType());
+        }
+
         private async Task OpenDocumentationAsync(Type type)
         {
             var uid = type.FullName;
@@ -2284,8 +2309,7 @@ namespace Bonsai.Editor
                 var selectedNode = selectionModel.SelectedNodes.FirstOrDefault();
                 if (selectedNode != null)
                 {
-                    var selectedElementType = ExpressionBuilder.GetWorkflowElement(selectedNode.Value).GetType();
-                    await OpenDocumentationAsync(selectedElementType);
+                    await OpenDocumentationAsync(selectedNode.Value);
                     return;
                 }
             }

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
@@ -1,4 +1,4 @@
-namespace Bonsai.Editor.GraphView
+﻿namespace Bonsai.Editor.GraphView
 {
     partial class WorkflowGraphView
     {
@@ -39,6 +39,8 @@ namespace Bonsai.Editor.GraphView
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.visualizerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.defaultEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.docsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.goToDefinitionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.cutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -55,7 +57,6 @@ namespace Bonsai.Editor.GraphView
             this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this.enableToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.disableToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.goToDefinitionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.graphView = new Bonsai.Editor.GraphView.GraphViewControl();
             this.contextMenuStrip.SuspendLayout();
             this.SuspendLayout();
@@ -71,6 +72,7 @@ namespace Bonsai.Editor.GraphView
             this.toolStripSeparator3,
             this.visualizerToolStripMenuItem,
             this.defaultEditorToolStripMenuItem,
+            this.docsToolStripMenuItem,
             this.goToDefinitionToolStripMenuItem,
             this.toolStripSeparator2,
             this.cutToolStripMenuItem,
@@ -89,7 +91,7 @@ namespace Bonsai.Editor.GraphView
             this.enableToolStripMenuItem,
             this.disableToolStripMenuItem});
             this.contextMenuStrip.Name = "contextMenuStrip";
-            this.contextMenuStrip.Size = new System.Drawing.Size(250, 480);
+            this.contextMenuStrip.Size = new System.Drawing.Size(250, 502);
             this.contextMenuStrip.Closed += new System.Windows.Forms.ToolStripDropDownClosedEventHandler(this.contextMenuStrip_Closed);
             this.contextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStrip_Opening);
             // 
@@ -146,6 +148,25 @@ namespace Bonsai.Editor.GraphView
             this.defaultEditorToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
             this.defaultEditorToolStripMenuItem.Text = "Show Default Editor...";
             this.defaultEditorToolStripMenuItem.Click += new System.EventHandler(this.defaultEditorToolStripMenuItem_Click);
+            // 
+            // docsToolStripMenuItem
+            // 
+            this.docsToolStripMenuItem.Enabled = false;
+            this.docsToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("docsToolStripMenuItem.Image")));
+            this.docsToolStripMenuItem.Name = "docsToolStripMenuItem";
+            this.docsToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F1;
+            this.docsToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
+            this.docsToolStripMenuItem.Text = "View Help...";
+            this.docsToolStripMenuItem.Click += new System.EventHandler(this.docsToolStripMenuItem_Click);
+            // 
+            // goToDefinitionToolStripMenuItem
+            // 
+            this.goToDefinitionToolStripMenuItem.Enabled = false;
+            this.goToDefinitionToolStripMenuItem.Name = "goToDefinitionToolStripMenuItem";
+            this.goToDefinitionToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F12;
+            this.goToDefinitionToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
+            this.goToDefinitionToolStripMenuItem.Text = "Go To Definition...";
+            this.goToDefinitionToolStripMenuItem.Click += new System.EventHandler(this.goToDefinitionToolStripMenuItem_Click);
             // 
             // toolStripSeparator2
             // 
@@ -286,15 +307,6 @@ namespace Bonsai.Editor.GraphView
             this.disableToolStripMenuItem.Text = "Disable";
             this.disableToolStripMenuItem.Click += new System.EventHandler(this.disableToolStripMenuItem_Click);
             // 
-            // goToDefinitionToolStripMenuItem
-            // 
-            this.goToDefinitionToolStripMenuItem.Enabled = false;
-            this.goToDefinitionToolStripMenuItem.Name = "goToDefinitionToolStripMenuItem";
-            this.goToDefinitionToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F12;
-            this.goToDefinitionToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
-            this.goToDefinitionToolStripMenuItem.Text = "Go To Definition...";
-            this.goToDefinitionToolStripMenuItem.Click += new System.EventHandler(this.goToDefinitionToolStripMenuItem_Click);
-            // 
             // graphView
             // 
             this.graphView.AllowDrop = true;
@@ -363,5 +375,6 @@ namespace Bonsai.Editor.GraphView
         private System.Windows.Forms.ToolStripMenuItem disableToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
         private System.Windows.Forms.ToolStripMenuItem goToDefinitionToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem docsToolStripMenuItem;
     }
 }

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1285,6 +1285,11 @@ namespace Bonsai.Editor.GraphView
             LaunchDefaultEditor(graphView.SelectedNode);
         }
 
+        private void docsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            editorService.OnKeyDown(new KeyEventArgs(Keys.F1));
+        }
+
         private void goToDefinitionToolStripMenuItem_Click(object sender, EventArgs e)
         {
             LaunchDefinition(graphView.SelectedNode);
@@ -1784,6 +1789,7 @@ namespace Bonsai.Editor.GraphView
                 var builder = WorkflowEditor.GetGraphNodeBuilder(selectedNode);
                 defaultEditorToolStripMenuItem.Enabled = HasDefaultEditor(builder);
                 goToDefinitionToolStripMenuItem.Enabled = HasDefinition(builder);
+                docsToolStripMenuItem.Enabled = true;
 
                 var workflowElement = ExpressionBuilder.GetWorkflowElement(builder);
                 if (workflowElement != null)

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.resx
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.resx
@@ -117,42 +117,42 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing">
+    <value>17, 17</value>
+  </data>
   <data name="cutToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAETSURBVDhPlZI9joMwEEZ9hD3CHiFnoEfallNwhb1BDkNP
-        T5Ut6Jci2YYiifgrHT8zQwwklvaTRtjzvfGMLUyovu8P4zheCacPSRvWmoeR9F4AeZ7boijsMAzfkjas
-        yeHBSHovZ9okSWyWZR6ks3Ynhwcj+F4hqFNo9/BgwfcCLstyBYeHVlW1utpLdV33y111Cu1ODk+w93Id
-        vuq6XqbQ7uTwBIsrnOJf3RGv3ratL7yc/3ywjr4+csARiHh3QBBHKZtFgjumaerhWMDArg7hVIzT6cfe
-        rnf/BWYSnSb0YKmR8ucfCKDBvmkaH688aqZp+lwO2E6gXWKeL0Zus3oDvnrPmCflswReuoa/7NZjPzvG
-        PACo9vZBhvc9ZwAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wgAADsIBFShKgAAAARNJREFUOE+Vkj2OgzAQRn2EPcIeIWegR9qWU3CFvUEOQ09PlS3olyLZhiKJ+Csd
+        PzNDDCSW9pNG2PO98YwtTKi+7w/jOF4Jpw9JG9aah5H0XgB5ntuiKOwwDN+SNqzJ4cFIei9n2iRJbJZl
+        HqSzdieHByP4XiGoU2j38GDB9wIuy3IFh4dWVbW62kt1XffLXXUK7U4OT7D3ch2+6rpeptDu5PAEiyuc
+        4l/dEa/etq0vvJz/fLCOvj5ywBGIeHdAEEcpm0WCO6Zp6uFYwMCuDuFUjNPpx96ud/8FZhKdJvRgqZHy
+        5x8IoMG+aRofrzxqpmn6XA7YTqBdYp4vRm6zegO+es+YJ+WzBF66hr/s1mM/O8Y8AKj29kGG9z1nAAAA
+        AElFTkSuQmCC
 </value>
   </data>
   <data name="copyToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABYSURBVDhPY8AGvn379p8YDFWOCUCSTk5OeDH9DPjw/iMK
-        xmoAiEMMxmsATAIXpp8BML/CMLKGYWAAjA3jQ7XT0QB0DNWOagAujKIBHVDFAGIwVDkSYGAAAJ5YL7el
-        /ns1AAAAAElFTkSuQmCC
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wgAADsIBFShKgAAAAFhJREFUOE9jwAa+ffv2nxgMVY4JQJJOTk54Mf0M+PD+IwrGagCIQwzGawBMAhem
+        nwEwv8IwsoZhYACMDeNDtdPRAHQM1Y5qAC6MogEdUMUAYjBUORJgYAAAnlgvt6X+ezUAAAAASUVORK5C
+        YII=
 </value>
   </data>
   <data name="pasteToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACWSURBVDhP3Y5NCsMgEEY9Qo8U3HtD75LLpN24sIWOLlO+
-        wUkkTk0CWeWDB8P8PDW9xBgfRDSmlGaAGr0y3g8OvPeztZZBjV4Z/0/OecCLIQQ+fE4vBrX8pqy2kQUg
-        L9eCWgLK2Zr6sMY51/ROCTR2Be/4UWkEKDToS8whgTS3YHZYoC3eRCAHW64XaGDWYxH04CU1xvwAFVFR
-        +LRFzJEAAAAASUVORK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wgAADsIBFShKgAAAAJZJREFUOE/djk0KwyAQRj1CjxTce0Pvksuk3biwhY4uU77BSSROTQJZ5YMHw/w8
+        Nb3EGB9ENKaUZoAavTLeDw6897O1lkGNXhn/T855wIshBD58Ti8GtfymrLaRBSAv14JaAsrZmvqwxjnX
+        9E4JNHYF7/hRaQQoNOhLzCGBNLdgdligLd5EIAdbrhdoYNZjEfTgJTXG/AAVUVH4tEXMkQAAAABJRU5E
+        rkJggg==
 </value>
   </data>
   <data name="deleteToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wAAADsABataJCQAAAVdJREFUOE+lk7FKw1AUhn0BwQdwcHJwEpzcsjkJmZ06+AABfYDqA1h3h+AiHQrS
+        vgAADr4B6kKxwAAAAVdJREFUOE+lk7FKw1AUhn0BwQdwcHJwEpzcsjkJmZ06+AABfYDqA1h3h+AiHQrS
         xUkoOjiIEFwERSgOtoqDdcl6/b+bc9OmJHbwhx+Sc/7z33NyT5acc/9iiTzP18S2mIgrFq6AuJiKA2Mr
         JKKfz7F7PDv11PtQrJjoPZ58jL4fTo7d2+01mqzU6CGl8Hx92fPu6ADBpeU4tTPK7l0v2nD93W2HkWKb
         vhjMG0A7hZGGT93UXWytemKkWGylBRTwI+AeDBATo5s508TKqlCiVWcSnulCmtTk9agzgTeH+xRPP1oT
@@ -164,7 +164,7 @@
   <data name="groupToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAMNJREFUOE/NksEN
+        wQAADsEBuJFr7QAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAMNJREFUOE/NksEN
         AiEQRbcESzLUwp0WbIEKPFIABXimCumANQQ44s6Gj8Ci8aY/eclmZv4HFpb/UM55ChRjzAUXQrg6505t
         f2omIDIzxnaklHkLubX9doUOBNE357yGoFdFBTTHIWJb8WKtPfSqELC6xw6GAA1jhtBaZ+/9vdj7AAwB
         BJBBCNHVi/14hHEnXwWAdwHoEUopqrtif11jOwSoNvuJKaVzsfcBM8j88RoRMAIZY6p5+pBGI4Da3Uyf
@@ -174,7 +174,7 @@
   <data name="ungroupToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAMpJREFUOE/NksEN
+        wQAADsEBuJFr7QAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAMpJREFUOE/NksEN
         wjAQBFMCJaHU4n9aoIVUwNMFpADeqQJ3YJAV+2myF290CQbBC1ZaRb69G50cN/+hnHPVWt77wzRN5xij
         n53hEn0GmIcvfd/ntm3FGwCJe2sQzhw2xkguAaRD+h3AOZfnjU4SQAxv/i4mgA4hXIdhWAGoldFFGsAm
         3cwc7rpOgGV0kW6Aa5swewnQjRWAt9auENTK6CJeFgHaqKWUjjp7ukQNqBk9+BKA3wiIDEME7K21f0jj
@@ -184,7 +184,7 @@
   <data name="enableToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAABl0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC4yMfEgaZUAAAFjSURBVDhPpVKx
+        wQAADsEBuJFr7QAAABl0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC4yMfEgaZUAAAFjSURBVDhPpVKx
         TsNADM3A0ChKhuQHmikrUjtHVeZ2YcvAkrk7G3N/oEhMLIAYkBj6Byxh6A9k6dCBASEiEQhZgvG7Jtfm
         OEVIWHrS+ez37LPPIKJ/QX9pGAPGmDFvgPNAm6teuK57YlnWexAEn0mS1ADOpml+2LZ9quZ3HCZf+L7/
         laYpu13DHWIscs3ubwFURkJRFOzqDTHkOI4Ts7sXwPvQtq6yashBLnOO2JUCY7xTZPzBkMucYz5KgTmG
@@ -197,7 +197,7 @@
   <data name="disableToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAABl0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC4yMfEgaZUAAAEvSURBVDhPpZIx
+        wQAADsEBuJFr7QAAABl0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC4yMfEgaZUAAAEvSURBVDhPpZIx
         TsNAEEW3oIhl2YXNAeLKLUVqFz4CXQoa1+7TcQxOQEHHMXwEJHo6JEs4MW7MMs94N8mysoIY6Us7O3/+
         zM6s0lr/C/5LpVaCjaCewXnl5boXSZLchmH4kef5oaqqEXAOgmAfRdGdyz9zJPkhy7LPpmnEPTfuiInI
         o7i/BagMoes6cf1GDE4cx1txjwK8j7Z9lV2DA1dyrsS1AhveOTEuMLiScyNHK1AzrCnq2DiOehgG3fe9
@@ -206,7 +206,18 @@
         SOAAAAAASUVORK5CYII=
 </value>
   </data>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="$this.TrayHeight" type="System.Int32, mscorlib">
     <value>27</value>
-  </metadata>
+  </data>
+  <data name="docsToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAOBJREFUOE+dU0sKwjAQzT3ceCj35gIuXHsGD+ExBCEI4jZeQVd+kNJNwYXEee2M
+        JJNUqw8eNPPmPZpkYjSaprFERwyKqFluy0HimOjdsQ7TzTmMVqeEqEFDD3rZ1oHN1Wx7zYyai/0NIVUS
+        QgsPQZrmu3uoH88gwDdqKsSL2eLXRAT7EPfwdiwCnN6zYLK+tBTEPfDAi4BEKFGg6/B+DFgearZ20PrX
+        gBgI0/rggJIGSkB2iEMYH2J2jUJBSXtfI8+CL02hQNeTQQJo0Y5yPI19LI4ywCH/PaYYJP7wnI15AZ9a
+        s/c7lU10AAAAAElFTkSuQmCC
+</value>
+  </data>
 </root>

--- a/Bonsai.Editor/IDocumentationProvider.cs
+++ b/Bonsai.Editor/IDocumentationProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace Bonsai.Editor
+{
+    public interface IDocumentationProvider
+    {
+        string GetDocumentationUrl(string assemblyName);
+    }
+}

--- a/Bonsai/DependencyInspector.cs
+++ b/Bonsai/DependencyInspector.cs
@@ -116,9 +116,9 @@ namespace Bonsai
             }
 
             var packageMap = packageConfiguration.GetPackageReferenceMap();
-            var dependencies = packageConfiguration.GetAssemblyPackageReferences(
-                assemblies.Select(assembly => assembly.GetName().Name),
-                packageMap);
+            var dependencies = assemblies.Select(assembly =>
+                packageConfiguration.GetAssemblyPackageReference(assembly.GetName().Name, packageMap))
+                .Where(package => package != null);
             if (File.Exists(scriptEnvironment.ProjectFileName))
             {
                 dependencies = dependencies.Concat(

--- a/Bonsai/DocumentationProvider.cs
+++ b/Bonsai/DocumentationProvider.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using Bonsai.Configuration;
+using Bonsai.Editor;
+using Bonsai.NuGet;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace Bonsai
+{
+    class DocumentationProvider : IDocumentationProvider
+    {
+        readonly SourceRepository packageRepository;
+        readonly PackageConfiguration packageConfiguration;
+        readonly IDictionary<string, PackageReference> packageMap;
+
+        public DocumentationProvider(PackageConfiguration configuration, PackageManager packageManager)
+        {
+            packageConfiguration = configuration;
+            packageMap = packageConfiguration.GetPackageReferenceMap();
+            packageRepository = packageManager.LocalRepository;
+        }
+
+        public string GetDocumentationUrl(string assemblyName)
+        {
+            if (assemblyName == null)
+            {
+                throw new ArgumentNullException(nameof(assemblyName));
+            }
+
+            var packageReference = packageConfiguration.GetAssemblyPackageReference(assemblyName, packageMap);
+            if (packageReference == null)
+            {
+                return null;
+            }
+
+            var identity = new PackageIdentity(packageReference.Id, NuGetVersion.Parse(packageReference.Version));
+            var package = packageRepository.GetLocalPackage(identity);
+            return package?.Nuspec.GetProjectUrl();
+        }
+    }
+}

--- a/Bonsai/Launcher.cs
+++ b/Bonsai/Launcher.cs
@@ -9,6 +9,7 @@ using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.Design;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
@@ -86,8 +87,12 @@ namespace Bonsai
             }, cancellation.Token);
 
             EditorBootstrapper.EnableVisualStyles();
+            using var serviceContainer = new ServiceContainer();
             var scriptEnvironment = new ScriptExtensionsEnvironment(scriptExtensions);
-            using var mainForm = new EditorForm(elementProvider, visualizerProvider, scriptEnvironment, editorScale);
+            var documentationProvider = new DocumentationProvider(packageConfiguration, packageManager);
+            serviceContainer.AddService(typeof(IScriptEnvironment), scriptEnvironment);
+            serviceContainer.AddService(typeof(IDocumentationProvider), documentationProvider);
+            using var mainForm = new EditorForm(elementProvider, visualizerProvider, serviceContainer, editorScale);
             try
             {
                 updatesAvailable.ContinueWith(

--- a/Bonsai/ScriptExtensionsEnvironment.cs
+++ b/Bonsai/ScriptExtensionsEnvironment.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 
 namespace Bonsai
 {
-    class ScriptExtensionsEnvironment : IScriptEnvironment, IServiceProvider
+    class ScriptExtensionsEnvironment : IScriptEnvironment
     {
         readonly ScriptExtensions extensions;
 
@@ -34,16 +34,6 @@ namespace Bonsai
         public void AddAssemblyReferences(IEnumerable<string> assemblyReferences)
         {
             extensions.AddAssemblyReferences(assemblyReferences);
-        }
-
-        public object GetService(Type serviceType)
-        {
-            if (serviceType == typeof(IScriptEnvironment))
-            {
-                return this;
-            }
-
-            return null;
         }
     }
 }


### PR DESCRIPTION
This PR adds built-in editor integration for searching the reference documentation website. Following the DocFX standard, it looks for the `xrefmap.yml` file in the project website of the package containing the module. If the index exists, it then looks up the UID of the target operator to retrieve the corresponding documentation page.

Fixes #936 