### PR TITLE
Ensure embedded workflows also upgrade on ungroup

### DIFF
--- a/Bonsai.Editor/GraphModel/UpgradeHelper.cs
+++ b/Bonsai.Editor/GraphModel/UpgradeHelper.cs
@@ -78,7 +78,10 @@ namespace Bonsai.Editor.GraphModel
 
         internal static bool TryUpgradeWorkflow(ExpressionBuilderGraph workflow, string fileName, out ExpressionBuilderGraph upgradedWorkflow)
         {
-            var workflowStream = GetWorkflowStream(fileName);
+            Stream workflowStream;
+            try { workflowStream = GetWorkflowStream(fileName); }
+            catch (SystemException) { workflowStream = null; }
+
             if (workflowStream != null)
             {
                 using var reader = XmlReader.Create(workflowStream);


### PR DESCRIPTION
This PR extends the functionality of upgrading included workflows on ungrouping also to embedded workflows.

There is some redundancy on code used for accessing the embedded resource stream that should probably be refactored into the core API. However, the code is not too complex and this is a critical bit of functionality for package maintainers, so the decision was made to port a simplified version from `IncludeWorkflowBuilder`.

Fixes #1126 