### PR TITLE
Ensure priority of base non-polymorphic properties

### DIFF
--- a/Bonsai.Core/Bonsai.Core.csproj
+++ b/Bonsai.Core/Bonsai.Core.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Reactive Extensions</PackageTags>
     <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>Bonsai</RootNamespace>
-    <VersionPrefix>2.7.2</VersionPrefix>
+    <VersionPrefix>2.7.3</VersionPrefix>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Rx-Linq" Version="2.2.5" />

--- a/Bonsai.Core/Expressions/ExpressionBuilder.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilder.cs
@@ -1033,6 +1033,7 @@ namespace Bonsai.Expressions
                 return argument;
             }
 
+            MemberExpression property = default;
             if (element is ICustomTypeDescriptor typeDescriptor)
             {
                 var propertyInfo = instance.Type.GetProperty(propertyName);
@@ -1044,9 +1045,10 @@ namespace Bonsai.Expressions
                         instance = Expression.Constant(propertyOwner);
                     }
                 }
+                else property = Expression.Property(instance, propertyInfo);
             }
 
-            var property = Expression.Property(instance, propertyName);
+            property ??= Expression.Property(instance, propertyName);
             if (source == EmptyExpression.Instance) return source;
             var sourceType = source.Type.GetGenericArguments()[0];
             var parameter = Expression.Parameter(sourceType);

--- a/Bonsai.Core/Expressions/ExpressionBuilder.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilder.cs
@@ -1035,10 +1035,14 @@ namespace Bonsai.Expressions
 
             if (element is ICustomTypeDescriptor typeDescriptor)
             {
-                var propertyOwner = typeDescriptor.GetPropertyOwner(null);
-                if (propertyOwner != instance.Value)
+                var propertyInfo = instance.Type.GetProperty(propertyName);
+                if (propertyInfo == null)
                 {
-                    instance = Expression.Constant(propertyOwner);
+                    var propertyOwner = typeDescriptor.GetPropertyOwner(null);
+                    if (propertyOwner != instance.Value)
+                    {
+                        instance = Expression.Constant(propertyOwner);
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR ensures that non-polymorphic properties of the base type get search priority over properties of the polymorphic operator. This allows exposing externalizable properties of both the base type and polymorphic operator type.

The proposed implementation uses a simple reflection search for public properties to disambiguate whether it is worth performing polymorphic property search. A caveat of this implementation is that in cases where the polymorphic operator exposes a property with the same name of a non-polymorphic property in the base type, the non-polymorphic property will be preferred.

Fixes #1305 