### PR TITLE
Add scheduler and concurrency control operators

### DIFF
--- a/Bonsai.Core/Bonsai.Core.csproj
+++ b/Bonsai.Core/Bonsai.Core.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Rx-Linq" Version="2.2.5" />
+    <PackageReference Include="Rx-PlatformServices" Version="2.2.5" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="System.Reactive" Version="5.0.0" />

--- a/Bonsai.Core/Reactive/Concurrency/CurrentThreadScheduler.cs
+++ b/Bonsai.Core/Reactive/Concurrency/CurrentThreadScheduler.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
 using Rx = System.Reactive.Concurrency;
 
 namespace Bonsai.Reactive
@@ -8,14 +10,19 @@ namespace Bonsai.Reactive
     /// on the current thread.
     /// </summary>
     [Description("Returns an object that schedules units of work on the current thread.")]
-    public sealed class CurrentThreadScheduler : SchedulerSource<Rx.CurrentThreadScheduler>
+    public sealed class CurrentThreadScheduler : Source<Rx.CurrentThreadScheduler>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="CurrentThreadScheduler"/> class.
+        /// Generates an observable sequence that returns the singleton
+        /// <see cref="Rx.CurrentThreadScheduler"/> object.
         /// </summary>
-        public CurrentThreadScheduler()
-            : base(Rx.CurrentThreadScheduler.Instance)
+        /// <returns>
+        /// A sequence containing the singleton <see cref="Rx.CurrentThreadScheduler"/>
+        /// object.
+        /// </returns>
+        public override IObservable<Rx.CurrentThreadScheduler> Generate()
         {
+            return Observable.Return(Rx.CurrentThreadScheduler.Instance);
         }
     }
 }

--- a/Bonsai.Core/Reactive/Concurrency/CurrentThreadScheduler.cs
+++ b/Bonsai.Core/Reactive/Concurrency/CurrentThreadScheduler.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+using Rx = System.Reactive.Concurrency;
+
+namespace Bonsai.Reactive
+{
+    /// <summary>
+    /// Represents an operator that returns an object that schedules units of work
+    /// on the current thread.
+    /// </summary>
+    [Description("Returns an object that schedules units of work on the current thread.")]
+    public sealed class CurrentThreadScheduler : SchedulerSource<Rx.CurrentThreadScheduler>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CurrentThreadScheduler"/> class.
+        /// </summary>
+        public CurrentThreadScheduler()
+            : base(Rx.CurrentThreadScheduler.Instance)
+        {
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/Concurrency/DefaultScheduler.cs
+++ b/Bonsai.Core/Reactive/Concurrency/DefaultScheduler.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
 using Rx = System.Reactive.Concurrency;
 
 namespace Bonsai.Reactive
@@ -8,14 +10,19 @@ namespace Bonsai.Reactive
     /// on the platform's default scheduler.
     /// </summary>
     [Description("Returns an object that schedules units of work on the platform's default scheduler.")]
-    public sealed class DefaultScheduler : SchedulerSource<Rx.DefaultScheduler>
+    public sealed class DefaultScheduler : Source<Rx.DefaultScheduler>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultScheduler"/> class.
+        /// Generates an observable sequence that returns the singleton
+        /// <see cref="Rx.DefaultScheduler"/> object.
         /// </summary>
-        public DefaultScheduler()
-            : base(Rx.DefaultScheduler.Instance)
+        /// <returns>
+        /// A sequence containing the singleton <see cref="Rx.DefaultScheduler"/>
+        /// object.
+        /// </returns>
+        public override IObservable<Rx.DefaultScheduler> Generate()
         {
+            return Observable.Return(Rx.DefaultScheduler.Instance);
         }
     }
 }

--- a/Bonsai.Core/Reactive/Concurrency/DefaultScheduler.cs
+++ b/Bonsai.Core/Reactive/Concurrency/DefaultScheduler.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+using Rx = System.Reactive.Concurrency;
+
+namespace Bonsai.Reactive
+{
+    /// <summary>
+    /// Represents an operator that returns an object that schedules units of work
+    /// on the platform's default scheduler.
+    /// </summary>
+    [Description("Returns an object that schedules units of work on the platform's default scheduler.")]
+    public sealed class DefaultScheduler : SchedulerSource<Rx.DefaultScheduler>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultScheduler"/> class.
+        /// </summary>
+        public DefaultScheduler()
+            : base(Rx.DefaultScheduler.Instance)
+        {
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/Concurrency/EventLoopScheduler.cs
+++ b/Bonsai.Core/Reactive/Concurrency/EventLoopScheduler.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using Rx = System.Reactive.Concurrency;
+
+namespace Bonsai.Reactive
+{
+    /// <summary>
+    /// Represents an operator that creates an object that schedules units of work
+    /// on a single dedicated thread.
+    /// </summary>
+    [Description("Creates an object that schedules units of work on a single dedicated thread.")]
+    public sealed class EventLoopScheduler : Source<Rx.EventLoopScheduler>
+    {
+        /// <summary>
+        /// Generates an observable sequence that returns a new
+        /// <see cref="Rx.EventLoopScheduler"/> object.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing the created <see cref="Rx.EventLoopScheduler"/> object.
+        /// </returns>
+        public override IObservable<Rx.EventLoopScheduler> Generate()
+        {
+            return Observable.Defer(() => Observable.Return(new Rx.EventLoopScheduler()));
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/Concurrency/ImmediateScheduler.cs
+++ b/Bonsai.Core/Reactive/Concurrency/ImmediateScheduler.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+using Rx = System.Reactive.Concurrency;
+
+namespace Bonsai.Reactive
+{
+    /// <summary>
+    /// Represents an operator that returns an object that schedules units of work
+    /// to run immediately on the current thread.
+    /// </summary>
+    [Description("Returns an object that schedules units of work to run immediately on the current thread.")]
+    public sealed class ImmediateScheduler : SchedulerSource<Rx.ImmediateScheduler>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImmediateScheduler"/> class.
+        /// </summary>
+        public ImmediateScheduler()
+            : base(Rx.ImmediateScheduler.Instance)
+        {
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/Concurrency/ImmediateScheduler.cs
+++ b/Bonsai.Core/Reactive/Concurrency/ImmediateScheduler.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
 using Rx = System.Reactive.Concurrency;
 
 namespace Bonsai.Reactive
@@ -8,14 +10,19 @@ namespace Bonsai.Reactive
     /// to run immediately on the current thread.
     /// </summary>
     [Description("Returns an object that schedules units of work to run immediately on the current thread.")]
-    public sealed class ImmediateScheduler : SchedulerSource<Rx.ImmediateScheduler>
+    public sealed class ImmediateScheduler : Source<Rx.ImmediateScheduler>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ImmediateScheduler"/> class.
+        /// Generates an observable sequence that returns the singleton
+        /// <see cref="Rx.ImmediateScheduler"/> object.
         /// </summary>
-        public ImmediateScheduler()
-            : base(Rx.ImmediateScheduler.Instance)
+        /// <returns>
+        /// A sequence containing the singleton <see cref="Rx.ImmediateScheduler"/>
+        /// object.
+        /// </returns>
+        public override IObservable<Rx.ImmediateScheduler> Generate()
         {
+            return Observable.Return(Rx.ImmediateScheduler.Instance);
         }
     }
 }

--- a/Bonsai.Core/Reactive/Concurrency/NewThreadScheduler.cs
+++ b/Bonsai.Core/Reactive/Concurrency/NewThreadScheduler.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+using Rx = System.Reactive.Concurrency;
+
+namespace Bonsai.Reactive
+{
+    /// <summary>
+    /// Represents an operator that returns an object that schedules each unit of work
+    /// on a separate thread.
+    /// </summary>
+    [Description("Returns an object that schedules each unit of work on a separate thread.")]
+    public sealed class NewThreadScheduler : SchedulerSource<Rx.NewThreadScheduler>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewThreadScheduler"/> class.
+        /// </summary>
+        public NewThreadScheduler()
+            : base(Rx.NewThreadScheduler.Default)
+        {
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/Concurrency/NewThreadScheduler.cs
+++ b/Bonsai.Core/Reactive/Concurrency/NewThreadScheduler.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
 using Rx = System.Reactive.Concurrency;
 
 namespace Bonsai.Reactive
@@ -8,14 +10,19 @@ namespace Bonsai.Reactive
     /// on a separate thread.
     /// </summary>
     [Description("Returns an object that schedules each unit of work on a separate thread.")]
-    public sealed class NewThreadScheduler : SchedulerSource<Rx.NewThreadScheduler>
+    public sealed class NewThreadScheduler : Source<Rx.NewThreadScheduler>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="NewThreadScheduler"/> class.
+        /// Generates an observable sequence that returns the default
+        /// <see cref="Rx.NewThreadScheduler"/> object.
         /// </summary>
-        public NewThreadScheduler()
-            : base(Rx.NewThreadScheduler.Default)
+        /// <returns>
+        /// A sequence containing the default <see cref="Rx.NewThreadScheduler"/>
+        /// object.
+        /// </returns>
+        public override IObservable<Rx.NewThreadScheduler> Generate()
         {
+            return Observable.Return(Rx.NewThreadScheduler.Default);
         }
     }
 }

--- a/Bonsai.Core/Reactive/Concurrency/SchedulerMapping.cs
+++ b/Bonsai.Core/Reactive/Concurrency/SchedulerMapping.cs
@@ -31,7 +31,7 @@ namespace Bonsai.Reactive
         /// Gets or sets the scheduler object assigned to the mapping.
         /// </summary>
         [XmlIgnore]
-        public IScheduler Instance { get; set; }
+        public IScheduler Instance { get; private set; }
 
         /// <summary>
         /// Gets or sets an XML representation of the scheduler instance for serialization.

--- a/Bonsai.Core/Reactive/Concurrency/SchedulerMapping.cs
+++ b/Bonsai.Core/Reactive/Concurrency/SchedulerMapping.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Xml.Serialization;
+
+namespace Bonsai.Reactive
+{
+    /// <summary>
+    /// Represents an object that specifies a scheduler to be used when handling
+    /// concurrency in a reactive operator.
+    /// </summary>
+    [XmlType(Namespace = Constants.ReactiveXmlNamespace)]
+    public class SchedulerMapping
+    {
+        internal static readonly SchedulerMapping Default = new DefaultScheduler();
+
+        internal SchedulerMapping()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SchedulerMapping"/> class
+        /// using the specified scheduler.
+        /// </summary>
+        /// <param name="scheduler">The scheduler to be assigned to the mapping.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="scheduler"/> is <see langword="null"/>.
+        /// </exception>
+        public SchedulerMapping(IScheduler scheduler)
+        {
+            Instance = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
+        }
+
+        internal IScheduler Instance { get; }
+    }
+
+    /// <summary>
+    /// Represents an operator that returns a scheduler object.
+    /// </summary>
+    /// <typeparam name="TScheduler">The type of the scheduler object.</typeparam>
+    [Combinator(MethodName = nameof(Generate))]
+    [WorkflowElementCategory(ElementCategory.Source)]
+    [XmlType(Namespace = Constants.ReactiveXmlNamespace)]
+    public abstract class SchedulerSource<TScheduler> : SchedulerMapping where TScheduler : IScheduler
+    {
+        internal SchedulerSource(TScheduler defaultScheduler)
+            : base(defaultScheduler)
+        {
+        }
+
+        /// <summary>
+        /// Generates an observable sequence that returns the scheduler instance.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing the <see cref="IScheduler"/> object.
+        /// </returns>
+        public IObservable<TScheduler> Generate()
+        {
+            return Observable.Return((TScheduler)Instance);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            return obj is SchedulerSource<TScheduler> scheduler && scheduler.Instance == Instance;
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return Instance.GetHashCode();
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/Concurrency/SchedulerMappingConverter.cs
+++ b/Bonsai.Core/Reactive/Concurrency/SchedulerMappingConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Globalization;
 using Rx = System.Reactive.Concurrency;
@@ -10,12 +10,12 @@ namespace Bonsai.Reactive.Concurrency
         static readonly SchedulerMapping[] DefaultSchedulers = new SchedulerMapping[]
         {
             new SchedulerMapping(),
-            new SchedulerMapping { Instance = Rx.DefaultScheduler.Instance },
-            new SchedulerMapping { Instance = Rx.CurrentThreadScheduler.Instance },
-            new SchedulerMapping { Instance = Rx.ImmediateScheduler.Instance },
-            new SchedulerMapping { Instance = Rx.ThreadPoolScheduler.Instance },
-            new SchedulerMapping { Instance = Rx.NewThreadScheduler.Default },
-            new SchedulerMapping { Instance = Rx.TaskPoolScheduler.Default },
+            new SchedulerMapping(Rx.DefaultScheduler.Instance),
+            new SchedulerMapping(Rx.CurrentThreadScheduler.Instance),
+            new SchedulerMapping(Rx.ImmediateScheduler.Instance),
+            new SchedulerMapping(Rx.ThreadPoolScheduler.Instance),
+            new SchedulerMapping(Rx.NewThreadScheduler.Default),
+            new SchedulerMapping(Rx.TaskPoolScheduler.Default),
         };
 
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)

--- a/Bonsai.Core/Reactive/Concurrency/SchedulerMappingConverter.cs
+++ b/Bonsai.Core/Reactive/Concurrency/SchedulerMappingConverter.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Bonsai.Reactive.Concurrency
+{
+    internal class SchedulerMappingConverter : TypeConverter
+    {
+        static readonly SchedulerMapping[] DefaultSchedulers = new SchedulerMapping[]
+        {
+            new DefaultScheduler(),
+            new CurrentThreadScheduler(),
+            new ImmediateScheduler(),
+            new NewThreadScheduler(),
+            new TaskPoolScheduler(),
+            new ThreadPoolScheduler()
+        };
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string name)
+            {
+                var scheduler = Array.Find(DefaultSchedulers, x => x?.GetType().Name == (string)value);
+                return scheduler ?? throw new ArgumentException(
+                    "The specified string does not identify a well-known scheduler type.",
+                    nameof(value));
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (value != null && destinationType == typeof(string))
+            {
+                var scheduler = Array.Find(DefaultSchedulers, x => x != null && x.Equals(value));
+                if (scheduler == null)
+                {
+                    return "(" + nameof(SchedulerMapping) + ")";
+                }
+
+                var sourceType = value.GetType();
+                return sourceType.Name;
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+
+        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+        {
+            return true;
+        }
+
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        {
+            return new StandardValuesCollection(DefaultSchedulers);
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/Concurrency/TaskPoolScheduler.cs
+++ b/Bonsai.Core/Reactive/Concurrency/TaskPoolScheduler.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
 using Rx = System.Reactive.Concurrency;
 
 namespace Bonsai.Reactive
@@ -8,14 +10,19 @@ namespace Bonsai.Reactive
     /// on the Task Parallel Library (TPL) task pool.
     /// </summary>
     [Description("Returns an object that schedules units of work on the Task Parallel Library (TPL) task pool.")]
-    public sealed class TaskPoolScheduler : SchedulerSource<Rx.TaskPoolScheduler>
+    public sealed class TaskPoolScheduler : Source<Rx.TaskPoolScheduler>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="TaskPoolScheduler"/> class.
+        /// Generates an observable sequence that returns the default
+        /// <see cref="Rx.TaskPoolScheduler"/> object.
         /// </summary>
-        public TaskPoolScheduler()
-            : base(Rx.TaskPoolScheduler.Default)
+        /// <returns>
+        /// A sequence containing the default <see cref="Rx.TaskPoolScheduler"/>
+        /// object.
+        /// </returns>
+        public override IObservable<Rx.TaskPoolScheduler> Generate()
         {
+            return Observable.Return(Rx.TaskPoolScheduler.Default);
         }
     }
 }

--- a/Bonsai.Core/Reactive/Concurrency/TaskPoolScheduler.cs
+++ b/Bonsai.Core/Reactive/Concurrency/TaskPoolScheduler.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+using Rx = System.Reactive.Concurrency;
+
+namespace Bonsai.Reactive
+{
+    /// <summary>
+    /// Represents an operator that returns an object that schedules units of work
+    /// on the Task Parallel Library (TPL) task pool.
+    /// </summary>
+    [Description("Returns an object that schedules units of work on the Task Parallel Library (TPL) task pool.")]
+    public sealed class TaskPoolScheduler : SchedulerSource<Rx.TaskPoolScheduler>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskPoolScheduler"/> class.
+        /// </summary>
+        public TaskPoolScheduler()
+            : base(Rx.TaskPoolScheduler.Default)
+        {
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/Concurrency/ThreadPoolScheduler.cs
+++ b/Bonsai.Core/Reactive/Concurrency/ThreadPoolScheduler.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
 using Rx = System.Reactive.Concurrency;
 
 namespace Bonsai.Reactive
@@ -8,14 +10,19 @@ namespace Bonsai.Reactive
     /// on the CLR thread pool.
     /// </summary>
     [Description("Returns an object that schedules units of work on the CLR thread pool.")]
-    public sealed class ThreadPoolScheduler : SchedulerSource<Rx.ThreadPoolScheduler>
+    public sealed class ThreadPoolScheduler : Source<Rx.ThreadPoolScheduler>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ThreadPoolScheduler"/> class.
+        /// Generates an observable sequence that returns the singleton
+        /// <see cref="Rx.ThreadPoolScheduler"/> object.
         /// </summary>
-        public ThreadPoolScheduler()
-            : base(Rx.ThreadPoolScheduler.Instance)
+        /// <returns>
+        /// A sequence containing the singleton <see cref="Rx.ThreadPoolScheduler"/>
+        /// object.
+        /// </returns>
+        public override IObservable<Rx.ThreadPoolScheduler> Generate()
         {
+            return Observable.Return(Rx.ThreadPoolScheduler.Instance);
         }
     }
 }

--- a/Bonsai.Core/Reactive/Concurrency/ThreadPoolScheduler.cs
+++ b/Bonsai.Core/Reactive/Concurrency/ThreadPoolScheduler.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+using Rx = System.Reactive.Concurrency;
+
+namespace Bonsai.Reactive
+{
+    /// <summary>
+    /// Represents an operator that returns an object that schedules units of work
+    /// on the CLR thread pool.
+    /// </summary>
+    [Description("Returns an object that schedules units of work on the CLR thread pool.")]
+    public sealed class ThreadPoolScheduler : SchedulerSource<Rx.ThreadPoolScheduler>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThreadPoolScheduler"/> class.
+        /// </summary>
+        public ThreadPoolScheduler()
+            : base(Rx.ThreadPoolScheduler.Instance)
+        {
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/ObserveOn.cs
+++ b/Bonsai.Core/Reactive/ObserveOn.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Xml.Serialization;
+using System.ComponentModel;
+using Bonsai.Expressions;
+using Bonsai.Reactive.Concurrency;
+
+namespace Bonsai.Reactive
+{
+    /// <summary>
+    /// Represents an operator that sends all notifications in the sequence to
+    /// the specified scheduler.
+    /// </summary>
+    [XmlType(Namespace = Constants.XmlNamespace)]
+    [Description("Sends all notifications in the sequence to the specified scheduler.")]
+    public class ObserveOn : Combinator, ISerializableElement
+    {
+        /// <summary>
+        /// Gets or sets a value specifying the scheduler on which to observe notifications.
+        /// </summary>
+        [XmlElement(Namespace = Constants.XmlNamespace)]
+        [TypeConverter(typeof(SchedulerMappingConverter))]
+        [Description("Specifies the scheduler on which to observe notifications.")]
+        public SchedulerMapping Scheduler { get; set; } = SchedulerMapping.Default;
+
+        object ISerializableElement.Element => Scheduler;
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="Scheduler"/> property should be serialized.
+        /// </summary>
+        [Browsable(false)]
+        public bool SchedulerSpecified
+        {
+            get
+            {
+                var scheduler = Scheduler;
+                return scheduler != SchedulerMapping.Default &&
+                    scheduler?.GetType() != typeof(SchedulerMapping);
+            }
+        }
+
+        /// <summary>
+        /// Sends all notifications in an observable sequence to the specified scheduler.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">The source sequence to schedule notifications for.</param>
+        /// <returns>
+        /// An observable sequence where all notifications are sent to the specified
+        /// scheduler.
+        /// </returns>
+        public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.ObserveOn(Scheduler?.Instance);
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/ObserveOn.cs
+++ b/Bonsai.Core/Reactive/ObserveOn.cs
@@ -22,6 +22,15 @@ namespace Bonsai.Reactive
         public SchedulerMapping Scheduler { get; set; }
 
         /// <summary>
+        /// Gets a value indicating whether the <see cref="Scheduler"/> property should be serialized.
+        /// </summary>
+        [Browsable(false)]
+        public bool SchedulerSpecified
+        {
+            get { return !string.IsNullOrEmpty(Scheduler.InstanceXml); }
+        }
+
+        /// <summary>
         /// Sends all notifications in an observable sequence to the specified scheduler.
         /// </summary>
         /// <typeparam name="TSource">

--- a/Bonsai.Core/Reactive/ObserveOn.cs
+++ b/Bonsai.Core/Reactive/ObserveOn.cs
@@ -2,7 +2,6 @@
 using System.Reactive.Linq;
 using System.Xml.Serialization;
 using System.ComponentModel;
-using Bonsai.Expressions;
 using Bonsai.Reactive.Concurrency;
 
 namespace Bonsai.Reactive
@@ -13,31 +12,14 @@ namespace Bonsai.Reactive
     /// </summary>
     [XmlType(Namespace = Constants.XmlNamespace)]
     [Description("Sends all notifications in the sequence to the specified scheduler.")]
-    public class ObserveOn : Combinator, ISerializableElement
+    public class ObserveOn : Combinator
     {
         /// <summary>
         /// Gets or sets a value specifying the scheduler on which to observe notifications.
         /// </summary>
-        [XmlElement(Namespace = Constants.XmlNamespace)]
         [TypeConverter(typeof(SchedulerMappingConverter))]
         [Description("Specifies the scheduler on which to observe notifications.")]
-        public SchedulerMapping Scheduler { get; set; } = SchedulerMapping.Default;
-
-        object ISerializableElement.Element => Scheduler;
-
-        /// <summary>
-        /// Gets a value indicating whether the <see cref="Scheduler"/> property should be serialized.
-        /// </summary>
-        [Browsable(false)]
-        public bool SchedulerSpecified
-        {
-            get
-            {
-                var scheduler = Scheduler;
-                return scheduler != SchedulerMapping.Default &&
-                    scheduler?.GetType() != typeof(SchedulerMapping);
-            }
-        }
+        public SchedulerMapping Scheduler { get; set; }
 
         /// <summary>
         /// Sends all notifications in an observable sequence to the specified scheduler.
@@ -52,7 +34,7 @@ namespace Bonsai.Reactive
         /// </returns>
         public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
         {
-            return source.ObserveOn(Scheduler?.Instance);
+            return source.ObserveOn(Scheduler.Instance);
         }
     }
 }

--- a/Bonsai.Core/Reactive/SubscribeOn.cs
+++ b/Bonsai.Core/Reactive/SubscribeOn.cs
@@ -25,6 +25,15 @@ namespace Bonsai.Reactive
         public SchedulerMapping Scheduler { get; set; }
 
         /// <summary>
+        /// Gets a value indicating whether the <see cref="Scheduler"/> property should be serialized.
+        /// </summary>
+        [Browsable(false)]
+        public bool SchedulerSpecified
+        {
+            get { return !string.IsNullOrEmpty(Scheduler.InstanceXml); }
+        }
+
+        /// <summary>
         /// Wraps the source sequence in order to run its subscription and
         /// unsubscription logic on the specified scheduler.
         /// </summary>

--- a/Bonsai.Core/Reactive/SubscribeOn.cs
+++ b/Bonsai.Core/Reactive/SubscribeOn.cs
@@ -2,7 +2,6 @@
 using System.Reactive.Linq;
 using System.Xml.Serialization;
 using System.ComponentModel;
-using Bonsai.Expressions;
 using Bonsai.Reactive.Concurrency;
 
 namespace Bonsai.Reactive
@@ -15,31 +14,15 @@ namespace Bonsai.Reactive
     /// <seealso cref="ObserveOn"/>
     [XmlType(Namespace = Constants.ReactiveXmlNamespace)]
     [Description("Wraps the source sequence in order to run its subscription and unsubscription logic on the specified scheduler.")]
-    public class SubscribeOn : Combinator, ISerializableElement
+    public class SubscribeOn : Combinator
     {
         /// <summary>
         /// Gets or sets a value specifying the scheduler on which to run subscription and
         /// unsubscription actions.
         /// </summary>
-        [XmlElement(Namespace = Constants.XmlNamespace)]
         [TypeConverter(typeof(SchedulerMappingConverter))]
-        public SchedulerMapping Scheduler { get; set; } = SchedulerMapping.Default;
-
-        object ISerializableElement.Element => Scheduler;
-
-        /// <summary>
-        /// Gets a value indicating whether the <see cref="Scheduler"/> property should be serialized.
-        /// </summary>
-        [Browsable(false)]
-        public bool SchedulerSpecified
-        {
-            get
-            {
-                var scheduler = Scheduler;
-                return scheduler != SchedulerMapping.Default &&
-                    scheduler?.GetType() != typeof(SchedulerMapping);
-            }
-        }
+        [Description("Specifies the scheduler on which to run subscription and unsubscription actions.")]
+        public SchedulerMapping Scheduler { get; set; }
 
         /// <summary>
         /// Wraps the source sequence in order to run its subscription and
@@ -55,7 +38,7 @@ namespace Bonsai.Reactive
         /// </returns>
         public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
         {
-            return source.SubscribeOn(Scheduler?.Instance);
+            return source.SubscribeOn(Scheduler.Instance);
         }
     }
 }

--- a/Bonsai.Core/Reactive/SubscribeOn.cs
+++ b/Bonsai.Core/Reactive/SubscribeOn.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Xml.Serialization;
+using System.ComponentModel;
+using Bonsai.Expressions;
+using Bonsai.Reactive.Concurrency;
+
+namespace Bonsai.Reactive
+{
+    /// <summary>
+    /// Represents an operator that wraps the source sequence in order to run its
+    /// subscription and unsubscription logic on the specified scheduler.
+    /// </summary>
+    /// <remarks>This operator is not commonly used.</remarks>
+    /// <seealso cref="ObserveOn"/>
+    [XmlType(Namespace = Constants.ReactiveXmlNamespace)]
+    [Description("Wraps the source sequence in order to run its subscription and unsubscription logic on the specified scheduler.")]
+    public class SubscribeOn : Combinator, ISerializableElement
+    {
+        /// <summary>
+        /// Gets or sets a value specifying the scheduler on which to run subscription and
+        /// unsubscription actions.
+        /// </summary>
+        [XmlElement(Namespace = Constants.XmlNamespace)]
+        [TypeConverter(typeof(SchedulerMappingConverter))]
+        public SchedulerMapping Scheduler { get; set; } = SchedulerMapping.Default;
+
+        object ISerializableElement.Element => Scheduler;
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="Scheduler"/> property should be serialized.
+        /// </summary>
+        [Browsable(false)]
+        public bool SchedulerSpecified
+        {
+            get
+            {
+                var scheduler = Scheduler;
+                return scheduler != SchedulerMapping.Default &&
+                    scheduler?.GetType() != typeof(SchedulerMapping);
+            }
+        }
+
+        /// <summary>
+        /// Wraps the source sequence in order to run its subscription and
+        /// unsubscription logic on the specified scheduler.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">The observable sequence to wrap.</param>
+        /// <returns>
+        /// An observable sequence where subscription and unsubscription logic
+        /// run on the specified scheduler.
+        /// </returns>
+        public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.SubscribeOn(Scheduler?.Instance);
+        }
+    }
+}

--- a/Bonsai.Editor/Bonsai.Editor.csproj
+++ b/Bonsai.Editor/Bonsai.Editor.csproj
@@ -13,7 +13,6 @@
     <EmbeddedResource Include="**\*.svg" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Rx-PlatformServices" Version="2.2.5" />
     <PackageReference Include="SvgNet" Version="3.2.0" />
     <PackageReference Include="YamlDotNet" Version="12.0.2" />
   </ItemGroup>

--- a/Bonsai.System/Bonsai.System.csproj
+++ b/Bonsai.System/Bonsai.System.csproj
@@ -7,9 +7,6 @@
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <VersionPrefix>2.7.0</VersionPrefix>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Rx-PlatformServices" Version="2.2.5" />
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.IO.Ports" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
This PR adds operators for creating objects that schedule units of work in various concurrency platforms. It also adds support to control concurrency for operator notifications and subscription logic using the `ObserveOn` and `SubscribeOn` operators.

Schedulers are specified as properties in each of the operators which can either be externalized and assigned dynamically from user-specified sequences, or from a drop-down list of well-known default scheduler types.

Fixes #1081 