### PR TITLE
Allow overload inference for polymorphic operators

### DIFF
--- a/Bonsai.Design/Bonsai.Design.csproj
+++ b/Bonsai.Design/Bonsai.Design.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Design Rx Reactive Extensions</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.7.1</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.Core\Bonsai.Core.csproj" />

--- a/Bonsai.Design/TypeMappingEditor.cs
+++ b/Bonsai.Design/TypeMappingEditor.cs
@@ -25,6 +25,7 @@ namespace Bonsai.Design
         {
             const BindingFlags bindingAttributes = BindingFlags.Instance | BindingFlags.Public;
             var combinatorAttributes = combinatorType.GetCustomAttributes(typeof(CombinatorAttribute), true);
+            if (combinatorAttributes.Length != 1) return Enumerable.Empty<MethodInfo>();
             var methodName = ((CombinatorAttribute)combinatorAttributes.Single()).MethodName;
             return combinatorType.GetMethods(bindingAttributes).Where(m => m.Name == methodName);
         }


### PR DESCRIPTION
This PR adds support for type mapping overload inference for polymorphic combinators. This allows `InputMapping` operators to select target overloads when the downstream operator is a polymorphic combinator builder. In this case, `InputMapping` will find overloads in the selected concrete type.

This will allow libraries relying on auto-generated polymorphic types to expose use of those types as if they were first-class operators in the language.