### PR TITLE
Load package manager dependencies without assembly lock

### DIFF
--- a/Bonsai.Configuration/ConfigurationHelper.cs
+++ b/Bonsai.Configuration/ConfigurationHelper.cs
@@ -101,7 +101,7 @@ namespace Bonsai.Configuration
             return null;
         }
 
-        public static void SetAssemblyResolve(PackageConfiguration configuration)
+        public static void SetAssemblyResolve(PackageConfiguration configuration, bool assemblyLock = true)
         {
             var platform = GetEnvironmentPlatform();
             var configurationRoot = GetConfigurationRoot(configuration);
@@ -144,7 +144,12 @@ namespace Bonsai.Configuration
 
                     if (File.Exists(assemblyLocation))
                     {
-                        return Assembly.LoadFrom(assemblyLocation);
+                        if (!assemblyLock)
+                        {
+                            var assemblyBytes = File.ReadAllBytes(assemblyLocation);
+                            return Assembly.Load(assemblyBytes);
+                        }
+                        else return Assembly.LoadFrom(assemblyLocation);
                     }
                 }
 

--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -121,7 +121,7 @@ namespace Bonsai
                 }
                 else if (launchResult == EditorResult.ManagePackages)
                 {
-                    ConfigurationHelper.SetAssemblyResolve(packageConfiguration);
+                    ConfigurationHelper.SetAssemblyResolve(packageConfiguration, assemblyLock: false);
                     return Launcher.LaunchPackageManager(
                         packageConfiguration,
                         editorRepositoryPath,


### PR DESCRIPTION
This PR introduces a runtime assembly resolution path without locking the assembly file on disk by leveraging `File.ReadAllBytes` to load the assembly into memory without a file reference. This allows the package manager UI to use installed local dependencies while still allowing those same dependencies to be updated.

**Caveat:** _code used specifically by the package manager UI can never depend on `Assembly.Location` or similar properties in the `Assembly` class that depend on loading the assembly from a file path._

Fixes #1048 
