### PR TITLE
Increase default max number of significant digits for floating-point values in CsvWriter

### DIFF
--- a/Bonsai.System/Bonsai.System.csproj
+++ b/Bonsai.System/Bonsai.System.csproj
@@ -5,7 +5,7 @@
     <Description>Bonsai System Library containing reactive infrastructure to interface with the underlying operating system.</Description>
     <PackageTags>Bonsai Rx Reactive Extensions IO Serial Port Resources</PackageTags>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.7.1</VersionPrefix>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.IO.Ports" Version="6.0.0" />


### PR DESCRIPTION
This PR overrides the default maximum number of significant digits when formatting floating-point values to ensure they can round-trip successfully using `CsvReader` or other applications.

The formatting defaults of the [General format specifier](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings?redirectedfrom=MSDN#GFormatString) use G7 and G15 respectively as max precision defaults on .NET framework.

In the guidelines for using the [Round-trip format specifier](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings?redirectedfrom=MSDN#RFormatString) the recommendation is to use G9 and G17 respectively for maximum fidelity.

The defaults have been fixed in .NET Core 3.0 onwards, but we need the override until we move out of .NET framework.

Fixes #1260 