### PR TITLE
Fix drag and dropping of workflow files into the graph view

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
@@ -780,8 +780,10 @@ namespace Bonsai.Editor
                     MessageBoxIcon.Warning);
             }
 
-            workflowBuilder = new WorkflowBuilder(workflow.ToInspectableGraph());
-            return workflowBuilder;
+            return new WorkflowBuilder(workflow.ToInspectableGraph())
+            {
+                Description = workflowBuilder.Description
+            };
         }
 
         void ClearWorkflow()

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -980,7 +980,7 @@ namespace Bonsai.Editor.GraphView
                             groupBuilder.Description = workflowBuilder.Description;
                             elements.Add(groupBuilder);
                         }
-                        InsertWorkflow(elements, nodeType, branch);
+                        InsertWorkflow(elements.ToInspectableGraph(recurse: false), nodeType, branch);
                     }
                     else
                     {


### PR DESCRIPTION
This PR fixes pending issues when drag and dropping workflow files into the graph view, which were causing crashes and unexpected loss of information.

Fixes #1104 
Fixes #1105 