### PR TITLE
Update reactive extensions to version 5.0.0

### DIFF
--- a/Bonsai.Configuration/ScriptExtensions.cs
+++ b/Bonsai.Configuration/ScriptExtensions.cs
@@ -105,7 +105,7 @@ namespace Bonsai.Configuration
             yield return "System.dll";
             yield return "System.Core.dll";
             yield return "System.Drawing.dll";
-            yield return "System.Reactive.Linq.dll";
+            yield return "System.Reactive.dll";
             yield return "System.Xml.dll";
             yield return "Bonsai.Core.dll";
 

--- a/Bonsai.Core/Bonsai.Core.csproj
+++ b/Bonsai.Core/Bonsai.Core.csproj
@@ -10,7 +10,7 @@
     <VersionPrefix>2.7.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Rx-Linq" Version="2.2.5" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/Bonsai.Core/WorkflowBuilder.cs
+++ b/Bonsai.Core/WorkflowBuilder.cs
@@ -237,6 +237,19 @@ namespace Bonsai
         static readonly Type[] SerializerLegacyTypes = new[] { typeof(SourceBuilder), typeof(WindowWorkflowBuilder) };
 #pragma warning restore CS0612 // Type or member is obsolete
 
+        /// <summary>
+        /// Clears the serializer type cache. This method is provided for
+        /// compatibility tooling only and might be removed in a future version.
+        /// </summary>
+        public static void ClearSerializerCache()
+        {
+            lock (cacheLock)
+            {
+                serializerTypes = null;
+                serializerCache = null;
+            }
+        }
+
         static IEnumerable<Type> GetDefaultSerializerTypes()
         {
             var builderType = typeof(ExpressionBuilder);

--- a/Bonsai.Editor/Bonsai.Editor.csproj
+++ b/Bonsai.Editor/Bonsai.Editor.csproj
@@ -13,7 +13,6 @@
     <EmbeddedResource Include="**\*.svg" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Rx-PlatformServices" Version="2.2.5" />
     <PackageReference Include="SvgNet" Version="2.2.2" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1162,7 +1162,7 @@ namespace Bonsai.Editor
 
         IDisposable ShutdownSequence()
         {
-            return new ScheduledDisposable(new ControlScheduler(this), Disposable.Create(() =>
+            return new ScheduledDisposable(new Design.ControlScheduler(this), Disposable.Create(() =>
             {
                 editorSite.OnWorkflowStopped(EventArgs.Empty);
                 propertyGrid.BrowsableAttributes = DesignTimeAttributes;

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -793,6 +793,7 @@ namespace Bonsai.Editor
             }
 
             workflowBuilder = new WorkflowBuilder(workflow.ToInspectableGraph());
+            if (upgraded) WorkflowBuilder.ClearSerializerCache();
             return workflowBuilder;
         }
 

--- a/Bonsai.NuGet.Design/PackageBuilderDialog.cs
+++ b/Bonsai.NuGet.Design/PackageBuilderDialog.cs
@@ -1,5 +1,4 @@
-﻿using Bonsai.Design;
-using Bonsai.NuGet.Design.Properties;
+﻿using Bonsai.NuGet.Design.Properties;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging;

--- a/Bonsai.NuGet.Design/PackageViewController.cs
+++ b/Bonsai.NuGet.Design/PackageViewController.cs
@@ -1,5 +1,4 @@
-using Bonsai.Design;
-using Bonsai.NuGet.Design.Properties;
+﻿using Bonsai.NuGet.Design.Properties;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Packaging;

--- a/Bonsai.NuGet/Bonsai.NuGet.csproj
+++ b/Bonsai.NuGet/Bonsai.NuGet.csproj
@@ -7,7 +7,7 @@
     <VersionPrefix>2.7.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Rx-Main" Version="2.2.5" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="NuGet.Protocol" Version="6.1.0" />
     <PackageReference Include="NuGet.Resolver" Version="6.1.0" />
   </ItemGroup>

--- a/Bonsai.System/Bonsai.System.csproj
+++ b/Bonsai.System/Bonsai.System.csproj
@@ -8,9 +8,6 @@
     <VersionPrefix>2.7.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Rx-PlatformServices" Version="2.2.5" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Bonsai.Core\Bonsai.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/Bonsai/Bonsai.csproj
+++ b/Bonsai/Bonsai.csproj
@@ -14,6 +14,8 @@
     <ApplicationManifest>App.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Rx-Linq" Version="2.2.5" ExcludeAssets="compile" />
+    <PackageReference Include="Rx-PlatformServices" Version="2.2.5" ExcludeAssets="compile" />
     <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This PR updates the core Reactive Extensions dependency to the latest version. Unfortunately, even though the API is exactly the same, this update breaks binary compatibility with dependent packages and extensions since `System.Reactive` assembly public key token has changed from v2.2.5 to v3.0.

Backwards compatibility is attempted by providing the legacy versions of Rx assemblies for dynamic targeting. This solves most straight-forward bindings by running Rx v2.2.5 and Rx v5.0.0 side-by-side. Unfortunately, indirect method calls to reactive combinators in Bonsai.Core will not survive retargeting of method signatures. For example, all packages using `PublishReconnectable` will require rebuilding to target the new version.

Fixes #1028