### PR TITLE
Reuse top-level prefix for all extension base types with explicit XML type declarations

### DIFF
--- a/Bonsai.Core.Tests/Constants.cs
+++ b/Bonsai.Core.Tests/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace Bonsai.Core.Tests
+{
+    internal static class Constants
+    {
+        public const string XmlNamespace = "clr-namespace:Bonsai.Core.Tests;assembly=Bonsai.Core.Tests";
+    }
+}

--- a/Bonsai.Core.Tests/TypeMappingTests.cs
+++ b/Bonsai.Core.Tests/TypeMappingTests.cs
@@ -16,18 +16,18 @@ namespace Bonsai.Core.Tests
         {
             var workflow = new WorkflowBuilder();
             var builder = new StringBuilder();
-            workflow.Workflow.Add(new CombinatorBuilder() { Combinator = new MappingCombinator() });
-            workflow.Workflow.Add(new CombinatorBuilder() { Combinator = new GenericMappingCombinator<int>() });
+            workflow.Workflow.Add(new CombinatorBuilder { Combinator = new MappingCombinator() });
+            workflow.Workflow.Add(new CombinatorBuilder { Combinator = new GenericMappingCombinator<int>() });
             workflow.Workflow.Add(new AddBuilder { Operand = new WorkflowProperty<int>() });
 #pragma warning disable CS0612 // Type or member is obsolete
             workflow.Workflow.Add(new ExternalizedTimeSpan<int>());
 #pragma warning restore CS0612 // Type or member is obsolete
-            workflow.Workflow.Add(new PropertySource<Bonsai.Reactive.WindowCount, int>());
+            workflow.Workflow.Add(new PropertySource<Reactive.WindowCount, int>());
             workflow.Workflow.Add(new InputMappingBuilder { TypeMapping = new TypeMapping<Tuple<int, int>>() });
             workflow.Workflow.Add(new InputMappingBuilder { TypeMapping = new TypeMapping<Tuple<Tuple<int, int, int>>>() });
             workflow.Workflow.Add(new InputMappingBuilder { TypeMapping = new TypeMapping<Tuple<Tuple<int, int>, int>>() });
-            workflow.Workflow.Add(new InputMappingBuilder { TypeMapping = new TypeMapping<List<Bonsai.Core.Tests.MappingNamespace1.Vector2>>() });
-            workflow.Workflow.Add(new InputMappingBuilder { TypeMapping = new TypeMapping<List<Bonsai.Core.Tests.MappingNamespace2.Vector2>>() });
+            workflow.Workflow.Add(new InputMappingBuilder { TypeMapping = new TypeMapping<List<MappingNamespace1.Vector2>>() });
+            workflow.Workflow.Add(new InputMappingBuilder { TypeMapping = new TypeMapping<List<MappingNamespace2.Vector2>>() });
             workflow.Workflow.Add(new InputMappingBuilder { TypeMapping = new TypeMapping<System.Diagnostics.Stopwatch>() });
             using (var writer = XmlWriter.Create(builder, new XmlWriterSettings { Indent = true }))
             {

--- a/Bonsai.Core.Tests/WorkflowBuilderTests.cs
+++ b/Bonsai.Core.Tests/WorkflowBuilderTests.cs
@@ -50,7 +50,7 @@ namespace Bonsai.Core.Tests
 
     namespace DerivedNamespace
     {
-        public class DerivedClassWithProperty : BaseNamespace.BaseClassWithProperty
+        public class DerivedClassWithProperty : IntermediateTypeWithProperty
         {
             public int NewProperty { get; set; }
         }
@@ -60,5 +60,10 @@ namespace Bonsai.Core.Tests
     public class DerivedXmlTypeWithProperty : BaseNamespace.BaseClassWithProperty
     {
         public int NewProperty { get; set; }
+    }
+
+    public class IntermediateTypeWithProperty : BaseNamespace.BaseClassWithProperty
+    {
+        public int IntermediateProperty { get; set; }
     }
 }

--- a/Bonsai.Core.Tests/WorkflowBuilderTests.cs
+++ b/Bonsai.Core.Tests/WorkflowBuilderTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.Serialization;
+using Bonsai.Expressions;
+using Bonsai.Reactive;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Core.Tests
+{
+    [TestClass]
+    public class WorkflowBuilderTests
+    {
+        [TestMethod]
+        public void Serialize_DerivedXmlType_BasePropertiesShouldSerializeWithBaseXmlNamespace()
+        {
+            var builder = new StringBuilder();
+            var workflow = new WorkflowBuilder();
+            var derivedClass = new DerivedClassWithProperty();
+            derivedClass.DueTime = TimeSpan.FromSeconds(10);
+            workflow.Workflow.Add(new CombinatorBuilder { Combinator = derivedClass });
+            workflow.Workflow.Add(new CombinatorBuilder { Combinator = new DerivedXmlTypeWithProperty() });
+
+            using (var writer = XmlWriter.Create(builder, new XmlWriterSettings { Indent = true }))
+            {
+                WorkflowBuilder.Serializer.Serialize(writer, workflow);
+            }
+
+            var xml = builder.ToString();
+            var document = XDocument.Parse(xml);
+            var element = document.Descendants(XName.Get(nameof(Combinator), document.Root.Name.NamespaceName)).FirstOrDefault();
+            var property = element.Descendants().FirstOrDefault(descendant => descendant.Name.LocalName == nameof(Timer.DueTime));
+            Assert.IsNotNull(property);
+            Assert.AreNotEqual(document.Root.Name.NamespaceName, property.Name.NamespaceName);
+        }
+    }
+
+    public class DerivedClassWithProperty : Timer
+    {
+        public int NewProperty { get; set; }
+    }
+
+    [XmlType(Namespace = Constants.XmlNamespace)]
+    public class DerivedXmlTypeWithProperty : Timer
+    {
+        public int NewProperty { get; set; }
+    }
+}

--- a/Bonsai.Core/Bonsai.Core.csproj
+++ b/Bonsai.Core/Bonsai.Core.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Reactive Extensions</PackageTags>
     <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>Bonsai</RootNamespace>
-    <VersionPrefix>2.7.1</VersionPrefix>
+    <VersionPrefix>2.7.2</VersionPrefix>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Rx-Linq" Version="2.2.5" />

--- a/Bonsai.Core/WorkflowBuilder.cs
+++ b/Bonsai.Core/WorkflowBuilder.cs
@@ -253,9 +253,9 @@ namespace Bonsai
             return builderType.Assembly.GetTypes().Where(type =>
                 !type.IsGenericType && !type.IsAbstract &&
                 type.Namespace == builderType.Namespace &&
-                Attribute.IsDefined(type, typeof(XmlTypeAttribute), false) &&
-                Attribute.IsDefined(type, typeof(ObsoleteAttribute), false) &&
-                Attribute.IsDefined(type, typeof(ProxyTypeAttribute), false))
+                Attribute.IsDefined(type, typeof(XmlTypeAttribute), inherit: false) &&
+                Attribute.IsDefined(type, typeof(ObsoleteAttribute), inherit: false) &&
+                Attribute.IsDefined(type, typeof(ProxyTypeAttribute), inherit: false))
 #pragma warning disable CS0612 // Type or member is obsolete
                 .Concat(new[]
                 {
@@ -339,8 +339,8 @@ namespace Bonsai
             var overrides = new XmlAttributeOverrides();
             foreach (var type in serializerTypes)
             {
-                var obsolete = Attribute.IsDefined(type, typeof(ObsoleteAttribute), false);
-                var xmlTypeDefined = Attribute.IsDefined(type, typeof(XmlTypeAttribute), false);
+                var obsolete = Attribute.IsDefined(type, typeof(ObsoleteAttribute), inherit: false);
+                var xmlTypeDefined = Attribute.IsDefined(type, typeof(XmlTypeAttribute), inherit: false);
                 if (xmlTypeDefined && !obsolete) continue;
 
                 var attributes = new XmlAttributes();
@@ -649,9 +649,9 @@ namespace Bonsai
             var assemblyName = builderType.Assembly.GetName().Name;
             foreach (var type in builderType.Assembly.GetTypes().Where(type =>
                 type.IsGenericType && !type.IsAbstract &&
-                Attribute.IsDefined(type, typeof(XmlTypeAttribute), false) &&
-                (!Attribute.IsDefined(type, typeof(ObsoleteAttribute), false) ||
-                  Attribute.IsDefined(type, typeof(ProxyTypeAttribute), false))))
+                Attribute.IsDefined(type, typeof(XmlTypeAttribute), inherit: false) &&
+                (!Attribute.IsDefined(type, typeof(ObsoleteAttribute), inherit: false) ||
+                  Attribute.IsDefined(type, typeof(ProxyTypeAttribute), inherit: false))))
             {
                 var xmlTypeAttribute = (XmlTypeAttribute)Attribute.GetCustomAttribute(type, typeof(XmlTypeAttribute));
                 if (string.IsNullOrEmpty(xmlTypeAttribute.TypeName)) continue;
@@ -668,7 +668,7 @@ namespace Bonsai
             var typeMap = new Dictionary<Type, Type>();
             var assemblyName = builderType.Assembly.GetName().Name;
             foreach (var type in builderType.Assembly.GetTypes().Where(type =>
-                Attribute.IsDefined(type, typeof(ProxyTypeAttribute), false)))
+                Attribute.IsDefined(type, typeof(ProxyTypeAttribute), inherit: false)))
             {
                 var proxyTypeAttribute = (ProxyTypeAttribute)Attribute.GetCustomAttribute(type, typeof(ProxyTypeAttribute));
                 if (proxyTypeAttribute.Destination == null) continue;

--- a/Bonsai.Core/WorkflowBuilder.cs
+++ b/Bonsai.Core/WorkflowBuilder.cs
@@ -452,6 +452,15 @@ namespace Bonsai
                 {
                     types.Add(xmlInclude[i].Type);
                 }
+
+                while (type.BaseType != null)
+                {
+                    type = type.BaseType;
+                    if (Attribute.IsDefined(type, typeof(XmlTypeAttribute)))
+                    {
+                        AddExtensionType(types, type);
+                    }
+                }
             }
         }
 

--- a/Bonsai.Core/WorkflowBuilder.cs
+++ b/Bonsai.Core/WorkflowBuilder.cs
@@ -241,8 +241,8 @@ namespace Bonsai
         {
             var builderType = typeof(ExpressionBuilder);
             return builderType.Assembly.GetTypes().Where(type =>
-                !type.IsGenericType && !type.IsAbstract &&
-                type.Namespace == builderType.Namespace &&
+                !type.IsGenericType &&
+                (type.Namespace == builderType.Namespace || type.Namespace == nameof(Bonsai)) &&
                 Attribute.IsDefined(type, typeof(XmlTypeAttribute), inherit: false) &&
                 !Attribute.IsDefined(type, typeof(ObsoleteAttribute), inherit: false));
         }
@@ -453,7 +453,7 @@ namespace Bonsai
                     types.Add(xmlInclude[i].Type);
                 }
 
-                while (type.BaseType != null)
+                while (type.BaseType != null && !SerializerExtraTypes.Contains(type.BaseType))
                 {
                     type = type.BaseType;
                     if (Attribute.IsDefined(type, typeof(XmlTypeAttribute), inherit: false))

--- a/Bonsai.Core/WorkflowBuilder.cs
+++ b/Bonsai.Core/WorkflowBuilder.cs
@@ -243,8 +243,8 @@ namespace Bonsai
             return builderType.Assembly.GetTypes().Where(type =>
                 !type.IsGenericType && !type.IsAbstract &&
                 type.Namespace == builderType.Namespace &&
-                Attribute.IsDefined(type, typeof(XmlTypeAttribute), false) &&
-                !Attribute.IsDefined(type, typeof(ObsoleteAttribute), false));
+                Attribute.IsDefined(type, typeof(XmlTypeAttribute), inherit: false) &&
+                !Attribute.IsDefined(type, typeof(ObsoleteAttribute), inherit: false));
         }
 
         static IEnumerable<Type> GetSerializerLegacyTypes()
@@ -378,7 +378,7 @@ namespace Bonsai
                     XmlAttributeOverrides overrides = new XmlAttributeOverrides();
                     foreach (var type in serializerTypes)
                     {
-                        var xmlTypeDefined = Attribute.IsDefined(type, typeof(XmlTypeAttribute), false);
+                        var xmlTypeDefined = Attribute.IsDefined(type, typeof(XmlTypeAttribute), inherit: false);
                         var attributes = new XmlAttributes();
                         attributes.XmlType = xmlTypeDefined
                             ? (XmlTypeAttribute)Attribute.GetCustomAttribute(type, typeof(XmlTypeAttribute))
@@ -456,7 +456,7 @@ namespace Bonsai
                 while (type.BaseType != null)
                 {
                     type = type.BaseType;
-                    if (Attribute.IsDefined(type, typeof(XmlTypeAttribute)))
+                    if (Attribute.IsDefined(type, typeof(XmlTypeAttribute), inherit: false))
                     {
                         AddExtensionType(types, type);
                     }


### PR DESCRIPTION
`WorkflowBuilder` serialization procedure has been modified to walk up the inheritance tree of each extension type to search for any base types with explicit `XmlTypeAttribute` declarations. If any exist, they are explicitly added to the set of serializable extension types.

This prevents overly verbose inline XML namespace declarations for properties provided by base types which are not directly used elsewhere in the workflow.

Fixes #1056 