### PR TITLE
Disable modifier keys for docs and rename actions

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
@@ -2016,6 +2016,11 @@ namespace Bonsai.Editor
 
         private void renameSubjectToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            if (ModifierKeys != Keys.None)
+            {
+                return;
+            }
+
             if (!toolboxTreeView.Focused)
             {
                 var model = selectionModel.SelectedView;
@@ -2276,6 +2281,11 @@ namespace Bonsai.Editor
 
         private async void docsToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            if (ModifierKeys != Keys.None)
+            {
+                return;
+            }
+
             if (toolboxTreeView.Focused || searchTextBox.Focused)
             {
                 var typeNode = toolboxTreeView.SelectedNode;

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2292,7 +2292,10 @@ namespace Bonsai.Editor
                 if (typeNode != null && typeNode.Tag != null)
                 {
                     var type = Type.GetType(typeNode.Name);
-                    await OpenDocumentationAsync(type);
+                    if (type != null)
+                    {
+                        await OpenDocumentationAsync(type);
+                    }
                     return;
                 }
             }


### PR DESCRIPTION
This PR prevents activating docs and rename UI actions when modifier keys are held. This expands the range of available shortcuts when rapid prototyping workflows.

Fixes #1057 