### PR TITLE
Avoid locked file access when upgrading and re-saving extensions

### DIFF
--- a/Bonsai.Editor/GraphModel/UpgradeHelper.cs
+++ b/Bonsai.Editor/GraphModel/UpgradeHelper.cs
@@ -92,7 +92,7 @@ namespace Bonsai.Editor.GraphModel
 
             if (workflowStream != null)
             {
-                using var reader = XmlReader.Create(workflowStream);
+                using var reader = XmlReader.Create(workflowStream, new XmlReaderSettings { CloseInput = true });
                 ElementStore.ReadWorkflowVersion(reader, out SemanticVersion version);
                 return TryUpgradeWorkflow(workflow, version, out upgradedWorkflow);
             }

--- a/Bonsai/WorkflowElementLoader.cs
+++ b/Bonsai/WorkflowElementLoader.cs
@@ -75,7 +75,7 @@ namespace Bonsai
                 {
                     var description = string.Empty;
                     var name = Path.GetFileNameWithoutExtension(embeddedResources[i]);
-                    var resourceStream = assembly.GetManifestResourceStream(embeddedResources[i]);
+                    using var resourceStream = assembly.GetManifestResourceStream(embeddedResources[i]);
                     try
                     {
                         var metadataType = assembly.GetType(name);


### PR DESCRIPTION
When ungrouping an include workflow, the file may be quickly checked for whether an upgrade is required. This PR ensures that this check does not keep the file locked when re-saving the workflow. Apparently `XmlReader` does not close source streams by default, unless specific reader settings are activated.

Fixes #1163 