### PR TITLE
Add extension folders to IronPython search path

### DIFF
--- a/Bonsai.Scripting.IronPython.Design/Bonsai.Scripting.IronPython.Design.csproj
+++ b/Bonsai.Scripting.IronPython.Design/Bonsai.Scripting.IronPython.Design.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Scripting Iron Python Design</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.7.1</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="jacobslusser.ScintillaNET" Version="3.6.3" />

--- a/Bonsai.Scripting.IronPython/Bonsai.Scripting.IronPython.csproj
+++ b/Bonsai.Scripting.IronPython/Bonsai.Scripting.IronPython.csproj
@@ -5,7 +5,7 @@
     <Description>Bonsai Scripting Library containing IronPython scripting infrastructure for Bonsai.</Description>
     <PackageTags>Bonsai Rx Scripting Iron Python</PackageTags>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.7.1</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="IronPython" Version="2.7.5" />


### PR DESCRIPTION
This PR adds support for Python scripts to be included in the standard scripting extension folders used by the editor for both C# and workflow extensions.

Fixes #1143 