### PR TITLE
Ensure correct upgrade of inspectable workflows

### DIFF
--- a/Bonsai.Editor/Bonsai.Editor.csproj
+++ b/Bonsai.Editor/Bonsai.Editor.csproj
@@ -7,7 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>2.7.1</VersionPrefix>
+    <VersionPrefix>2.7.2</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.svg" />

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -1642,8 +1642,8 @@ namespace Bonsai.Editor.GraphModel
                 var path = includeBuilder.Path;
                 if (workflow != null && !string.IsNullOrEmpty(path))
                 {
-                    UpgradeHelper.TryUpgradeWorkflow(workflow, path, out workflow);
-                    groupBuilder = new GroupWorkflowBuilder(workflow);
+                    UpgradeHelper.TryUpgradeWorkflow(workflow.FromInspectableGraph(), path, out workflow);
+                    groupBuilder = new GroupWorkflowBuilder(workflow.ToInspectableGraph());
                 }
                 else groupBuilder = new GroupWorkflowBuilder();
                 groupBuilder.Name = includeBuilder.Name;


### PR DESCRIPTION
This PR ensures the upgrade routine works correctly when ungrouping included workflows by reverting the upgraded workflow to its non-inspectable form.

Fixes #1148 