### PR TITLE
Add support for dynamic keyword and dynamic object binding in C# scripts

### DIFF
--- a/Bonsai.Configuration/ScriptExtensions.cs
+++ b/Bonsai.Configuration/ScriptExtensions.cs
@@ -109,6 +109,7 @@ namespace Bonsai.Configuration
             yield return "System.Xml.dll";
             yield return "Bonsai.Core.dll";
             yield return "Microsoft.CSharp.dll";
+            yield return "netstandard.dll";
 
             if (!File.Exists(ProjectFileName)) yield break;
             using var stream = File.OpenRead(ProjectFileName);

--- a/Bonsai.Configuration/ScriptExtensions.cs
+++ b/Bonsai.Configuration/ScriptExtensions.cs
@@ -108,6 +108,7 @@ namespace Bonsai.Configuration
             yield return "System.Reactive.Linq.dll";
             yield return "System.Xml.dll";
             yield return "Bonsai.Core.dll";
+            yield return "Microsoft.CSharp.dll";
 
             if (!File.Exists(ProjectFileName)) yield break;
             using var stream = File.OpenRead(ProjectFileName);


### PR DESCRIPTION
This PR adds support for the dynamic keyword and dynamic object runtime binding for interfacing with external scripting packages such as Python.NET. A reference to the `netstandard` assembly was also added to ensure general package compatibility.

Fixes #1238 