### PR TITLE
Allow generic type resolution of TypeMapping values outside the core namespace

### DIFF
--- a/Bonsai.Core/WorkflowBuilder.cs
+++ b/Bonsai.Core/WorkflowBuilder.cs
@@ -841,7 +841,7 @@ namespace Bonsai
                             }
 
                             // ensure xsi:type attributes are resolved only for workflow element types
-                            if (!string.IsNullOrEmpty(xsiType) && lookupTypes && !includeWorkflow)
+                            if (!string.IsNullOrEmpty(xsiType) && (lookupTypes || xsiType == nameof(TypeMapping)) && !includeWorkflow)
                             {
                                 // ensure xsi:type attributes nested inside include workflow properties are ignored
                                 includeWorkflow = xsiType == IncludeWorkflowTypeName;

--- a/Bonsai.Core/WorkflowBuilder.cs
+++ b/Bonsai.Core/WorkflowBuilder.cs
@@ -844,9 +844,9 @@ namespace Bonsai
                             if (!string.IsNullOrEmpty(xsiType) && lookupTypes && !includeWorkflow)
                             {
                                 // ensure xsi:type attributes nested inside include workflow properties are ignored
-                                includeWorkflow = value == IncludeWorkflowTypeName;
+                                includeWorkflow = xsiType == IncludeWorkflowTypeName;
                                 var typeArguments = reader.GetAttribute(TypeArgumentsAttributeName);
-                                var type = ResolveXmlExtension(reader, value, typeArguments);
+                                var type = ResolveXmlExtension(reader, xsiType, typeArguments);
                                 if (type != null)
                                 {
                                     // resolve any xsi:type proxy types


### PR DESCRIPTION
This PR allows generic type resolution of `TypeMapping` properties in operators outside the core namespace. This is to support automatic code generation frameworks (e.g. for the Harp protocol) where types can benefit from being co-opted for operations which do not require an instance, but just a mapping on the type.

All other uses of `TypeMapping` remain reserved, and libraries should not rely on any internal features of the type.

Fixes #1277 