### PR TITLE
Add operators to select a file, or folder, to the `System` package

### DIFF
--- a/Bonsai.System/IO/SelectFile.cs
+++ b/Bonsai.System/IO/SelectFile.cs
@@ -1,0 +1,47 @@
+﻿using Bonsai;
+using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+
+namespace Bonsai.IO
+{
+    /// <summary>
+    /// An operator that generates a sequence of strings representing
+    /// the path to a user-selected file.
+    /// </summary>
+    [DefaultProperty("Path")]
+    [Description("Returns a string with the name of the selected file path.")]
+    public class SelectFile : Source<string>
+    {
+        /// <summary>
+        /// Gets or sets the relative or absolute path of the selected file.
+        /// </summary>
+        [FileNameFilter("Any|*.*")]
+        [Editor("Bonsai.Design.OpenFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        [Description("The relative or absolute path of the selected file.")]
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Generates an observable sequence containing a string of the selected file.
+        /// </summary>
+        /// <returns>
+        /// An observable sequence containing a string of the selected file.
+        /// </returns>
+        public override IObservable<string> Generate()
+        {
+            return Observable.Return(Path);
+        }
+
+        /// <summary>
+        /// Generates an observable sequence containing a string of the selected file,
+        /// triggered with any input sequence.
+        /// </summary>
+        /// <returns>
+        /// An observable sequence containing a string of the selected file.
+        /// </returns>
+        public IObservable<string> Generate<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(x => {return Path;});
+        }
+        }
+}

--- a/Bonsai.System/IO/SelectFolder.cs
+++ b/Bonsai.System/IO/SelectFolder.cs
@@ -1,0 +1,46 @@
+﻿using Bonsai;
+using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+
+namespace Bonsai.IO
+{
+    /// <summary>
+    /// An operator that generates a sequence of strings representing
+    /// the path to a user-selected folder.
+    /// </summary>
+    [DefaultProperty("Path")]
+    [Description("Returns a string with the name of the selected folder path.")]
+    public class SelectFolder : Source<string>
+    {
+        /// <summary>
+        /// Gets or sets the relative or absolute path of the selected folder.
+        /// </summary>
+        [Editor("Bonsai.Design.FolderNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        [Description("The relative or absolute path of the selected folder.")]
+        public string Path { get; set; } = ".";
+
+        /// <summary>
+        /// Generates an observable sequence containing a string of the selected folder.
+        /// </summary>
+        /// <returns>
+        /// An observable sequence containing a string of the selected folder.
+        /// </returns>
+        public override IObservable<string> Generate()
+        {
+            return Observable.Return(Path);
+        }
+
+        /// <summary>
+        /// Generates an observable sequence containing a string of the selected folder,
+        /// triggered with any input sequence.
+        /// </summary>
+        /// <returns>
+        /// An observable sequence containing a string of the selected folder.
+        /// </returns>
+        public IObservable<string> Generate<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(x => {return Path;});
+        }
+        }
+}


### PR DESCRIPTION
This PR attempts to close #614.

- Both operators allow the user to select a target file, or folder, from a corresponding UI Editor. 

- Both operators have a default `Defer` reactive logic, but can be optionally overloaded with any input sequence, triggering an output event with the currently set `Path` property value.