### PR TITLE
Ensure single subscription to Gate opening events

### DIFF
--- a/Bonsai.Core/ObservableCombinators.cs
+++ b/Bonsai.Core/ObservableCombinators.cs
@@ -114,7 +114,7 @@ namespace Bonsai
             this IObservable<TSource> source,
             IObservable<TGateOpening> gateOpenings)
         {
-            return source.Window(() => gateOpenings)
+            return source.Window(gateOpenings)
                          .SelectMany(window => window.Take(1));
         }
 


### PR DESCRIPTION
This PR fixes the behavior of the `Gate` operator to be consistent with common language patterns re. subscription. The `Gate` operator in Rx can be called either with a factory overload, where a new subscription is created for each gate trigger, or with a single subscription to an event sequence, where each notification triggers the gate.

The latter overload is more consistent with the rules of similar operators such as `WindowTrigger`. In general one can use the `Defer` operator if the former behavior is required. Alternatively, a new variant of the `Gate` operator can be exposed in the future which surfaces the factory overload through a nested operator.

Fixes #1206 