### PR TITLE
Fix layout for gallery and package export dialogs

### DIFF
--- a/Bonsai.NuGet.Design/Bonsai.NuGet.Design.csproj
+++ b/Bonsai.NuGet.Design/Bonsai.NuGet.Design.csproj
@@ -5,7 +5,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.7.1</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.Design\Bonsai.Design.csproj" />

--- a/Bonsai.NuGet.Design/GalleryDialog.Designer.cs
+++ b/Bonsai.NuGet.Design/GalleryDialog.Designer.cs
@@ -125,7 +125,9 @@
             // 
             // prereleaseCheckBox
             // 
+            this.prereleaseCheckBox.AutoSize = true;
             this.prereleaseCheckBox.Location = new System.Drawing.Point(341, 3);
+            this.prereleaseCheckBox.Margin = new System.Windows.Forms.Padding(3, 6, 3, 3);
             this.prereleaseCheckBox.Name = "prereleaseCheckBox";
             this.prereleaseCheckBox.Size = new System.Drawing.Size(147, 26);
             this.prereleaseCheckBox.TabIndex = 3;

--- a/Bonsai.NuGet.Design/PackageBuilderDialog.cs
+++ b/Bonsai.NuGet.Design/PackageBuilderDialog.cs
@@ -402,7 +402,9 @@ namespace Bonsai.NuGet.Design
                                            property.Name != nameof(PackageBuilder.Serviceable) &&
                                            property.Name != nameof(PackageBuilder.TargetFrameworks) &&
                                            property.Name != nameof(PackageBuilder.Icon) &&
-                                           property.Name != nameof(PackageBuilder.LicenseMetadata)
+                                           property.Name != nameof(PackageBuilder.LicenseMetadata) &&
+                                           property.Name != nameof(PackageBuilder.EmitRequireLicenseAcceptance) &&
+                                           property.Name != nameof(PackageBuilder.Readme)
                                      select ConvertPropertyDescriptor(property);
                     var output = new PropertyDescriptorCollection(properties.ToArray()).Sort(SortOrder);
                     return output;

--- a/Bonsai/Bonsai.csproj
+++ b/Bonsai/Bonsai.csproj
@@ -7,7 +7,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <UseWindowsForms>true</UseWindowsForms>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.7.1</VersionPrefix>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>
     <ApplicationIcon>..\Bonsai.Editor\Bonsai.ico</ApplicationIcon>


### PR DESCRIPTION
This PR fixes a small number of layout issues with the gallery and package export dialogs, ensuring uniformity with other package manager dialogs.

Fixes #1096 