### PR TITLE
Avoid throwing on ResourceSubject dispose if source sequence terminated exceptionally

### DIFF
--- a/Bonsai.Core.Tests/SubjectTests.cs
+++ b/Bonsai.Core.Tests/SubjectTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Reactive.Linq;
+using Bonsai.Expressions;
+using Bonsai.Reactive;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Core.Tests
+{
+    [TestClass]
+    public class SubjectTests
+    {
+        [TestMethod]
+        public void ResourceSubject_SourceTerminatesExceptionally_ShouldNotTryToDispose()
+        {
+            var workflowBuilder = new WorkflowBuilder();
+            var source = workflowBuilder.Workflow.Add(new CombinatorBuilder { Combinator = new ThrowSource() });
+            var subject = workflowBuilder.Workflow.Add(new ResourceSubject { Name = nameof(ResourceSubject) });
+            var sink = workflowBuilder.Workflow.Add(new CombinatorBuilder { Combinator = new CatchSink() });
+            workflowBuilder.Workflow.AddEdge(source, subject, new ExpressionBuilderArgument());
+            workflowBuilder.Workflow.AddEdge(subject, sink, new ExpressionBuilderArgument());
+            var observable = workflowBuilder.Workflow.BuildObservable();
+            observable.FirstOrDefaultAsync().Wait();
+        }
+
+        class ThrowSource : Source<IDisposable>
+        {
+            public override IObservable<IDisposable> Generate()
+            {
+                return Observable.Throw<IDisposable>(new SubjectException());
+            }
+        }
+
+        class CatchSink : Sink
+        {
+            public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
+            {
+                return source.Catch<TSource>(Observable.Empty<TSource>());
+            }
+        }
+
+        class SubjectException : Exception
+        {
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/Subjects/ResourceSubject.cs
+++ b/Bonsai.Core/Reactive/Subjects/ResourceSubject.cs
@@ -82,11 +82,15 @@ namespace Bonsai.Reactive
             {
                 if (subject.IsCompleted)
                 {
-                    var disposable = subject.GetResult();
-                    if (disposable != null)
+                    try
                     {
-                        disposable.Dispose();
+                        var disposable = subject.GetResult();
+                        if (disposable != null)
+                        {
+                            disposable.Dispose();
+                        }
                     }
+                    catch { /* source terminated exceptionally */ }
                 }
 
                 subject.Dispose();


### PR DESCRIPTION
This PR adds a guard on `ResourceSubject` dispose to avoid throwing if the source sequence terminated exceptionally. In this situation, the exception will be propagated to the downstream observer regardless, and calling `Dispose` is simply a cleanup side-effect.

Fixes #1256 