### PR TITLE
Ensure XmlInclude types are included in serializer

### DIFF
--- a/Bonsai.Core/Bonsai.Core.csproj
+++ b/Bonsai.Core/Bonsai.Core.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Reactive Extensions</PackageTags>
     <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>Bonsai</RootNamespace>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.7.1</VersionPrefix>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Rx-Linq" Version="2.2.5" />


### PR DESCRIPTION
This PR ensures that XML include types declared on any extension type are correctly included in the XML serializer.

Strangely, this seems to work automatically for serialization but not deserialization. Fortunately, it is easy to fix by querying types when they are first added to the set of extensions for any extra XML include types declared using `XmlIncludeAttribute`.

Fixes #1154 