### PR TITLE
Ensure upgrading does not re-enable disabled nodes

### DIFF
--- a/Bonsai.Editor/GraphModel/UpgradeHelper.cs
+++ b/Bonsai.Editor/GraphModel/UpgradeHelper.cs
@@ -63,6 +63,14 @@ namespace Bonsai.Editor.GraphModel
             return separatorIndex >= 0 && !Path.IsPathRooted(path);
         }
 
+        static ExpressionBuilder ConvertBuilder(ExpressionBuilder builder, Func<ExpressionBuilder, ExpressionBuilder> selector)
+        {
+            //TODO: Remove this workaround for ensuring workflow node order (refactor core conversion API)
+            var set = new[] { new Node<ExpressionBuilder, ExpressionBuilderArgument>(builder) };
+            var result = set.Convert(selector, recurse: false);
+            return result.First().Value;
+        }
+
         internal static bool TryUpgradeWorkflow(ExpressionBuilderGraph workflow, string fileName, out ExpressionBuilderGraph upgradedWorkflow)
         {
             if (!IsEmbeddedResourcePath(fileName) && File.Exists(fileName))
@@ -95,6 +103,18 @@ namespace Bonsai.Editor.GraphModel
             GetArgumentCount(workflow, argumentCount);
             ExpressionBuilder UpgradeBuilder(ExpressionBuilder builder)
             {
+                if (builder is DisableBuilder disableBuilder)
+                {
+                    var upgradedBuilder = UpgradeBuilder(disableBuilder.Builder);
+                    if (upgradedBuilder != disableBuilder.Builder)
+                    {
+                        upgradedBuilder = ConvertBuilder(disableBuilder, builder => upgradedBuilder);
+                        return new DisableBuilder(upgradedBuilder);
+                    }
+
+                    return builder;
+                }
+
 #pragma warning disable CS0612 // Type or member is obsolete
                 if (builder is SourceBuilder sourceBuilder)
                 {


### PR DESCRIPTION
This PR ensures that upgrading disabled nodes does not cause the node to be re-enabled.

The fix is actually more involved than expected since there is currently no good way to convert / replace individual builder nodes in a way that keeps their sort order. As a temporary workaround we are running a local convert routine just for the individual upgraded node, but this would greatly benefit from refactoring the core API in the future to more easily support such conversion operations, especially if growing decorator support is anticipated.

Fixes #1097 