### PR TITLE
Add support for COLLADA, FBX and STL formats

### DIFF
--- a/Bonsai.Shaders.Rendering/Bonsai.Shaders.Rendering.csproj
+++ b/Bonsai.Shaders.Rendering/Bonsai.Shaders.Rendering.csproj
@@ -5,7 +5,7 @@
     <Description>Bonsai Shaders Rendering Library containing modules for rendering complex 3D scenes.</Description>
     <PackageTags>Bonsai Rx Shaders Rendering Assets Graphics OpenGL</PackageTags>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.3.1</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AssimpNet" Version="4.1.0" />

--- a/Bonsai.Shaders.Rendering/SceneConfiguration.cs
+++ b/Bonsai.Shaders.Rendering/SceneConfiguration.cs
@@ -19,7 +19,7 @@ namespace Bonsai.Shaders.Rendering
         /// </summary>
         [TypeConverter(typeof(ResourceFileNameConverter))]
         [Editor(DesignTypes.OpenFileNameEditor, DesignTypes.UITypeEditor)]
-        [FileNameFilter("Blender Files (*.blend)|*.blend|OBJ Files (*.obj)|*.obj|All Files|*.*")]
+        [FileNameFilter("COLLADA Files (*.dae)|*.dae|Blender Files (*.blend)|*.blend|FBX Files (*.fbx)|*.fbx|OBJ Files (*.obj)|*.obj|STL Files (*.stl)|*.stl|All Files|*.*")]
         [Description("The name of the file from which to load the scene.")]
         public string FileName { get; set; }
 


### PR DESCRIPTION
This PR adds drag and drop support for more formats compatible with the Open Asset Import Library, to make it easier to import multiple files.

Fixes #1124 