### PR TITLE
Ensure initial and current directories are equal

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -309,6 +309,7 @@ namespace Bonsai.Editor
             }
 
             directoryToolStripItem.Text = currentDirectory;
+            openWorkflowDialog.InitialDirectory = saveWorkflowDialog.InitialDirectory = currentDirectory;
             extensionsPath = new DirectoryInfo(Path.Combine(workflowBaseDirectory, ExtensionsDirectory));
             if (extensionsPath.Exists) OnExtensionsDirectoryChanged(EventArgs.Empty);
 
@@ -980,7 +981,6 @@ namespace Bonsai.Editor
         void UpdateWorkflowDirectory(string fileName, bool setWorkingDirectory)
         {
             var workflowDirectory = Path.GetDirectoryName(fileName);
-            openWorkflowDialog.InitialDirectory = saveWorkflowDialog.InitialDirectory = workflowDirectory;
             if (setWorkingDirectory && directoryToolStripItem.Text != workflowDirectory)
             {
                 Environment.CurrentDirectory = workflowDirectory;


### PR DESCRIPTION
This PR ensures that the initial directory for the open and save dialogs on the main editor is consistent with the current working directory set on initialization. This aims to prevent saving workflows by mistake across different environments.

Fixes #1135 