### PR TITLE
Require opt-in attribute to reset combinator

### DIFF
--- a/Bonsai.Core/Expressions/CombinatorBuilder.cs
+++ b/Bonsai.Core/Expressions/CombinatorBuilder.cs
@@ -77,6 +77,11 @@ namespace Bonsai.Expressions
 
         static Delegate BuildResetCombinator(Type combinatorType)
         {
+            if (!combinatorType.IsDefined(typeof(ResetCombinatorAttribute)))
+            {
+                return null;
+            }
+
             List<PropertyInfo> resetProperties = null;
             var combinatorProperties = combinatorType.GetProperties();
             for (int i = 0; i < combinatorProperties.Length; i++)

--- a/Bonsai.Core/ResetCombinatorAttribute.cs
+++ b/Bonsai.Core/ResetCombinatorAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Bonsai
+{
+    /// <summary>
+    /// Instructs the build process to reset non-serializable public properties
+    /// marked with <see cref="System.Xml.Serialization.XmlIgnoreAttribute"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class ResetCombinatorAttribute : Attribute
+    {
+    }
+}

--- a/Bonsai.Vision/Drawing/AddImage.cs
+++ b/Bonsai.Vision/Drawing/AddImage.cs
@@ -8,6 +8,7 @@ namespace Bonsai.Vision.Drawing
     /// <summary>
     /// Represents an operator that specifies drawing the specified image to the canvas.
     /// </summary>
+    [ResetCombinator]
     [Description("Draws the specified image to the canvas.")]
     public class AddImage : CanvasElement
     {

--- a/Bonsai.Vision/Drawing/DrawContours.cs
+++ b/Bonsai.Vision/Drawing/DrawContours.cs
@@ -9,6 +9,7 @@ namespace Bonsai.Vision.Drawing
     /// Represents an operator that specifies drawing contour outlines or filled
     /// interiors in an image.
     /// </summary>
+    [ResetCombinator]
     [Description("Draws contour outlines or filled interiors in an image.")]
     public class DrawContours : CanvasElement
     {

--- a/Bonsai.Vision/Drawing/FillPolygon.cs
+++ b/Bonsai.Vision/Drawing/FillPolygon.cs
@@ -9,6 +9,7 @@ namespace Bonsai.Vision.Drawing
     /// Represents an operator that specifies filling an area bounded by several
     /// polygonal contours.
     /// </summary>
+    [ResetCombinator]
     [Description("Fills an area bounded by several polygonal contours.")]
     public class FillPolygon : CanvasElement
     {

--- a/Bonsai.Vision/Drawing/LineChart.cs
+++ b/Bonsai.Vision/Drawing/LineChart.cs
@@ -9,6 +9,7 @@ namespace Bonsai.Vision.Drawing
     /// Represents an operator that specifies drawing a line chart by plotting
     /// each row of a matrix as a polyline element.
     /// </summary>
+    [ResetCombinator]
     [Description("Draws a line chart by plotting each row of a matrix as a polyline element.")]
     public class LineChart : CanvasElement
     {

--- a/Bonsai.Vision/Drawing/Path.cs
+++ b/Bonsai.Vision/Drawing/Path.cs
@@ -9,6 +9,7 @@ namespace Bonsai.Vision.Drawing
     /// <summary>
     /// Represents an operator that specifies drawing a path from an array of vertices.
     /// </summary>
+    [ResetCombinator]
     [Description("Draws a path from an array of vertices.")]
     public class Path : CanvasElement
     {

--- a/Bonsai.Vision/Drawing/PolyLine.cs
+++ b/Bonsai.Vision/Drawing/PolyLine.cs
@@ -8,6 +8,7 @@ namespace Bonsai.Vision.Drawing
     /// <summary>
     /// Represents an operator that specifies drawing one or more polygonal curves.
     /// </summary>
+    [ResetCombinator]
     [Description("Draws one or more polygonal curves.")]
     public class PolyLine : CanvasElement
     {


### PR DESCRIPTION
This PR introduces the `ResetCombinatorAttribute` as an explicit opt-in requirement for resetting non-serializable combinator properties. This allows classes to request a reset of their volatile runtime state at workflow build time without compromising performance or introducing unexpected behavior for all other regular combinators.

Fixes #659 