### PR TITLE
Refactor and standardize SVG export functions

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1029,12 +1029,12 @@ namespace Bonsai.Editor
             var extension = Path.GetExtension(fileName);
             if (extension == ".svg")
             {
-                var svg = WorkflowExporter.ExportSvg(workflow, iconRenderer);
+                var svg = ExportHelper.ExportSvg(workflow, iconRenderer);
                 File.WriteAllText(fileName, svg);
             }
             else
             {
-                using var bitmap = WorkflowExporter.ExportBitmap(workflow, Font, iconRenderer);
+                using var bitmap = ExportHelper.ExportBitmap(workflow, Font, iconRenderer);
                 if (string.IsNullOrEmpty(fileName))
                 {
                     Clipboard.SetImage(bitmap);

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1029,8 +1029,7 @@ namespace Bonsai.Editor
             var extension = Path.GetExtension(fileName);
             if (extension == ".svg")
             {
-                using var font = new Font(Font.FontFamily, Font.SizeInPoints * inverseScaleFactor.Height);
-                var svg = WorkflowExporter.ExportSvg(workflow, font, iconRenderer);
+                var svg = WorkflowExporter.ExportSvg(workflow, iconRenderer);
                 File.WriteAllText(fileName, svg);
             }
             else

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1019,29 +1019,23 @@ namespace Bonsai.Editor
 
         void ExportImage(WorkflowGraphView model, string fileName)
         {
+            var workflow = model.Workflow;
             if (model.GraphView.SelectedNodes.Count() > 0)
             {
                 var selectedElements = model.GraphView.SelectedNodes.ToWorkflowBuilder();
-                using var graphView = WorkflowExporter.CreateGraphView(
-                    selectedElements.Workflow,
-                    model.GraphView.Font,
-                    model.GraphView.IconRenderer);
-                ExportImage(graphView, fileName);
+                workflow = selectedElements.Workflow;
             }
-            else ExportImage(model.GraphView, fileName);
-        }
 
-        void ExportImage(GraphViewControl graphView, string fileName)
-        {
             var extension = Path.GetExtension(fileName);
             if (extension == ".svg")
             {
-                var svg = WorkflowExporter.ExportSvg(graphView);
+                using var font = new Font(Font.FontFamily, Font.SizeInPoints * inverseScaleFactor.Height);
+                var svg = WorkflowExporter.ExportSvg(workflow, font, iconRenderer);
                 File.WriteAllText(fileName, svg);
             }
             else
             {
-                using var bitmap = WorkflowExporter.ExportBitmap(graphView);
+                using var bitmap = WorkflowExporter.ExportBitmap(workflow, Font, iconRenderer);
                 if (string.IsNullOrEmpty(fileName))
                 {
                     Clipboard.SetImage(bitmap);

--- a/Bonsai.Editor/ExportHelper.cs
+++ b/Bonsai.Editor/ExportHelper.cs
@@ -7,7 +7,7 @@ using Bonsai.Expressions;
 
 namespace Bonsai.Editor
 {
-    static class WorkflowExporter
+    static class ExportHelper
     {
         const float ReferenceDpi = 96f;
         const float ReferenceFontSize = 8.25f;

--- a/Bonsai.Editor/WorkflowExporter.cs
+++ b/Bonsai.Editor/WorkflowExporter.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using System.Windows.Forms;
+using System.Xml;
+using System.Xml.Serialization;
+using Bonsai.Editor.GraphView;
+
+namespace Bonsai.Editor
+{
+    public static class WorkflowExporter
+    {
+        public static void ExportImage(string fileName, string imageFileName)
+        {
+            if (string.IsNullOrEmpty(fileName))
+            {
+                throw new ArgumentNullException(nameof(fileName));
+            }
+
+            if (!File.Exists(fileName))
+            {
+                throw new ArgumentException("Specified workflow file does not exist.", nameof(fileName));
+            }
+
+            if (string.IsNullOrEmpty(imageFileName))
+            {
+                throw new ArgumentException("No output image file is specified.", nameof(imageFileName));
+            }
+
+            WorkflowBuilder workflowBuilder;
+            using (var reader = XmlReader.Create(fileName))
+            {
+                reader.MoveToContent();
+                var serializer = new XmlSerializer(typeof(WorkflowBuilder), reader.NamespaceURI);
+                workflowBuilder = (WorkflowBuilder)serializer.Deserialize(reader);
+            }
+
+            var iconRenderer = new SvgRendererFactory();
+            var extension = Path.GetExtension(imageFileName);
+            if (extension == ".svg")
+            {
+                var svg = ExportHelper.ExportSvg(workflowBuilder.Workflow, iconRenderer);
+                File.WriteAllText(imageFileName, svg);
+            }
+            else
+            {
+                using var bitmap = ExportHelper.ExportBitmap(workflowBuilder.Workflow, Control.DefaultFont, iconRenderer);
+                bitmap.Save(imageFileName);
+            }
+        }
+    }
+}

--- a/Bonsai.Editor/WorkflowExporter.cs
+++ b/Bonsai.Editor/WorkflowExporter.cs
@@ -1,0 +1,59 @@
+﻿using System.Drawing;
+using System.Linq;
+using Bonsai.Editor.GraphModel;
+using Bonsai.Editor.GraphView;
+using Bonsai.Expressions;
+
+namespace Bonsai.Editor
+{
+    static class WorkflowExporter
+    {
+        public static GraphViewControl CreateGraphView(ExpressionBuilderGraph workflow, Font font, SvgRendererFactory iconRenderer)
+        {
+            var selectedLayout = workflow.ConnectedComponentLayering().ToList();
+            return new GraphViewControl
+            {
+                Font = font,
+                IconRenderer = iconRenderer,
+                Nodes = selectedLayout
+            };
+        }
+
+        public static string ExportSvg(ExpressionBuilderGraph workflow, Font font, SvgRendererFactory iconRenderer)
+        {
+            using var graphView = CreateGraphView(workflow, font, iconRenderer);
+            return ExportSvg(graphView);
+        }
+
+        public static string ExportSvg(GraphViewControl graphView)
+        {
+            var bounds = graphView.GetLayoutSize();
+            var graphics = new SvgNet.SvgGdi.SvgGraphics();
+            graphView.DrawGraphics(graphics, scaleFont: true);
+            var svg = graphics.WriteSVGString();
+            var attributes = string.Format(
+                "<svg width=\"{0}\" height=\"{1}\" ",
+                bounds.Width, bounds.Height);
+            svg = svg.Replace("<svg ", attributes);
+            return svg;
+        }
+
+        public static Bitmap ExportBitmap(ExpressionBuilderGraph workflow, Font font, SvgRendererFactory iconRenderer)
+        {
+            using var graphView = CreateGraphView(workflow, font, iconRenderer);
+            return ExportBitmap(graphView);
+        }
+
+        public static Bitmap ExportBitmap(GraphViewControl graphView)
+        {
+            var bounds = graphView.GetLayoutSize();
+            var bitmap = new Bitmap((int)bounds.Width, (int)bounds.Height);
+            using (var graphics = Graphics.FromImage(bitmap))
+            {
+                var gdi = new SvgNet.SvgGdi.GdiGraphics(graphics);
+                graphView.DrawGraphics(gdi, scaleFont: false);
+                return bitmap;
+            }
+        }
+    }
+}

--- a/Bonsai/Launcher.cs
+++ b/Bonsai/Launcher.cs
@@ -141,6 +141,27 @@ namespace Bonsai
             return Program.NormalExitCode;
         }
 
+        internal static int LaunchExportImage(
+            string fileName,
+            string imageFileName,
+            PackageConfiguration packageConfiguration)
+        {
+            if (string.IsNullOrEmpty(fileName))
+            {
+                Console.WriteLine("No workflow file was specified.");
+                return Program.NormalExitCode;
+            }
+
+            if (string.IsNullOrEmpty(imageFileName))
+            {
+                Console.WriteLine("No image file was specified.");
+                return Program.NormalExitCode;
+            }
+
+            WorkflowExporter.ExportImage(fileName, imageFileName);
+            return Program.NormalExitCode;
+        }
+
         static int ShowManifestReadError(string path, string message)
         {
             MessageBox.Show(

--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -24,6 +24,7 @@ namespace Bonsai
         const string PackageManagerCommand = "--package-manager";
         const string PackageManagerUpdates = "updates";
         const string ExportPackageCommand = "--export-package";
+        const string ExportImageCommand = "--export-image";
         const string ReloadEditorCommand = "--reload-editor";
         const string GalleryCommand = "--gallery";
         const string EditorDomainName = "EditorDomain";
@@ -45,9 +46,11 @@ namespace Bonsai
             var launchEditor = true;
             var debugScripts = false;
             var editorScale = 1.0f;
+            var exportImage = false;
             var updatePackages = false;
             var launchResult = default(EditorResult);
             var initialFileName = default(string);
+            var imageFileName = default(string);
             var layoutPath = default(string);
             var libFolders = new List<string>();
             var propertyAssignments = new Dictionary<string, string>();
@@ -59,6 +62,7 @@ namespace Bonsai
             parser.RegisterCommand(DebugScriptCommand, () => debugScripts = true);
             parser.RegisterCommand(SuppressBootstrapCommand, () => bootstrap = false);
             parser.RegisterCommand(SuppressEditorCommand, () => launchEditor = false);
+            parser.RegisterCommand(ExportImageCommand, fileName => { imageFileName = fileName; exportImage = true; });
             parser.RegisterCommand(ExportPackageCommand, () => { launchResult = EditorResult.ExportPackage; bootstrap = false; });
             parser.RegisterCommand(ReloadEditorCommand, () => { launchResult = EditorResult.ReloadEditor; bootstrap = false; });
             parser.RegisterCommand(GalleryCommand, () => { launchResult = EditorResult.OpenGallery; bootstrap = false; });
@@ -143,6 +147,7 @@ namespace Bonsai
                     libFolders.ForEach(path => ConfigurationHelper.RegisterPath(packageConfiguration, path));
                     using var scriptExtensions = ScriptExtensionsProvider.CompileAssembly(Launcher.ProjectFramework, packageConfiguration, editorRepositoryPath, debugScripts);
                     ConfigurationHelper.SetAssemblyResolve(packageConfiguration);
+                    if (exportImage) return Launcher.LaunchExportImage(initialFileName, imageFileName, packageConfiguration);
                     if (!launchEditor) return Launcher.LaunchWorkflowPlayer(initialFileName, layoutPath, packageConfiguration, propertyAssignments);
                     else return Launcher.LaunchWorkflowEditor(
                         packageConfiguration,


### PR DESCRIPTION
This PR refactors the SVG and image export functions in preparation for resolving #929. We decided to postpone the full functionality to the next release cycle, but it would be useful to start preparing the code base.

This PR also standardizes export sizes to avoid DPI-dependent vector exports.

Fixes #939