### PR TITLE
Add dotnet template for creating a new bonsai environment

### DIFF
--- a/Bonsai.Templates/Bonsai.EnvironmentTemplate/.template.config/template.json
+++ b/Bonsai.Templates/Bonsai.EnvironmentTemplate/.template.config/template.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "Bonsai",
+    "classifications": [ "Bonsai", "Environment" ],
+    "description": "A template for bootstrapping a Bonsai environment",
+    "identity": "Bonsai.EnvironmentTemplate",
+    "name": "Bonsai Environment",
+    "tags": {
+        "type": "project"
+    },
+    "postActions": [{
+        "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
+        "description": "Initializes the bonsai environment.",
+        "manualInstructions": [{
+            "text": "Run the 'Setup.ps1' or 'Setup.cmd' scripts."
+        }],
+        "args": {
+            "executable": "powershell",
+            "args": "-File Setup.ps1",
+            "redirectStandardOutput": false
+        }
+          
+    }],
+    "shortName": "bonsaienv",
+    "preferNameDirectory": true
+}

--- a/Bonsai.Templates/Bonsai.EnvironmentTemplate/Setup.cmd
+++ b/Bonsai.Templates/Bonsai.EnvironmentTemplate/Setup.cmd
@@ -1,0 +1,1 @@
+powershell -ExecutionPolicy Bypass -File ./Setup.ps1

--- a/Bonsai.Templates/Bonsai.EnvironmentTemplate/Setup.ps1
+++ b/Bonsai.Templates/Bonsai.EnvironmentTemplate/Setup.ps1
@@ -1,0 +1,19 @@
+if (!(Test-Path "./Bonsai.exe")) {
+    $release = "https://github.com/bonsai-rx/bonsai/releases/latest/download/Bonsai.zip"
+    $configPath = "./Bonsai.config"
+    if (Test-Path $configPath) {
+        [xml]$config = Get-Content $configPath
+        $bootstrapper = $config.PackageConfiguration.Packages.Package.where{$_.id -eq 'Bonsai'}
+        if ($bootstrapper) {
+            $version = $bootstrapper.version
+            $release = "https://github.com/bonsai-rx/bonsai/releases/download/$version/Bonsai.zip"
+        }
+    }
+    Invoke-WebRequest $release -OutFile "temp.zip"
+    Move-Item -Path "NuGet.config" "temp.config"
+    Expand-Archive "temp.zip" -DestinationPath "." -Force
+    Move-Item -Path "temp.config" "NuGet.config" -Force
+    Remove-Item -Path "temp.zip"
+	Remove-Item -Path "Bonsai32.exe"
+}
+& .\Bonsai.exe --no-editor

--- a/Bonsai.Templates/Bonsai.PackageTemplate/.template.config/template.json
+++ b/Bonsai.Templates/Bonsai.PackageTemplate/.template.config/template.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json.schemastore.org/template",
-    "author": "Gonçalo Lopes",
-    "classifications": [ "Common", "Bonsai", "Package" ],
+    "author": "Bonsai",
+    "classifications": [ "Bonsai", "Package" ],
+    "description": "A project for creating a C# Bonsai package (.dll)",
     "identity": "Bonsai.PackageTemplate",
     "name": "Bonsai Package",
     "tags": {
@@ -57,6 +58,6 @@
         }
     },
     "sourceName": "$projectname$",
-    "shortName": "bonsai-package",
+    "shortName": "bonsaipackage",
     "preferNameDirectory": true
 }

--- a/Bonsai.Templates/Bonsai.Templates.csproj
+++ b/Bonsai.Templates/Bonsai.Templates.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
     <PackageVersion>2.7.0</PackageVersion>
     <PackageId>Bonsai.Templates</PackageId>
     <Title>Bonsai Templates</Title>
-    <Authors>Gonçalo Lopes</Authors>
+    <Authors>Bonsai</Authors>
     <Description>Templates for creating a C# Bonsai package (.nupkg)</Description>
     <PackageTags>Bonsai Rx Package Templates</PackageTags>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/Bonsai.Templates/Bonsai.Templates.csproj
+++ b/Bonsai.Templates/Bonsai.Templates.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="Bonsai.EnvironmentTemplate\**\*" />
     <Content Include="Bonsai.PackageTemplate\**\*" Exclude="**\**\bin\**;**\**\obj\**;**\**\Properties\**;**\*.ico;**\*.user;**\*.vstemplate;**\Bonsai.PackageTemplate.csproj" />
     <Compile Remove="**\*" />
   </ItemGroup>

--- a/Bonsai.Templates/Bonsai.Templates.csproj
+++ b/Bonsai.Templates/Bonsai.Templates.csproj
@@ -7,7 +7,7 @@
     <Title>Bonsai Templates</Title>
     <Authors>Bonsai</Authors>
     <Description>Templates for creating a C# Bonsai package (.nupkg)</Description>
-    <PackageTags>Bonsai Rx Package Templates</PackageTags>
+    <PackageTags>Bonsai Rx Package Environment Templates</PackageTags>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>


### PR DESCRIPTION
This PR adds support for bootstrapping a new self-contained Bonsai environment using the `dotnet` templating system, PowerShell, and GitHub releases.

To install:
```
dotnet new -i Bonsai.Templates
```

Create a new environment folder:
```
dotnet new bonsaienv -o bonsai
```

If there is an existing `Bonsai.config` and/or `NuGet.config` in the folder, these will be used as part of the environment reconstruction process. In this case, it is enough to navigate to the folder where `Bonsai.config` is and simply run:
```
dotnet new bonsaienv
```