### PR TITLE
Optimized workflow reordering and insert at cursor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       run: msbuild Bonsai.sln /t:Bonsai32 /p:Configuration=Release
 
     - name: Build Tests
-      run: msbuild Bonsai.sln /t:Bonsai_Core_Tests /t:Bonsai_System_Tests /p:Configuration=Release
+      run: msbuild Bonsai.sln /t:Bonsai_Core_Tests /t:Bonsai_System_Tests /t:Bonsai_Editor_Tests /p:Configuration=Release
 
     - name: Run Tests
       run: msbuild Bonsai.Tests.proj

--- a/Bonsai.Configuration/Bonsai.Configuration.csproj
+++ b/Bonsai.Configuration/Bonsai.Configuration.csproj
@@ -4,7 +4,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>2.7.1</VersionPrefix>
+    <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.NuGet\Bonsai.NuGet.csproj" />

--- a/Bonsai.Core.Tests/Bonsai.Core.Tests.csproj
+++ b/Bonsai.Core.Tests/Bonsai.Core.Tests.csproj
@@ -3,7 +3,7 @@
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.bonsai" />

--- a/Bonsai.Core.Tests/DirectedGraphTests.cs
+++ b/Bonsai.Core.Tests/DirectedGraphTests.cs
@@ -560,6 +560,7 @@ namespace Bonsai.Core.Tests
         public void RemoveWhere_NodeMatches_ReorderIndexOfRemainingNodes()
         {
             var graph = CreateGraph(0, 1, 2, 3);
+            var removedNode = graph[3];
             graph.AddEdge(graph[0], graph[1], label: 0);
             graph.AddEdge(graph[0], graph[2], label: 0);
             graph.AddEdge(graph[0], graph[3], label: 0);
@@ -570,6 +571,7 @@ namespace Bonsai.Core.Tests
             Assert.AreEqual(expected: 3, graph[0].Successors.Count);
             Assert.AreEqual(expected: 1, graph[2].Successors.Count);
             graph.RemoveWhere(node => node.Value % 2 != 0);
+            Assert.IsFalse(graph.Contains(removedNode));
             Assert.AreEqual(expected: 2, graph[1].Value);
             Assert.AreEqual(expected: 1, graph[0].Successors.Count);
             Assert.AreEqual(expected: 0, graph[1].Successors.Count);
@@ -607,6 +609,7 @@ namespace Bonsai.Core.Tests
         public void RemoveRange_ValidRange_ReorderIndexOfRemainingNodes()
         {
             var graph = CreateGraph(0, 1, 2, 3);
+            var removedNode = graph[2];
             graph.AddEdge(graph[0], graph[1], label: 0);
             graph.AddEdge(graph[0], graph[2], label: 0);
             graph.AddEdge(graph[0], graph[3], label: 0);
@@ -617,6 +620,7 @@ namespace Bonsai.Core.Tests
             Assert.AreEqual(expected: 3, graph[0].Successors.Count);
             Assert.AreEqual(expected: 1, graph[2].Successors.Count);
             graph.RemoveRange(index: 1, count: 2);
+            Assert.IsFalse(graph.Contains(removedNode));
             Assert.AreEqual(expected: 3, graph[1].Value);
             Assert.AreEqual(expected: 1, graph[0].Successors.Count);
             Assert.AreEqual(expected: 0, graph[1].Successors.Count);

--- a/Bonsai.Core.Tests/DirectedGraphTests.cs
+++ b/Bonsai.Core.Tests/DirectedGraphTests.cs
@@ -505,11 +505,11 @@ namespace Bonsai.Core.Tests
         public void Remove_NodeWithExistingLinks_ReturnsTrueAndRemovesLinks()
         {
             var graph = CreateGraph(0, 1, 2);
-            var node = graph[1];
-            graph.AddEdge(graph[0], node, label: 0);
+            graph.AddEdge(graph[0], graph[1], label: 0);
+            graph.AddEdge(graph[0], graph[2], label: 0);
+            Assert.AreEqual(expected: 2, graph[0].Successors.Count);
+            Assert.IsTrue(graph.Remove(graph[1]));
             Assert.AreEqual(expected: 1, graph[0].Successors.Count);
-            Assert.IsTrue(graph.Remove(node));
-            Assert.AreEqual(expected: 0, graph[0].Successors.Count);
         }
 
         #endregion
@@ -533,7 +533,7 @@ namespace Bonsai.Core.Tests
         }
 
         [TestMethod]
-        public void RemoveAt_NodeAtValidIndex_ReorderIndexOfExistingNodes()
+        public void RemoveAt_NodeAtValidIndex_ReorderIndexOfRemainingNodes()
         {
             var graph = CreateGraph(0, 1, 2);
             graph.AddEdge(graph[0], graph[1], label: 0);

--- a/Bonsai.Core.Tests/DirectedGraphTests.cs
+++ b/Bonsai.Core.Tests/DirectedGraphTests.cs
@@ -390,7 +390,7 @@ namespace Bonsai.Core.Tests
         }
 
         [TestMethod]
-        public void Insert_ExistingNodes_ReorderNodeIndices()
+        public void Insert_NodeWithExistingSuccessors_ReorderNodeIndex()
         {
             var graph = CreateGraph(0, 1, 2, 3, 4, 5);
             graph.AddEdge(graph[4], graph[0], label: 0);
@@ -399,7 +399,7 @@ namespace Bonsai.Core.Tests
             Assert.AreEqual(expected: 4, graph.IndexOf(graph[4]));
             graph.Insert(3, node: graph[4]);
             Assert.AreEqual(
-                FormatSequence(new[] { 4, 0, 1, 2, 3, 5 }),
+                FormatSequence(new[] { 0, 1, 2, 4, 3, 5 }),
                 FormatNodeSequence(graph));
         }
 
@@ -440,9 +440,9 @@ namespace Bonsai.Core.Tests
             graph.AddEdge(graph[2], graph[5], label: 0);
             graph.AddEdge(graph[5], graph[4], label: 0);
             Assert.AreEqual(expected: 4, graph.IndexOf(graph[4]));
-            graph.InsertRange(1, new[] { graph[2], graph[4] });
+            graph.InsertRange(1, new[] { graph[2], graph[4], graph[0] });
             Assert.AreEqual(
-                FormatSequence(new[] { 2, 5, 4, 0, 1, 3 }),
+                FormatSequence(new[] { 2, 4, 0, 1, 3, 5 }),
                 FormatNodeSequence(graph));
         }
 

--- a/Bonsai.Core.Tests/DirectedGraphTests.cs
+++ b/Bonsai.Core.Tests/DirectedGraphTests.cs
@@ -546,6 +546,84 @@ namespace Bonsai.Core.Tests
 
         #endregion
 
+        #region RemoveWhere
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void RemoveWhere_NullDelegate_ArgumentNullException()
+        {
+            var graph = CreateGraph();
+            graph.RemoveWhere(null);
+        }
+
+        [TestMethod]
+        public void RemoveWhere_NodeMatches_ReorderIndexOfRemainingNodes()
+        {
+            var graph = CreateGraph(0, 1, 2, 3);
+            graph.AddEdge(graph[0], graph[1], label: 0);
+            graph.AddEdge(graph[0], graph[2], label: 0);
+            graph.AddEdge(graph[0], graph[3], label: 0);
+            graph.AddEdge(graph[1], graph[2], label: 0);
+            graph.AddEdge(graph[1], graph[3], label: 0);
+            graph.AddEdge(graph[2], graph[3], label: 0);
+            Assert.AreEqual(expected: 1, graph[1].Value);
+            Assert.AreEqual(expected: 3, graph[0].Successors.Count);
+            Assert.AreEqual(expected: 1, graph[2].Successors.Count);
+            graph.RemoveWhere(node => node.Value % 2 != 0);
+            Assert.AreEqual(expected: 2, graph[1].Value);
+            Assert.AreEqual(expected: 1, graph[0].Successors.Count);
+            Assert.AreEqual(expected: 0, graph[1].Successors.Count);
+        }
+
+        #endregion
+
+        #region RemoveRange
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void RemoveRange_NegativeIndex_ArgumentOutOfRangeException()
+        {
+            var graph = CreateGraph(0);
+            graph.RemoveRange(index: -1, count: 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void RemoveRange_NegativeCount_ArgumentOutOfRangeException()
+        {
+            var graph = CreateGraph(0);
+            graph.RemoveRange(index: 0, count: -1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void RemoveRange_CountExceedsNumberOfElements_ArgumentOutOfRangeException()
+        {
+            var graph = CreateGraph(0);
+            graph.RemoveRange(index: 0, count: 2);
+        }
+
+        [TestMethod]
+        public void RemoveRange_ValidRange_ReorderIndexOfRemainingNodes()
+        {
+            var graph = CreateGraph(0, 1, 2, 3);
+            graph.AddEdge(graph[0], graph[1], label: 0);
+            graph.AddEdge(graph[0], graph[2], label: 0);
+            graph.AddEdge(graph[0], graph[3], label: 0);
+            graph.AddEdge(graph[1], graph[2], label: 0);
+            graph.AddEdge(graph[1], graph[3], label: 0);
+            graph.AddEdge(graph[2], graph[3], label: 0);
+            Assert.AreEqual(expected: 1, graph[1].Value);
+            Assert.AreEqual(expected: 3, graph[0].Successors.Count);
+            Assert.AreEqual(expected: 1, graph[2].Successors.Count);
+            graph.RemoveRange(index: 1, count: 2);
+            Assert.AreEqual(expected: 3, graph[1].Value);
+            Assert.AreEqual(expected: 1, graph[0].Successors.Count);
+            Assert.AreEqual(expected: 0, graph[1].Successors.Count);
+        }
+
+        #endregion
+
         #region RemoveEdge
 
         [TestMethod]

--- a/Bonsai.Core.Tests/DirectedGraphTests.cs
+++ b/Bonsai.Core.Tests/DirectedGraphTests.cs
@@ -446,6 +446,21 @@ namespace Bonsai.Core.Tests
                 FormatNodeSequence(graph));
         }
 
+        [TestMethod]
+        public void InsertRange_NodeCollectionWithSuccessors_SuccessorNodesInsertedAtEnd()
+        {
+            var graph = CreateGraph(2, 3);
+            var node = new Node<int, int>(0);
+            var node2 = new Node<int, int>(4);
+            var successor = new Node<int, int>(1);
+            node.Successors.Add(Edge.Create(successor, label: 0));
+            Assert.AreEqual(expected: 2, graph.Count);
+            graph.InsertRange(1, new[] { node, node2 });
+            Assert.AreEqual(
+                FormatSequence(new[] { 2, 0, 4, 1, 3 }),
+                FormatNodeSequence(graph));
+        }
+
         #endregion
 
         #region Remove

--- a/Bonsai.Core.Tests/DirectedGraphTests.cs
+++ b/Bonsai.Core.Tests/DirectedGraphTests.cs
@@ -403,6 +403,16 @@ namespace Bonsai.Core.Tests
                 FormatNodeSequence(graph));
         }
 
+        [TestMethod]
+        public void Insert_ExistingNodeAtSamePosition_KeepSameNodeIndex()
+        {
+            var graph = CreateGraph(0, 1, 2);
+            var node = graph[1];
+            Assert.AreEqual(expected: 1, graph.IndexOf(node));
+            graph.Insert(1, node);
+            Assert.AreEqual(expected: 1, graph.IndexOf(node));
+        }
+
         #endregion
 
         #region InsertRange

--- a/Bonsai.Core.Tests/DirectedGraphTests.cs
+++ b/Bonsai.Core.Tests/DirectedGraphTests.cs
@@ -71,6 +71,33 @@ namespace Bonsai.Core.Tests
 
         #endregion
 
+        #region AddRange
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void AddRange_NullCollection_ArgumentNullException()
+        {
+            var graph = CreateGraph();
+            graph.AddRange(null);
+        }
+
+        [TestMethod]
+        public void AddRange_NodeCollection_SuccessorNodesInsertedAtEnd()
+        {
+            var graph = CreateGraph();
+            var node = new Node<int, int>(0);
+            var node2 = new Node<int, int>(4);
+            var successor = new Node<int, int>(1);
+            node.Successors.Add(Edge.Create(successor, label: 0));
+            Assert.AreEqual(expected: 0, graph.Count);
+            graph.AddRange(new[] { node, node2 });
+            Assert.AreEqual(
+                FormatSequence(new[] { 0, 4, 1 }),
+                FormatNodeSequence(graph));
+        }
+
+        #endregion
+
         #region AddEdge
 
         [TestMethod]

--- a/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
+++ b/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reactive;
+using Bonsai.Expressions;
+using Bonsai.Reactive;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Core.Tests
+{
+    [TestClass]
+    public class ExpressionBuilderGraphTests
+    {
+        [TestMethod]
+        public void Build_SingleSource_ReturnsExpression()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            workflow.Add(new UnitBuilder());
+            var expression = workflow.Build();
+            Assert.AreEqual(expected: typeof(IObservable<Unit>), expression.Type);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(WorkflowBuildException))]
+        public void Build_CyclicGraph_WorkflowBuildException()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            var source = workflow.Add(new UnitBuilder());
+            workflow.AddEdge(source, source, index: 0);
+            workflow.Build();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(WorkflowBuildException))]
+        public void Build_CyclicalDependency_WorkflowBuildException()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            var source = workflow.Add(new SubscribeSubject { Name = nameof(SubjectBuilder) });
+            var sink = workflow.Add(new PublishSubject { Name = nameof(SubjectBuilder) });
+            workflow.AddEdge(source, sink, index: 0);
+            workflow.Build();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(WorkflowBuildException))]
+        public void Build_NullArgumentRange_WorkflowBuildException()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            workflow.Add(new NullArgumentRangeBuilder());
+            workflow.Build();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(WorkflowBuildException))]
+        public void Build_BelowArgumentRange_WorkflowBuildException()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            workflow.Add(new WorkflowOutputBuilder());
+            workflow.Build();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(WorkflowBuildException))]
+        public void Build_AboveArgumentRange_WorkflowBuildException()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            var source = workflow.Add(new UnitBuilder());
+            var sink = workflow.Add(new CombinatorBuilder { Combinator = new Timer() });
+            workflow.AddEdge(source, sink, index: 0);
+            workflow.Build();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(WorkflowBuildException))]
+        public void Build_WorkflowOutputIsNotTerminalNode_WorkflowBuildException()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            var source = workflow.Add(new UnitBuilder());
+            var sink = workflow.Add(new WorkflowOutputBuilder());
+            var appendix = workflow.Add(new UnitBuilder());
+            workflow.AddEdge(source, sink, index: 0);
+            workflow.AddEdge(sink, appendix, index: 0);
+            workflow.Build();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(WorkflowBuildException))]
+        public void Build_MultipleWorkflowOutputs_WorkflowBuildException()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            var source = workflow.Add(new UnitBuilder());
+            var sink = workflow.Add(new WorkflowOutputBuilder());
+            var source2 = workflow.Add(new UnitBuilder());
+            var sink2 = workflow.Add(new WorkflowOutputBuilder());
+            workflow.AddEdge(source, sink, index: 0);
+            workflow.AddEdge(source2, sink2, index: 0);
+            workflow.Build();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(WorkflowBuildException))]
+        public void Build_MultipleWorkflowOutputBranch_WorkflowBuildException()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            var source = workflow.Add(new UnitBuilder());
+            var sink = workflow.Add(new WorkflowOutputBuilder());
+            var sink2 = workflow.Add(new WorkflowOutputBuilder());
+            workflow.AddEdge(source, sink, index: 0);
+            workflow.AddEdge(source, sink2, index: 0);
+            workflow.Build();
+        }
+
+        [TestMethod]
+        public void Build_HasBuildTarget_ReturnsBuildTargetExpression()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            var source = workflow.Add(new UnitBuilder());
+            var sink = workflow.Add(new CombinatorBuilder { Combinator = new IntProperty() });
+            workflow.AddEdge(source, sink, index: 0);
+            var expression = workflow.Build(source.Value);
+            Assert.AreEqual(expected: typeof(IObservable<Unit>), expression.Type);
+        }
+
+        [TestMethod]
+        public void Build_ActiveBranch_HasMulticastExpression()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            var source = workflow.Add(new UnitBuilder());
+            var sink = workflow.Add(new UnitBuilder());
+            var sink2 = workflow.Add(new UnitBuilder());
+            workflow.AddEdge(source, sink, index: 0);
+            workflow.AddEdge(source, sink2, index: 0);
+            var expression = workflow.Build();
+            var visitor = new PublishBranchVisitor();
+            visitor.Visit(expression);
+            Assert.IsTrue(visitor.HasPublishBranch);
+        }
+
+        [TestMethod]
+        public void Build_DisabledBranch_AvoidMulticastExpression()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            var source = workflow.Add(new UnitBuilder());
+            var sink = workflow.Add(new CombinatorBuilder { Combinator = new IntProperty() });
+            var sink2 = workflow.Add(new DisableBuilder(new UnitBuilder()));
+            workflow.AddEdge(source, sink, index: 0);
+            workflow.AddEdge(source, sink2, index: 0);
+            var expression = workflow.Build();
+            var visitor = new PublishBranchVisitor();
+            visitor.Visit(expression);
+            Assert.IsFalse(visitor.HasPublishBranch);
+        }
+
+        [TestMethod]
+        public void Build_DisableAllBranches_ReturnSourceExpression()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            var source = workflow.Add(new UnitBuilder());
+            var sink = workflow.Add(new DisableBuilder(new FormatBuilder()));
+            var sink2 = workflow.Add(new DisableBuilder(new FormatBuilder()));
+            workflow.AddEdge(source, sink, index: 0);
+            workflow.AddEdge(source, sink2, index: 0);
+            var expression = workflow.Build();
+            var visitor = new MergeBranchVisitor();
+            visitor.Visit(expression);
+            Assert.AreEqual(expected: 0, visitor.BranchCount);
+            Assert.AreEqual(expected: typeof(IObservable<Unit>), expression.Type);
+        }
+
+        [TestMethod]
+        public void Build_DisabledSource_ReturnsEmptyExpression()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            workflow.Add(new DisableBuilder(new UnitBuilder()));
+            var expression = workflow.Build();
+            var visitor = new MergeBranchVisitor();
+            visitor.Visit(expression);
+            Assert.AreEqual(expected: 0, visitor.BranchCount);
+        }
+
+        [TestMethod]
+        public void Build_DisabledPropertyMapping_DisconnectedBranch()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            var source = workflow.Add(new UnitBuilder());
+            var source2 = workflow.Add(new UnitBuilder());
+            var mapping = workflow.Add(new DisableBuilder(new PropertyMappingBuilder()));
+            workflow.AddEdge(source2, mapping, index: 0);
+            workflow.AddEdge(mapping, source, index: 0);
+            var expression = workflow.Build();
+            var visitor = new MergeBranchVisitor();
+            visitor.Visit(expression);
+            Assert.AreEqual(expected: 2, visitor.BranchCount);
+        }
+
+        [TestMethod]
+        public void Build_BranchPropertyMapping_AvoidMulticastExpression()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            var source = workflow.Add(new UnitBuilder());
+            var mapping = workflow.Add(new PropertyMappingBuilder());
+            var sink = workflow.Add(new UnitBuilder());
+            var sink2 = workflow.Add(new UnitBuilder());
+            workflow.AddEdge(source, mapping, index: 0);
+            workflow.AddEdge(mapping, sink, index: 0);
+            workflow.AddEdge(mapping, sink2, index: 0);
+            var expression = workflow.Build();
+            var visitor = new PublishBranchVisitor();
+            visitor.Visit(expression);
+            Assert.IsFalse(visitor.HasPublishBranch);
+        }
+
+        class MergeBranchVisitor : ExpressionVisitor
+        {
+            public int BranchCount { get; private set; }
+
+            protected override Expression VisitNewArray(NewArrayExpression node)
+            {
+                BranchCount = node.Expressions.Count;
+                return base.VisitNewArray(node);
+            }
+        }
+
+        class PublishBranchVisitor : ExpressionVisitor
+        {
+            public bool HasPublishBranch { get; private set; }
+
+            protected override Expression VisitMethodCall(MethodCallExpression node)
+            {
+                if (node.Method?.Name == "Multicast")
+                {
+                    HasPublishBranch = (node.Object?.Type.Name.Contains("Publish"))
+                        .GetValueOrDefault();
+                }
+
+                return base.VisitMethodCall(node);
+            }
+        }
+
+        class NullArgumentRangeBuilder : ExpressionBuilder
+        {
+            public override Range<int> ArgumentRange => null;
+
+            public override Expression Build(IEnumerable<Expression> arguments)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
+++ b/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
@@ -21,6 +21,24 @@ namespace Bonsai.Core.Tests
         }
 
         [TestMethod]
+        public void Build_SimpleGroup_ReturnsExpression()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            workflow.Add(new GroupWorkflowBuilder());
+            var expression = workflow.Build();
+            Assert.AreEqual(expected: typeof(IObservable<Unit>), expression.Type);
+        }
+
+        [TestMethod]
+        public void Build_SimpleInspectBuilderGroup_ReturnsExpression()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            workflow.Add(new InspectBuilder(new GroupWorkflowBuilder()));
+            var expression = workflow.Build();
+            Assert.AreEqual(expected: typeof(IObservable<Unit>), expression.Type);
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(WorkflowBuildException))]
         public void Build_CyclicGraph_WorkflowBuildException()
         {

--- a/Bonsai.Core.Tests/TestGraphExtensions.cs
+++ b/Bonsai.Core.Tests/TestGraphExtensions.cs
@@ -10,20 +10,23 @@ namespace Bonsai.Core.Tests
         protected class TestGraph : DirectedGraph<string, int>
         {
             readonly Dictionary<char, Node<string, int>> nodes;
+            readonly Dictionary<char, int> argumentCount;
 
             public TestGraph(int count)
             {
                 nodes = new Dictionary<char, Node<string, int>>(count);
+                argumentCount = new Dictionary<char, int>(count);
                 for (int i = 0; i < count; i++)
                 {
                     var key = (char)('A' + i);
                     nodes.Add(key, Add(key.ToString()));
+                    argumentCount.Add(key, 0);
                 }
             }
 
             public void Add(char from, char to)
             {
-                AddEdge(nodes[from], nodes[to], 0);
+                AddEdge(nodes[from], nodes[to], argumentCount[to]++);
             }
 
             public void Add(int label, char from, char to)
@@ -33,14 +36,17 @@ namespace Bonsai.Core.Tests
 
             public void Add(params char[] chain)
             {
-                Add(0, chain);
+                for (int i = 1; i < chain.Length; i++)
+                {
+                    Add(chain[i - 1], chain[i]);
+                }
             }
 
             public void Add(int label, params char[] chain)
             {
                 for (int i = 1; i < chain.Length; i++)
                 {
-                    AddEdge(nodes[chain[i - 1]], nodes[chain[i]], label);
+                    Add(label, chain[i - 1], chain[i]);
                 }
             }
         }

--- a/Bonsai.Core.Tests/TopologicalSortTests.cs
+++ b/Bonsai.Core.Tests/TopologicalSortTests.cs
@@ -167,7 +167,7 @@ namespace Bonsai.Core.Tests
         }
 
         [TestMethod]
-        public void TopologicalSort_DeferredConnectedComponents_InsertionOrder()
+        public void TopologicalSort_DeferredConnectedComponents_ConnectedComponentOrder()
         {
             AssertOrder(new TestGraph(7)
             {
@@ -176,7 +176,7 @@ namespace Bonsai.Core.Tests
                 { 'E', 'F' },
                 { 'G', 'E' },
                 { 'G', 'A' }
-            }, "GABCDEF");
+            }, "GABEFCD");
         }
 
         [TestMethod]

--- a/Bonsai.Core.Tests/TopologicalSortTests.cs
+++ b/Bonsai.Core.Tests/TopologicalSortTests.cs
@@ -244,5 +244,16 @@ namespace Bonsai.Core.Tests
                      { 'C', 'D', 'A' },
             }, "BCDA");
         }
+
+        [TestMethod]
+        public void TopologicalSort_CyclicGraph_ReturnsEmptySequence()
+        {
+            AssertOrder(new TestGraph(4)
+            {
+                { 'B',           'A' },
+                { 'B', 'C',      'A' },
+                     { 'C', 'D', 'B' },
+            }, string.Empty);
+        }
     }
 }

--- a/Bonsai.Core.Tests/TopologicalSortTests.cs
+++ b/Bonsai.Core.Tests/TopologicalSortTests.cs
@@ -12,7 +12,7 @@ namespace Bonsai.Core.Tests
             AssertOrder(order, expected);
 
             var orderedGraph = new DirectedGraph<string, int>();
-            foreach (var node in order) orderedGraph.Add(node);
+            orderedGraph.InsertRange(0, order);
             var secondOrder = orderedGraph.TopologicalSort();
             AssertOrder(secondOrder, expected);
         }
@@ -53,7 +53,7 @@ namespace Bonsai.Core.Tests
             {
                 { 'E', 'C', 'D' },
                 { 'E', 'A', 'B' },
-            }, "ECDAB");
+            }, "EABCD");
         }
 
         [TestMethod]
@@ -75,7 +75,7 @@ namespace Bonsai.Core.Tests
                 { 'F', 'B', 'E' },
                      { 'B', 'A' },
                 { 'F', 'C', 'D' },
-            }, "FBEACD");
+            }, "FBACDE");
         }
 
         [TestMethod]
@@ -134,14 +134,12 @@ namespace Bonsai.Core.Tests
         [TestMethod]
         public void TopologicalSort_MergeDanglingBranch_InsertionOrder()
         {
-            // C comes after D, because C has a dependency on
-            // the second branch of A
             AssertOrder(new TestGraph(4)
             {
                 { 'A', 'B', 'C' },
                 { 'A',      'C' },
                 {      'B', 'D' }
-            }, "ABDC");
+            }, "ABCD");
         }
 
         [TestMethod]
@@ -165,7 +163,7 @@ namespace Bonsai.Core.Tests
                 { 'A', 'C' },
                 { 'F', 'B' },
                 { 'D', 'E' }
-            }, "ACFBDE");
+            }, "FBACDE");
         }
 
         [TestMethod]
@@ -178,7 +176,7 @@ namespace Bonsai.Core.Tests
                 { 'E', 'F' },
                 { 'G', 'E' },
                 { 'G', 'A' }
-            }, "CDGEFAB");
+            }, "GABCDEF");
         }
 
         [TestMethod]
@@ -197,7 +195,7 @@ namespace Bonsai.Core.Tests
                 { 'L', 'K' },
                 { 'L', 'I' },
                 { 'L', 'A' },
-            }, "LGHKCDEFIJAB");
+            }, "LABKCDEFGHIJ");
         }
 
         [TestMethod]
@@ -220,7 +218,7 @@ namespace Bonsai.Core.Tests
                 { 'D', 'E', 'A' },
                      { 'E', 'B', 'A' },
                      { 'C', 'A' }
-            }, "CDEBA");
+            }, "DEBCA");
         }
 
         [TestMethod]

--- a/Bonsai.Core/Dag/DirectedGraph.cs
+++ b/Bonsai.Core/Dag/DirectedGraph.cs
@@ -100,6 +100,28 @@ namespace Bonsai.Dag
             }
         }
 
+        /// <summary>
+        /// Adds the nodes in a collection to the end of the directed graph.
+        /// </summary>
+        /// <param name="collection">
+        /// The collection of nodes to insert into the directed graph.
+        /// </param>
+        /// <remarks>
+        /// If any of the nodes in the collection are already in the directed graph,
+        /// they will be moved into the new index position. Any successor nodes which
+        /// are not in the graph will also be added in depth-first order.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"></exception>
+        public void AddRange(IEnumerable<Node<TNodeValue, TEdgeLabel>> collection)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            InsertInternal(nodes.Count, collection);
+        }
+
         void ThrowIfEdgeVerticesNullOrNotInGraph(Node<TNodeValue, TEdgeLabel> from, Node<TNodeValue, TEdgeLabel> to, string targetParamName)
         {
             if (from == null)
@@ -301,17 +323,17 @@ namespace Bonsai.Dag
         }
 
         /// <summary>
-        /// Inserts a node and all its successors into the directed graph at the
-        /// specified index.
+        /// Inserts a node into the directed graph at the specified index.
         /// </summary>
         /// <param name="index">The zero-based index at which the node should be inserted.</param>
         /// <param name="node">The node to insert into the directed graph.</param>
+        /// <remarks>
+        /// If the node is already in the directed graph, it will be moved into the
+        /// new index position. Any successor nodes which are not in the graph will
+        /// also be added in depth-first order.
+        /// </remarks>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        /// <remarks>
-        /// If the node or any of its successors are already in the directed graph,
-        /// they will be moved into the new position, in depth-first order.
-        /// </remarks>
         public void Insert(int index, Node<TNodeValue, TEdgeLabel> node)
         {
             if (node == null)
@@ -328,8 +350,8 @@ namespace Bonsai.Dag
         }
 
         /// <summary>
-        /// Inserts all the nodes in a collection and their successors into the
-        /// directed graph at the specified index.
+        /// Inserts the nodes in a collection into the directed graph at the
+        /// specified index.
         /// </summary>
         /// <param name="index">
         /// The zero-based index at which the node collection should be inserted.
@@ -338,9 +360,9 @@ namespace Bonsai.Dag
         /// The collection of nodes to insert into the directed graph.
         /// </param>
         /// <remarks>
-        /// If any of the nodes in the collection, or their successors, are already
-        /// in the directed graph, they will be moved into the new index position,
-        /// in depth-first order.
+        /// If any of the nodes in the collection are already in the directed graph,
+        /// they will be moved into the new index position. Any successor nodes which
+        /// are not in the graph will also be added in depth-first order.
         /// </remarks>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>

--- a/Bonsai.Core/Dag/DirectedGraph.cs
+++ b/Bonsai.Core/Dag/DirectedGraph.cs
@@ -424,12 +424,14 @@ namespace Bonsai.Dag
                         return true;
                     }
 
-                    for (int i = 0; i < n.Successors.Count; i++)
+                    for (int i = 0; i < n.Successors.Count;)
                     {
                         if (n.Successors[i].Target == node)
                         {
                             n.Successors.RemoveAt(i);
+                            continue;
                         }
+                        i++;
                     }
                     return false;
                 });

--- a/Bonsai.Core/Dag/DirectedGraph.cs
+++ b/Bonsai.Core/Dag/DirectedGraph.cs
@@ -520,6 +520,7 @@ namespace Bonsai.Dag
             var removed = new HashSet<Node<TNodeValue, TEdgeLabel>>();
             for (int i = index; i < index + count; i++)
             {
+                nodeLookup.Remove(nodes[i]);
                 removed.Add(nodes[i]);
             }
             RemoveInternal(removed);

--- a/Bonsai.Core/Dag/DirectedGraph.cs
+++ b/Bonsai.Core/Dag/DirectedGraph.cs
@@ -387,7 +387,7 @@ namespace Bonsai.Dag
             nodes.RemoveAll(node =>
             {
                 var remove = inserted.Contains(node);
-                if (remove && nodeIndex <= index)
+                if (remove && nodeIndex < index)
                 {
                     insertionIndex--;
                 }

--- a/Bonsai.Core/Dag/DirectedGraph.cs
+++ b/Bonsai.Core/Dag/DirectedGraph.cs
@@ -363,19 +363,25 @@ namespace Bonsai.Dag
         {
             var nodeIndex = 0;
             var insertionIndex = index;
-            var inserted = new HashSet<Node<TNodeValue, TEdgeLabel>>();
+            var inserted = new HashSet<Node<TNodeValue, TEdgeLabel>>(collection);
+            var additionalNodes = default(List<Node<TNodeValue, TEdgeLabel>>);
             var visited = new HashSet<Node<TNodeValue, TEdgeLabel>>();
             var stack = new Stack<Node<TNodeValue, TEdgeLabel>>();
-            foreach (var node in collection)
+            foreach (var node in inserted)
             {
-                inserted.Add(node);
                 foreach (var successor in node.DepthFirstSearch(visited, stack))
                 {
-                    if (!Contains(successor))
+                    if (!inserted.Contains(successor) && !Contains(successor))
                     {
-                        inserted.Add(successor);
+                        additionalNodes ??= new();
+                        additionalNodes.Add(successor);
                     }
                 }
+            }
+
+            if (additionalNodes != null)
+            {
+                inserted.UnionWith(additionalNodes);
             }
 
             nodes.RemoveAll(node =>

--- a/Bonsai.Core/Dag/DirectedGraph.cs
+++ b/Bonsai.Core/Dag/DirectedGraph.cs
@@ -43,7 +43,7 @@ namespace Bonsai.Dag
         /// the order of the values in the directed graph.
         /// </summary>
         [Obsolete]
-        public IComparer<TNodeValue> Comparer
+        public virtual IComparer<TNodeValue> Comparer
         {
             get { return valueComparer; }
         }

--- a/Bonsai.Core/Dag/DirectedGraphExtensions.cs
+++ b/Bonsai.Core/Dag/DirectedGraphExtensions.cs
@@ -252,11 +252,11 @@ namespace Bonsai.Dag
                 throw new ArgumentNullException(nameof(source));
             }
 
-            if (!Dag.TopologicalSort.TrySort(source, out IEnumerable<Node<TNodeValue, TEdgeLabel>> topologicalOrder))
+            if (!Dag.TopologicalSort.TrySort(source, out IEnumerable<DirectedGraph<TNodeValue, TEdgeLabel>> topologicalOrder))
             {
                 return Enumerable.Empty<Node<TNodeValue, TEdgeLabel>>();
             }
-            return topologicalOrder;
+            return topologicalOrder.SelectMany(component => component);
         }
 
         /// <summary>

--- a/Bonsai.Core/Dag/DirectedGraphExtensions.cs
+++ b/Bonsai.Core/Dag/DirectedGraphExtensions.cs
@@ -128,9 +128,18 @@ namespace Bonsai.Dag
                 throw new ArgumentNullException(nameof(source));
             }
 
+            var successorSet = new HashSet<Node<TNodeValue, TEdgeLabel>>();
             foreach (var node in source)
             {
-                if (!source.Predecessors(node).Any())
+                foreach (var successor in node.Successors)
+                {
+                    successorSet.Add(successor.Target);
+                }
+            }
+
+            foreach (var node in source)
+            {
+                if (!successorSet.Contains(node))
                 {
                     yield return node;
                 }

--- a/Bonsai.Core/Dag/DirectedGraphExtensions.cs
+++ b/Bonsai.Core/Dag/DirectedGraphExtensions.cs
@@ -163,7 +163,7 @@ namespace Bonsai.Dag
             }
         }
 
-        static IEnumerable<Node<TNodeValue, TEdgeLabel>> DepthFirstSearch<TNodeValue, TEdgeLabel>(Node<TNodeValue, TEdgeLabel> node, HashSet<Node<TNodeValue, TEdgeLabel>> visited, Stack<Node<TNodeValue, TEdgeLabel>> stack)
+        internal static IEnumerable<Node<TNodeValue, TEdgeLabel>> DepthFirstSearch<TNodeValue, TEdgeLabel>(this Node<TNodeValue, TEdgeLabel> node, HashSet<Node<TNodeValue, TEdgeLabel>> visited, Stack<Node<TNodeValue, TEdgeLabel>> stack)
         {
             stack.Push(node);
             while (stack.Count > 0)
@@ -219,11 +219,6 @@ namespace Bonsai.Dag
                 throw new ArgumentNullException(nameof(source));
             }
 
-            return DepthFirstSearch((IEnumerable<Node<TNodeValue, TEdgeLabel>>)source);
-        }
-
-        internal static IEnumerable<Node<TNodeValue, TEdgeLabel>> DepthFirstSearch<TNodeValue, TEdgeLabel>(this IEnumerable<Node<TNodeValue, TEdgeLabel>> source)
-        {
             var visited = new HashSet<Node<TNodeValue, TEdgeLabel>>();
             var stack = new Stack<Node<TNodeValue, TEdgeLabel>>();
             return from root in source

--- a/Bonsai.Core/Dag/TopologicalSort.cs
+++ b/Bonsai.Core/Dag/TopologicalSort.cs
@@ -7,7 +7,7 @@ namespace Bonsai.Dag
     static class TopologicalSort
     {
         public static bool TrySort<TNodeValue, TEdgeLabel>(
-            DirectedGraph<TNodeValue, TEdgeLabel> source,
+            IReadOnlyList<Node<TNodeValue, TEdgeLabel>> source,
             out IEnumerable<DirectedGraph<TNodeValue, TEdgeLabel>> topologicalOrder)
         {
             return TopologicalSort<TNodeValue, TEdgeLabel>.TrySort(source, out topologicalOrder);
@@ -19,7 +19,7 @@ namespace Bonsai.Dag
         const int TemporaryMark = -1;
 
         public static bool TrySort(
-            DirectedGraph<TNodeValue, TEdgeLabel> source,
+            IReadOnlyList<Node<TNodeValue, TEdgeLabel>> source,
             out IEnumerable<DirectedGraph<TNodeValue, TEdgeLabel>> topologicalOrder)
         {
             var stack = new CallStack();

--- a/Bonsai.Core/Expressions/ExpressionBuilder.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilder.cs
@@ -923,7 +923,7 @@ namespace Bonsai.Expressions
             var mergedConnections = connections.ToArray();
             if (mergedConnections.Length == 0)
             {
-                return output ?? Expression.Constant(Observable.Empty<Unit>());
+                return output ?? Expression.Constant(Observable.Empty<Unit>(), typeof(IObservable<Unit>));
             }
             else if (mergedConnections.Length == 1 && output == null)
             {

--- a/Bonsai.Core/Expressions/ExpressionBuilderGraph.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilderGraph.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Bonsai.Dag;
 using System.ComponentModel;
+using System;
 
 namespace Bonsai.Expressions
 {
@@ -18,8 +19,18 @@ namespace Bonsai.Expressions
         /// Initializes a new instance of the <see cref="ExpressionBuilderGraph"/> class.
         /// </summary>
         public ExpressionBuilderGraph()
-            : base(InstanceComparer)
         {
+        }
+
+        /// <summary>
+        /// This read-only property is deprecated and should not be used. The getter is
+        /// implemented for backward compatibility with legacy clients only.
+        /// </summary>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override IComparer<ExpressionBuilder> Comparer
+        {
+            get { return InstanceComparer; }
         }
 
         class ExpressionBuilderComparer : IComparer<ExpressionBuilder>

--- a/Bonsai.Core/Expressions/ExpressionBuilderGraph.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilderGraph.cs
@@ -23,6 +23,22 @@ namespace Bonsai.Expressions
         }
 
         /// <summary>
+        /// Creates and adds a new edge specifying an argument assignment of the source
+        /// node to the target node with the specified index.
+        /// </summary>
+        /// <param name="from">The node that is the source of the edge.</param>
+        /// <param name="to">The node that is the target of the edge.</param>
+        /// <param name="index">The zero-based index of the input argument.</param>
+        /// <returns>The created edge.</returns>
+        public Edge<ExpressionBuilder, ExpressionBuilderArgument> AddEdge(
+            Node<ExpressionBuilder, ExpressionBuilderArgument> from,
+            Node<ExpressionBuilder, ExpressionBuilderArgument> to,
+            int index)
+        {
+            return AddEdge(from, to, new ExpressionBuilderArgument(index));
+        }
+
+        /// <summary>
         /// This read-only property is deprecated and should not be used. The getter is
         /// implemented for backward compatibility with legacy clients only.
         /// </summary>

--- a/Bonsai.Core/Expressions/ExpressionBuilderGraphDescriptor.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilderGraphDescriptor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Xml.Serialization;
 
 namespace Bonsai.Expressions
@@ -9,14 +10,31 @@ namespace Bonsai.Expressions
     public class ExpressionBuilderGraphDescriptor
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ExpressionBuilderGraphDescriptor"/> class.
+        /// </summary>
+        public ExpressionBuilderGraphDescriptor()
+        {
+            Nodes = new Collection<ExpressionBuilder>();
+            Edges = new Collection<ExpressionBuilderArgumentDescriptor>();
+        }
+
+        internal ExpressionBuilderGraphDescriptor(
+            IList<ExpressionBuilder> nodes,
+            IList<ExpressionBuilderArgumentDescriptor> edges)
+        {
+            Nodes = new Collection<ExpressionBuilder>(nodes);
+            Edges = new Collection<ExpressionBuilderArgumentDescriptor>(edges);
+        }
+
+        /// <summary>
         /// Gets the collection of labels associated with each node in the expression builder graph.
         /// </summary>
-        public Collection<ExpressionBuilder> Nodes { get; } = new Collection<ExpressionBuilder>();
+        public Collection<ExpressionBuilder> Nodes { get; }
 
         /// <summary>
         /// Gets a collection of descriptors corresponding to each edge in the expression builder graph.
         /// </summary>
         [XmlArrayItem("Edge")]
-        public Collection<ExpressionBuilderArgumentDescriptor> Edges { get; } = new Collection<ExpressionBuilderArgumentDescriptor>();
+        public Collection<ExpressionBuilderArgumentDescriptor> Edges { get; }
     }
 }

--- a/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
@@ -905,7 +905,7 @@ namespace Bonsai.Expressions
                             throw new WorkflowBuildException("The workflow output must be a terminal node.", builder);
                         }
 
-                        if (workflowOutput != null)
+                        if (workflowOutput != null || output != null)
                         {
                             throw new WorkflowBuildException("Workflows cannot have more than one output.", builder);
                         }
@@ -973,7 +973,7 @@ namespace Bonsai.Expressions
                         if (connection is MulticastBranchExpression branchExpression &&
                             branchExpression == scope.MulticastBuilder.BranchExpression)
                         {
-                            if (argumentIndex == null) argumentIndex = index;
+                            argumentIndex ??= index;
                             return true;
                         }
 

--- a/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
@@ -703,15 +703,16 @@ namespace Bonsai.Expressions
 
         internal static Expression Build(this ExpressionBuilderGraph source, IBuildContext buildContext)
         {
-            Expression workflowOutput = null;
+            Expression output = null;
             HashSet<string> externalizedProperties = null;
             var argumentLists = new Dictionary<ExpressionBuilder, ArgumentList>();
             var dependencyLists = new Dictionary<ExpressionBuilder, ArgumentList>();
             var edgeCollection = new List<Edge<ExpressionBuilder, ExpressionBuilderArgument>>();
+            var componentConnections = new List<Expression>();
             var multicastMap = new List<MulticastScope>();
             var connections = new List<Expression>();
 
-            if (!TopologicalSort.TrySort(source, out IEnumerable<Node<ExpressionBuilder, ExpressionBuilderArgument>> buildOrder))
+            if (!TopologicalSort.TrySort(source, out IEnumerable<DirectedGraph<ExpressionBuilder, ExpressionBuilderArgument>> buildOrder))
             {
                 var cyclicalDependency = FindCyclicalDependency(source, buildContext);
                 if (cyclicalDependency == null) throw new WorkflowBuildException("The workflow contains unspecified cyclical build dependencies.");
@@ -720,275 +721,286 @@ namespace Bonsai.Expressions
                 throw CreateDependencyException(message, cyclicalDependency);
             }
 
-            foreach (var node in buildOrder)
+            foreach (var component in buildOrder)
             {
-                Expression expression;
-                var builder = node.Value;
-                var arguments = GetArgumentList(argumentLists, builder);
-
-                // Propagate build target in case of a nested workflow
-                var workflowElement = ExpressionBuilder.Unwrap(builder);
-                var requireBuildContext = workflowElement as IRequireBuildContext;
-                if (requireBuildContext != null)
+                Expression workflowOutput = null;
+                foreach (var node in component)
                 {
-                    try { requireBuildContext.BuildContext = buildContext; }
+                    Expression expression;
+                    var builder = node.Value;
+                    var arguments = GetArgumentList(argumentLists, builder);
+
+                    // Propagate build target in case of a nested workflow
+                    var workflowElement = ExpressionBuilder.Unwrap(builder);
+                    var requireBuildContext = workflowElement as IRequireBuildContext;
+                    if (requireBuildContext != null)
+                    {
+                        try { requireBuildContext.BuildContext = buildContext; }
+                        catch (Exception e)
+                        {
+                            throw new WorkflowBuildException(e.Message, builder, e);
+                        }
+                    }
+
+                    var argumentRange = builder.ArgumentRange;
+                    if (argumentRange == null)
+                    {
+                        throw new WorkflowBuildException("Argument range not set in expression builder node.", builder);
+                    }
+
+                    if (arguments.Count < argumentRange.LowerBound)
+                    {
+                        throw new WorkflowBuildException(string.Format(Resources.Exception_UnsupportedMinArgumentCount, argumentRange.LowerBound), builder);
+                    }
+
+                    if (arguments.Count > argumentRange.UpperBound)
+                    {
+                        throw new WorkflowBuildException(string.Format(Resources.Exception_UnsupportedMaxArgumentCount, argumentRange.UpperBound), builder);
+                    }
+
+                    var externalizedBuilder = workflowElement as IExternalizedMappingBuilder;
+                    if (externalizedBuilder != null)
+                    {
+                        foreach (var property in externalizedBuilder.GetExternalizedProperties())
+                        {
+                            RegisterPropertyName(builder, property, ref externalizedProperties);
+                        }
+                    }
+
+                    try
+                    {
+                        expression = builder.Build(arguments);
+                    }
                     catch (Exception e)
                     {
                         throw new WorkflowBuildException(e.Message, builder, e);
                     }
-                }
-
-                var argumentRange = builder.ArgumentRange;
-                if (argumentRange == null)
-                {
-                    throw new WorkflowBuildException("Argument range not set in expression builder node.", builder);
-                }
-
-                if (arguments.Count < argumentRange.LowerBound)
-                {
-                    throw new WorkflowBuildException(string.Format(Resources.Exception_UnsupportedMinArgumentCount, argumentRange.LowerBound), builder);
-                }
-
-                if (arguments.Count > argumentRange.UpperBound)
-                {
-                    throw new WorkflowBuildException(string.Format(Resources.Exception_UnsupportedMaxArgumentCount, argumentRange.UpperBound), builder);
-                }
-
-                var externalizedBuilder = workflowElement as IExternalizedMappingBuilder;
-                if (externalizedBuilder != null)
-                {
-                    foreach (var property in externalizedBuilder.GetExternalizedProperties())
+                    finally
                     {
-                        RegisterPropertyName(builder, property, ref externalizedProperties);
-                    }
-                }
-
-                try
-                {
-                    expression = builder.Build(arguments);
-                }
-                catch (Exception e)
-                {
-                    throw new WorkflowBuildException(e.Message, builder, e);
-                }
-                finally
-                {
-                    if (requireBuildContext != null)
-                    {
-                        requireBuildContext.BuildContext = null;
-                    }
-                }
-
-                // Merge build dependencies
-                var reducible = ExpressionBuilder.IsReducible(expression);
-                var buildDependencies = GetArgumentList(dependencyLists, builder);
-                if (buildDependencies.Count > 0 && reducible)
-                {
-                    expression = ExpressionBuilder.MergeBuildDependencies(expression, buildDependencies);
-                }
-
-                // Check if build target was reached
-                if (builder == buildContext.BuildTarget)
-                {
-                    buildContext.BuildResult = expression;
-                }
-
-                if (buildContext.BuildResult != null)
-                {
-                    return expression;
-                }
-
-                // Filter disabled successors for property mapping nodes
-                var argumentBuilder = workflowElement as IArgumentBuilder;
-                var propertyMappingBuilder = ExpressionBuilder.IsBuildDependency(argumentBuilder);
-                IList<Edge<ExpressionBuilder, ExpressionBuilderArgument>> nodeSuccessors;
-                if (propertyMappingBuilder)
-                {
-                    edgeCollection.Clear();
-                    edgeCollection.AddRange(node.Successors.Where(edge => !(ExpressionBuilder.Unwrap(edge.Target.Value) is DisableBuilder)));
-                    nodeSuccessors = edgeCollection;
-                }
-                else nodeSuccessors = node.Successors;
-
-                // Remove all closing scopes
-                var disable = expression as DisableExpression;
-                var successorCount = requireBuildContext != null
-                    ? nodeSuccessors.Count(edge => edge.Label != null)
-                    : nodeSuccessors.Count;
-                multicastMap.RemoveAll(scope =>
-                {
-                    var referencesRemoved = scope.References.RemoveAll(reference => reference == builder);
-                    if (scope.References.Count == 0 && disable == null)
-                    {
-                        try
+                        if (requireBuildContext != null)
                         {
-                            expression = scope.Close(expression);
-                            return true;
-                        }
-                        catch (Exception e)
-                        {
-                            throw new WorkflowBuildException(e.Message, builder, e);
+                            requireBuildContext.BuildContext = null;
                         }
                     }
 
-                    if (referencesRemoved > 0)
+                    // Merge build dependencies
+                    var reducible = ExpressionBuilder.IsReducible(expression);
+                    var buildDependencies = GetArgumentList(dependencyLists, builder);
+                    if (buildDependencies.Count > 0 && reducible)
                     {
-                        var expandedArguments = disable?.Arguments.Skip(1).GetEnumerator();
-                        do
-                        {
-                            // If there are no successors, or the expression is a disabled build dependency, this scope should never close
-                            if (successorCount == 0 || expression == DisconnectExpression.Instance) scope.References.Add(null);
-                            else scope.References.AddRange(nodeSuccessors
-                                .Where(successor => successor.Label != null)
-                                .Select(successor => successor.Target.Value));
-                        }
-                        while (expandedArguments != null && expandedArguments.MoveNext());
-                    }
-                    return false;
-                });
-
-                // Evaluate irreducible extension expressions
-                if (!reducible)
-                {
-                    // Disconnect disabled build dependencies from their immediate successors
-                    if (expression == DisconnectExpression.Instance)
-                    {
-                        connections.AddRange(arguments);
-                        continue;
+                        expression = ExpressionBuilder.MergeBuildDependencies(expression, buildDependencies);
                     }
 
-                    // Validate externalized properties
-                    if (externalizedBuilder != null)
+                    // Check if build target was reached
+                    if (builder == buildContext.BuildTarget)
                     {
-                        var argument = expression;
-                        foreach (var successor in nodeSuccessors)
-                        {
-                            var successorElement = ExpressionBuilder.GetWorkflowElement(successor.Target.Value);
-                            var successorInstance = Expression.Constant(successorElement);
-                            foreach (var property in externalizedBuilder.GetExternalizedProperties())
-                            {
-                                try { argument = ExpressionBuilder.BuildPropertyMapping(argument, successorInstance, property.Name); }
-                                catch (Exception e)
-                                {
-                                    throw new WorkflowBuildException(e.Message, builder, e);
-                                }
-                            }
-                        }
-                        continue;
+                        buildContext.BuildResult = expression;
                     }
 
-                    // Do not generate output sequences if the result expression is empty
-                    if (expression == EmptyExpression.Instance)
+                    if (buildContext.BuildResult != null)
                     {
-                        continue;
+                        return expression;
                     }
 
-                    // Do not generate output or successor sequences if the result expression type is void
-                    if (successorCount > 0 && disable == null)
-                    {
-                        try { if (expression.Type == typeof(void)) continue; }
-                        catch (Exception e)
-                        {
-                            throw new WorkflowBuildException(e.Message, builder, e);
-                        }
-                    }
-                }
-
-                if (workflowElement is WorkflowOutputBuilder outputBuilder)
-                {
-                    if (successorCount > 0)
-                    {
-                        throw new WorkflowBuildException("The workflow output must be a terminal node.", builder);
-                    }
-
-                    if (workflowOutput != null)
-                    {
-                        throw new WorkflowBuildException("Workflows cannot have more than one output.", builder);
-                    }
-
-                    workflowOutput = expression;
-                    continue;
-                }
-
-                if (successorCount > 1 && reducible)
-                {
-                    // Start a new multicast scope
-                    MulticastBranchBuilder multicastBuilder;
+                    // Filter disabled successors for property mapping nodes
+                    var argumentBuilder = workflowElement as IArgumentBuilder;
+                    var propertyMappingBuilder = ExpressionBuilder.IsBuildDependency(argumentBuilder);
+                    IList<Edge<ExpressionBuilder, ExpressionBuilderArgument>> nodeSuccessors;
                     if (propertyMappingBuilder)
                     {
-                        // Property mappings get replayed across subscriptions
-                        multicastBuilder = new ReplayLatestBranchBuilder();
+                        edgeCollection.Clear();
+                        edgeCollection.AddRange(node.Successors.Where(edge => !(ExpressionBuilder.Unwrap(edge.Target.Value) is DisableBuilder)));
+                        nodeSuccessors = edgeCollection;
                     }
-                    else multicastBuilder = new PublishBranchBuilder();
-                    expression = multicastBuilder.Build(expression);
+                    else nodeSuccessors = node.Successors;
 
-                    // Ensure publish/subscribe subject dependencies are not multicast
-                    var multicastScope = new MulticastScope(multicastBuilder);
-                    multicastScope.References.AddRange(nodeSuccessors
-                        .Where(successor => successor.Label != null)
-                        .Select(successor => successor.Target.Value));
-                    multicastMap.Insert(0, multicastScope);
-                }
-
-                foreach (var successor in nodeSuccessors)
-                {
-                    if (successor.Label == null) continue;
-                    var argument = expression;
-                    var buildDependency = false;
-                    if (argumentBuilder != null)
+                    // Remove all closing scopes
+                    var disable = expression as DisableExpression;
+                    var successorCount = requireBuildContext != null
+                        ? nodeSuccessors.Count(edge => edge.Label != null)
+                        : nodeSuccessors.Count;
+                    multicastMap.RemoveAll(scope =>
                     {
-                        try { buildDependency = !argumentBuilder.BuildArgument(argument, successor, out argument); }
-                        catch (Exception e)
+                        var referencesRemoved = scope.References.RemoveAll(reference => reference == builder);
+                        if (scope.References.Count == 0 && disable == null)
                         {
-                            throw new WorkflowBuildException(e.Message, builder, e);
+                            try
+                            {
+                                expression = scope.Close(expression);
+                                return true;
+                            }
+                            catch (Exception e)
+                            {
+                                throw new WorkflowBuildException(e.Message, builder, e);
+                            }
+                        }
+
+                        if (referencesRemoved > 0)
+                        {
+                            var expandedArguments = disable?.Arguments.Skip(1).GetEnumerator();
+                            do
+                            {
+                                // If there are no successors, or the expression is a disabled build dependency, this scope should never close
+                                if (successorCount == 0 || expression == DisconnectExpression.Instance) scope.References.Add(null);
+                                else scope.References.AddRange(nodeSuccessors
+                                    .Where(successor => successor.Label != null)
+                                    .Select(successor => successor.Target.Value));
+                            }
+                            while (expandedArguments != null && expandedArguments.MoveNext());
+                        }
+                        return false;
+                    });
+
+                    // Evaluate irreducible extension expressions
+                    if (!reducible)
+                    {
+                        // Disconnect disabled build dependencies from their immediate successors
+                        if (expression == DisconnectExpression.Instance)
+                        {
+                            componentConnections.AddRange(arguments);
+                            continue;
+                        }
+
+                        // Validate externalized properties
+                        if (externalizedBuilder != null)
+                        {
+                            var argument = expression;
+                            foreach (var successor in nodeSuccessors)
+                            {
+                                var successorElement = ExpressionBuilder.GetWorkflowElement(successor.Target.Value);
+                                var successorInstance = Expression.Constant(successorElement);
+                                foreach (var property in externalizedBuilder.GetExternalizedProperties())
+                                {
+                                    try { argument = ExpressionBuilder.BuildPropertyMapping(argument, successorInstance, property.Name); }
+                                    catch (Exception e)
+                                    {
+                                        throw new WorkflowBuildException(e.Message, builder, e);
+                                    }
+                                }
+                            }
+                            continue;
+                        }
+
+                        // Do not generate output sequences if the result expression is empty
+                        if (expression == EmptyExpression.Instance)
+                        {
+                            continue;
+                        }
+
+                        // Do not generate output or successor sequences if the result expression type is void
+                        if (successorCount > 0 && disable == null)
+                        {
+                            try { if (expression.Type == typeof(void)) continue; }
+                            catch (Exception e)
+                            {
+                                throw new WorkflowBuildException(e.Message, builder, e);
+                            }
                         }
                     }
 
-                    if (buildDependency)
+                    if (workflowElement is WorkflowOutputBuilder outputBuilder)
                     {
-                        UpdateArgumentList(dependencyLists, successor, argument);
-                    }
-                    else UpdateArgumentList(argumentLists, successor, argument);
-                }
+                        if (successorCount > 0)
+                        {
+                            throw new WorkflowBuildException("The workflow output must be a terminal node.", builder);
+                        }
 
-                if (successorCount == 0)
-                {
-                    if (disable != null) connections.AddRange(disable.Arguments);
-                    else connections.Add(expression);
-                }
-            }
+                        if (workflowOutput != null)
+                        {
+                            throw new WorkflowBuildException("Workflows cannot have more than one output.", builder);
+                        }
 
-            // Prune disabled multicast branches from output
-            multicastMap.RemoveAll(scope =>
-            {
-                var index = -1;
-                int? argumentIndex = null;
-                var branchesRemoved = connections.RemoveAll(connection =>
-                {
-                    index++;
-                    if (connection is MulticastBranchExpression branchExpression &&
-                        branchExpression == scope.MulticastBuilder.BranchExpression)
-                    {
-                        if (argumentIndex == null) argumentIndex = index;
-                        return true;
+                        workflowOutput = expression;
+                        continue;
                     }
 
-                    return false;
+                    if (successorCount > 1 && reducible)
+                    {
+                        // Start a new multicast scope
+                        MulticastBranchBuilder multicastBuilder;
+                        if (propertyMappingBuilder)
+                        {
+                            // Property mappings get replayed across subscriptions
+                            multicastBuilder = new ReplayLatestBranchBuilder();
+                        }
+                        else multicastBuilder = new PublishBranchBuilder();
+                        expression = multicastBuilder.Build(expression);
+
+                        // Ensure publish/subscribe subject dependencies are not multicast
+                        var multicastScope = new MulticastScope(multicastBuilder);
+                        multicastScope.References.AddRange(nodeSuccessors
+                            .Where(successor => successor.Label != null)
+                            .Select(successor => successor.Target.Value));
+                        multicastMap.Insert(0, multicastScope);
+                    }
+
+                    foreach (var successor in nodeSuccessors)
+                    {
+                        if (successor.Label == null) continue;
+                        var argument = expression;
+                        var buildDependency = false;
+                        if (argumentBuilder != null)
+                        {
+                            try { buildDependency = !argumentBuilder.BuildArgument(argument, successor, out argument); }
+                            catch (Exception e)
+                            {
+                                throw new WorkflowBuildException(e.Message, builder, e);
+                            }
+                        }
+
+                        if (buildDependency)
+                        {
+                            UpdateArgumentList(dependencyLists, successor, argument);
+                        }
+                        else UpdateArgumentList(argumentLists, successor, argument);
+                    }
+
+                    if (successorCount == 0)
+                    {
+                        if (disable != null) componentConnections.AddRange(disable.Arguments);
+                        else componentConnections.Add(expression);
+                    }
+                }
+
+                // Prune disabled multicast branches from output
+                multicastMap.RemoveAll(scope =>
+                {
+                    var index = -1;
+                    int? argumentIndex = null;
+                    var branchesRemoved = componentConnections.RemoveAll(connection =>
+                    {
+                        index++;
+                        if (connection is MulticastBranchExpression branchExpression &&
+                            branchExpression == scope.MulticastBuilder.BranchExpression)
+                        {
+                            if (argumentIndex == null) argumentIndex = index;
+                            return true;
+                        }
+
+                        return false;
+                    });
+
+                    var activeBranches = scope.References.Count - branchesRemoved;
+                    if (activeBranches > 1) return false;
+                    if (activeBranches == 1) scope.MulticastBuilder.BranchExpression.Cancel();
+                    if (activeBranches == 0) componentConnections.Insert(argumentIndex.Value, scope.MulticastBuilder.Source);
+                    return true;
                 });
 
-                var activeBranches = scope.References.Count - branchesRemoved;
-                if (activeBranches > 1) return false;
-                if (activeBranches == 1) scope.MulticastBuilder.BranchExpression.Cancel();
-                if (activeBranches == 0) connections.Insert(argumentIndex.Value, scope.MulticastBuilder.Source);
-                return true;
-            });
+                var componentOutput = ExpressionBuilder.BuildOutput(workflowOutput, componentConnections);
+                multicastMap.RemoveAll(scope =>
+                {
+                    componentOutput = scope.Close(componentOutput);
+                    return true;
+                });
 
-            var output = ExpressionBuilder.BuildOutput(workflowOutput, connections);
-            multicastMap.RemoveAll(scope =>
-            {
-                output = scope.Close(output);
-                return true;
-            });
+                if (workflowOutput != null) output = componentOutput;
+                else connections.Add(componentOutput);
+                multicastMap.Clear();
+                componentConnections.Clear();
+            }
+
+            output = ExpressionBuilder.MergeOutput(output, connections);
             return buildContext.CloseContext(output);
         }
 
@@ -1232,12 +1244,12 @@ namespace Bonsai.Expressions
                 throw new ArgumentNullException("source");
             }
 
-            if (!TopologicalSort.TrySort(source, out IEnumerable<Node<ExpressionBuilder, ExpressionBuilderArgument>> buildOrder))
+            if (!TopologicalSort.TrySort(source, out IEnumerable<DirectedGraph<ExpressionBuilder, ExpressionBuilderArgument>> buildOrder))
             {
                 throw new ArgumentException("Cannot serialize a workflow with cyclical dependencies.", "source");
             }
 
-            var nodes = buildOrder.ToArray();
+            var nodes = buildOrder.SelectMany(component => component).ToArray();
             var descriptor = new ExpressionBuilderGraphDescriptor();
 
             foreach (var node in nodes)

--- a/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
+++ b/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <TargetFramework>net472</TargetFramework>
+    <VersionPrefix>2.8.0</VersionPrefix>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="**\*.bonsai" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Bonsai.Editor\Bonsai.Editor.csproj" />
+  </ItemGroup>
+</Project>

--- a/Bonsai.Editor.Tests/ConnectComponentWithHigherIndexIntoLowerIndex.bonsai
+++ b/Bonsai.Editor.Tests/ConnectComponentWithHigherIndexIntoLowerIndex.bonsai
@@ -20,9 +20,6 @@
       </Expression>
       <Expression xsi:type="GroupWorkflow">
         <Name>C</Name>
-      </Expression>
-      <Expression xsi:type="GroupWorkflow">
-        <Name>D</Name>
         <Workflow>
           <Nodes>
             <Expression xsi:type="WorkflowInput">
@@ -35,10 +32,13 @@
           <Edges />
         </Workflow>
       </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>D</Name>
+      </Expression>
     </Nodes>
     <Edges>
       <Edge From="0" To="1" Label="Source1" />
-      <Edge From="1" To="3" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/Bonsai.Editor.Tests/EditorHelper.cs
+++ b/Bonsai.Editor.Tests/EditorHelper.cs
@@ -1,0 +1,51 @@
+﻿using System.Linq;
+using Bonsai.Editor.GraphModel;
+using Bonsai.Expressions;
+
+namespace Bonsai.Editor.Tests
+{
+    static class EditorHelper
+    {
+        static ExpressionBuilder CreateBuilder(string name)
+        {
+            var nestedGraph = new ExpressionBuilderGraph();
+            nestedGraph.Add(new WorkflowInputBuilder());
+            return new GroupWorkflowBuilder(nestedGraph) { Name = name };
+        }
+
+        internal static ExpressionBuilderGraph CreateEditorGraph(params string[] values)
+        {
+            var graph = new ExpressionBuilderGraph();
+            for (int i = 0; i < values.Length; i++)
+            {
+                var builder = CreateBuilder(values[i]);
+                graph.Add(builder);
+            }
+            return graph.ToInspectableGraph();
+        }
+
+        internal static GraphNode FindNode(this WorkflowEditor editor, string name)
+        {
+            var node = editor.Workflow.First(n => ExpressionBuilder.GetElementDisplayName(n.Value) == name);
+            return editor.FindGraphNode(node.Value);
+        }
+
+        internal static void ConnectNodes(this WorkflowEditor editor, string source, string target)
+        {
+            var sourceNodes = new[] { editor.FindNode(source) };
+            var targetNode = editor.FindNode(target);
+            editor.ConnectGraphNodes(sourceNodes, targetNode);
+        }
+
+        internal static void CreateNode(
+            this WorkflowEditor editor,
+            string name,
+            GraphNode selectedNode = null,
+            CreateGraphNodeType nodeType = CreateGraphNodeType.Successor,
+            bool branch = false)
+        {
+            var builder = CreateBuilder(name);
+            editor.CreateGraphNode(builder, selectedNode, nodeType, branch);
+        }
+    }
+}

--- a/Bonsai.Editor.Tests/MockGraphView.cs
+++ b/Bonsai.Editor.Tests/MockGraphView.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Bonsai.Editor.GraphModel;
+using Bonsai.Expressions;
+
+namespace Bonsai.Editor.Tests
+{
+    class MockGraphView : IGraphView
+    {
+        ExpressionBuilderGraph workflow;
+        readonly HashSet<GraphNode> selectedNodes = new HashSet<GraphNode>();
+
+        public MockGraphView(ExpressionBuilderGraph workflow = null)
+        {
+            Workflow = workflow ?? new ExpressionBuilderGraph();
+        }
+
+        public ExpressionBuilderGraph Workflow
+        {
+            get { return workflow; }
+            set
+            {
+                workflow = value;
+                UpdateGraphLayout();
+            }
+        }
+
+        public IReadOnlyList<GraphNodeGrouping> Nodes { get; set; }
+
+        public IEnumerable<GraphNode> SelectedNodes
+        {
+            get { return selectedNodes; }
+            set
+            {
+                if (selectedNodes != value)
+                {
+                    selectedNodes.Clear();
+                    if (value != null)
+                    {
+                        foreach (var node in value)
+                        {
+                            selectedNodes.Add(node);
+                            CursorNode = node;
+                        }
+                    }
+                }
+            }
+        }
+
+        public GraphNode CursorNode { get; set; }
+
+        public void UpdateSelection(IEnumerable<ExpressionBuilder> selection)
+        {
+            SelectedNodes = Nodes
+                .LayeredNodes()
+                .Where(node =>
+                {
+                    var nodeBuilder = WorkflowEditor.GetGraphNodeBuilder(node);
+                    return selection.Any(builder => ExpressionBuilder.Unwrap(builder) == nodeBuilder);
+                });
+        }
+
+        public void UpdateGraphLayout()
+        {
+            Nodes = Workflow.ConnectedComponentLayering();
+        }
+
+        public void UpdateGraphLayout(bool _)
+        {
+            UpdateGraphLayout();
+        }
+    }
+}

--- a/Bonsai.Editor.Tests/MockGraphView.cs
+++ b/Bonsai.Editor.Tests/MockGraphView.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Design;
 using System.Linq;
+using Bonsai.Design;
 using Bonsai.Editor.GraphModel;
 using Bonsai.Expressions;
 
@@ -13,7 +16,15 @@ namespace Bonsai.Editor.Tests
         public MockGraphView(ExpressionBuilderGraph workflow = null)
         {
             Workflow = workflow ?? new ExpressionBuilderGraph();
+            CommandExecutor = new CommandExecutor();
+            var serviceContainer = new ServiceContainer();
+            serviceContainer.AddService(typeof(CommandExecutor), CommandExecutor);
+            ServiceProvider = serviceContainer;
         }
+
+        public CommandExecutor CommandExecutor { get;  }
+
+        public IServiceProvider ServiceProvider { get; }
 
         public ExpressionBuilderGraph Workflow
         {

--- a/Bonsai.Editor.Tests/ReorderComponentWithHigherIndexIntoLowerIndex.bonsai
+++ b/Bonsai.Editor.Tests/ReorderComponentWithHigherIndexIntoLowerIndex.bonsai
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>A</Name>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>B</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+          </Nodes>
+          <Edges />
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>C</Name>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>D</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source2</Name>
+            </Expression>
+          </Nodes>
+          <Edges />
+        </Workflow>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="3" Label="Source1" />
+      <Edge From="2" To="3" Label="Source2" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/Bonsai.Editor.Tests/ReorderDanglingBranchWithPredecessors.bonsai
+++ b/Bonsai.Editor.Tests/ReorderDanglingBranchWithPredecessors.bonsai
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>A</Name>
+        <Workflow>
+          <Nodes />
+          <Edges />
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>B</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+          </Nodes>
+          <Edges />
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>C</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+          </Nodes>
+          <Edges />
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>F</Name>
+        <Workflow>
+          <Nodes />
+          <Edges />
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>D</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source2</Name>
+            </Expression>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source3</Name>
+            </Expression>
+          </Nodes>
+          <Edges />
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>E</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+          </Nodes>
+          <Edges />
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>G</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+          </Nodes>
+          <Edges />
+        </Workflow>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="0" To="2" Label="Source1" />
+      <Edge From="0" To="4" Label="Source2" />
+      <Edge From="0" To="6" Label="Source1" />
+      <Edge From="2" To="4" Label="Source1" />
+      <Edge From="3" To="4" Label="Source3" />
+      <Edge From="4" To="5" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/Bonsai.Editor.Tests/ReorderDanglingBranchWithPredecessors.bonsai
+++ b/Bonsai.Editor.Tests/ReorderDanglingBranchWithPredecessors.bonsai
@@ -6,10 +6,6 @@
     <Nodes>
       <Expression xsi:type="GroupWorkflow">
         <Name>A</Name>
-        <Workflow>
-          <Nodes />
-          <Edges />
-        </Workflow>
       </Expression>
       <Expression xsi:type="GroupWorkflow">
         <Name>B</Name>
@@ -35,10 +31,6 @@
       </Expression>
       <Expression xsi:type="GroupWorkflow">
         <Name>F</Name>
-        <Workflow>
-          <Nodes />
-          <Edges />
-        </Workflow>
       </Expression>
       <Expression xsi:type="GroupWorkflow">
         <Name>D</Name>

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -132,8 +132,8 @@ namespace Bonsai.Editor.Tests
             var (editor, assertIsReversible) = CreateMockEditor(workflowBuilder.Workflow);
 
             // reorder D onto C
-            var sourceNode = editor.Workflow[3];
-            var targetNode = editor.Workflow[2];
+            var sourceNode = editor.Workflow[2];
+            var targetNode = editor.Workflow[0];
             var nodes = new[] { editor.FindGraphNode(sourceNode.Value) };
             var target = editor.FindGraphNode(targetNode.Value);
             editor.ReorderGraphNodes(nodes, target);

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -121,7 +121,7 @@ namespace Bonsai.Editor.Tests
             Assert.AreSame(branchLead, editor.FindGraphNodeTag(branchLead.Value));
             Assert.AreEqual(expected: 1, branchLead.Successors.Count);
             Assert.AreEqual(expected: 1, editor.Workflow.IndexOf(branchLead));
-            Assert.AreEqual(expected: 3, editor.Workflow.IndexOf(sourceNode));
+            Assert.AreEqual(expected: 4, editor.Workflow.IndexOf(sourceNode));
             assertIsReversible();
         }
 

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -68,15 +68,18 @@ namespace Bonsai.Editor.Tests
             var workflowBuilder = LoadEmbeddedWorkflow("ReorderDanglingBranchWithPredecessors.bonsai");
             var nodeSequence = workflowBuilder.Workflow.ToArray();
             var (editor, executor) = CreateMockEditor(workflowBuilder.Workflow);
-            var source = editor.Workflow[2];
-            Assert.AreEqual(expected: 1, source.Successors.Count);
 
-            var nodes = new[] { editor.FindGraphNode(editor.Workflow[4].Value) };
+            var branchLead = editor.Workflow[2];
+            var sourceNode = editor.Workflow[5];
+            var nodes = new[] { editor.FindGraphNode(sourceNode.Value) };
             var target = editor.FindGraphNode(editor.Workflow[1].Value);
             editor.ReorderGraphNodes(nodes, target);
+            Assert.AreEqual(expected: 1, branchLead.Successors.Count);
 
-            source = editor.FindGraphNodeTag(source.Value);
-            Assert.AreEqual(expected: 1, source.Successors.Count);
+            Assert.AreSame(branchLead, editor.FindGraphNodeTag(branchLead.Value));
+            Assert.AreEqual(expected: 1, branchLead.Successors.Count);
+            Assert.AreEqual(expected: 1, editor.Workflow.IndexOf(branchLead));
+            Assert.AreEqual(expected: 3, editor.Workflow.IndexOf(sourceNode));
 
             executor.Undo();
             AssertIsSequenceEqual(nodeSequence, editor.Workflow);

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -26,8 +26,7 @@ namespace Bonsai.Editor.Tests
         {
             using var workflowStream = LoadEmbeddedResource(name);
             using var reader = XmlReader.Create(workflowStream);
-            reader.MoveToContent();
-            return (WorkflowBuilder)WorkflowBuilder.Serializer.Deserialize(reader);
+            return ElementStore.LoadWorkflow(reader);
         }
 
         static void AssertIsSequenceEqual(

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.ComponentModel.Design;
+using System.IO;
+using System.Xml;
+using Bonsai.Dag;
+using Bonsai.Design;
+using Bonsai.Editor.GraphModel;
+using Bonsai.Expressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Editor.Tests
+{
+    [TestClass]
+    public class WorkflowEditorTests
+    {
+        static Stream LoadEmbeddedResource(string name)
+        {
+            var qualifierType = typeof(WorkflowEditorTests);
+            var embeddedWorkflowStream = qualifierType.Namespace + "." + name;
+            return qualifierType.Assembly.GetManifestResourceStream(embeddedWorkflowStream);
+        }
+
+        static WorkflowBuilder LoadEmbeddedWorkflow(string name)
+        {
+            using var workflowStream = LoadEmbeddedResource(name);
+            using var reader = XmlReader.Create(workflowStream);
+            reader.MoveToContent();
+            return (WorkflowBuilder)WorkflowBuilder.Serializer.Deserialize(reader);
+        }
+
+        WorkflowEditor CreateMockEditor(ExpressionBuilderGraph workflow = null)
+        {
+            var executor = new CommandExecutor();
+            var serviceProvider = new ServiceContainer();
+            serviceProvider.AddService(typeof(CommandExecutor), executor);
+            var graphView = new MockGraphView(workflow);
+            var editor = new WorkflowEditor(serviceProvider, graphView);
+            editor.UpdateLayout.Subscribe(graphView.UpdateGraphLayout);
+            editor.UpdateSelection.Subscribe(graphView.UpdateSelection);
+            editor.Workflow = graphView.Workflow;
+            return editor;
+        }
+
+        [TestMethod]
+        public void ReorderGraphNode_ReorderDanglingBranchWithPredecessors_KeepPredecessorEdges()
+        {
+            var workflowBuilder = LoadEmbeddedWorkflow("ReorderDanglingBranchWithPredecessors.bonsai");
+            var editor = CreateMockEditor(workflowBuilder.Workflow);
+            var source = editor.Workflow[2];
+            Assert.AreEqual(expected: 1, source.Successors.Count);
+
+            var nodes = new[] { editor.FindGraphNode(editor.Workflow[4].Value) };
+            var target = editor.FindGraphNode(editor.Workflow[1].Value);
+            editor.ReorderGraphNodes(nodes, target);
+
+            source = editor.FindGraphNodeTag(source.Value);
+            Assert.AreEqual(expected: 1, source.Successors.Count);
+        }
+    }
+
+    static class WorkflowEditorHelper
+    {
+        public static Node<ExpressionBuilder, ExpressionBuilderArgument> FindGraphNodeTag(
+            this WorkflowEditor editor,
+            ExpressionBuilder value)
+        {
+            return (Node<ExpressionBuilder, ExpressionBuilderArgument>)editor.FindGraphNode(value).Tag;
+        }
+    }
+}

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -72,6 +72,40 @@ namespace Bonsai.Editor.Tests
             });
         }
 
+        [DataTestMethod]
+        [DataRow(CreateGraphNodeType.Successor, false)]
+        [DataRow(CreateGraphNodeType.Successor, true)]
+        [DataRow(CreateGraphNodeType.Predecessor, false)]
+        [DataRow(CreateGraphNodeType.Predecessor, true)]
+        public void CreateGraphNode_EmptyWorkflow_SingleNode(object nodeType, bool branch)
+        {
+            var (editor, assertIsReversible) = CreateMockEditor();
+            Assert.AreEqual(expected: 0, editor.Workflow.Count);
+            editor.CreateGraphNode(new UnitBuilder(), default, (CreateGraphNodeType)nodeType, branch);
+            Assert.AreEqual(expected: 1, editor.Workflow.Count);
+            assertIsReversible();
+        }
+
+        [DataTestMethod]
+        [DataRow(CreateGraphNodeType.Successor, false)]
+        [DataRow(CreateGraphNodeType.Successor, true)]
+        [DataRow(CreateGraphNodeType.Predecessor, false)]
+        [DataRow(CreateGraphNodeType.Predecessor, true)]
+        public void CreateGraphNode_SingleSelectedNode_ChainNode(object nodeType, bool branch)
+        {
+            var workflow = new ExpressionBuilderGraph();
+            var target = workflow.Add(new UnitBuilder());
+            var (editor, assertIsReversible) = CreateMockEditor(workflow);
+            Assert.AreEqual(expected: 1, editor.Workflow.Count);
+            var selectedNode = editor.FindGraphNode(target.Value);
+            var createNodeType = (CreateGraphNodeType)nodeType;
+            editor.CreateGraphNode(new UnitBuilder(), selectedNode, createNodeType, branch);
+            Assert.AreEqual(expected: 2, editor.Workflow.Count);
+            var expectedTargetIndex = createNodeType == CreateGraphNodeType.Successor ? 0 : 1;
+            Assert.AreEqual(expected: expectedTargetIndex, editor.Workflow.IndexOf(target));
+            assertIsReversible();
+        }
+
         [TestMethod]
         public void ReorderGraphNode_DanglingBranchWithPredecessors_KeepPredecessorEdges()
         {

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -76,7 +76,6 @@ namespace Bonsai.Editor.Tests
         public void ReorderGraphNode_DanglingBranchWithPredecessors_KeepPredecessorEdges()
         {
             var workflowBuilder = LoadEmbeddedWorkflow("ReorderDanglingBranchWithPredecessors.bonsai");
-            var nodeSequence = workflowBuilder.Workflow.ToArray();
             var (editor, assertIsReversible) = CreateMockEditor(workflowBuilder.Workflow);
 
             var branchLead = editor.Workflow[2];
@@ -97,22 +96,38 @@ namespace Bonsai.Editor.Tests
         public void ReorderGraphNode_ComponentWithHigherIndexIntoLowerIndex_ReorderComponentNodes()
         {
             var workflowBuilder = LoadEmbeddedWorkflow("ReorderComponentWithHigherIndexIntoLowerIndex.bonsai");
-            var nodeSequence = workflowBuilder.Workflow.ToArray();
             var (editor, assertIsReversible) = CreateMockEditor(workflowBuilder.Workflow);
 
-            // disconnect C from D
+            // reorder D onto C
             var sourceNode = editor.Workflow[3];
             var targetNode = editor.Workflow[2];
-            var nodes = new[] { editor.FindGraphNode(targetNode.Value) };
-            var target = editor.FindGraphNode(sourceNode.Value);
-            editor.DisconnectGraphNodes(nodes, target);
-
-            // reorder D into C
-            nodes = new[] { editor.FindGraphNode(sourceNode.Value) };
-            target = editor.FindGraphNode(targetNode.Value);
+            var nodes = new[] { editor.FindGraphNode(sourceNode.Value) };
+            var target = editor.FindGraphNode(targetNode.Value);
             editor.ReorderGraphNodes(nodes, target);
 
             Assert.AreEqual(expected: editor.Workflow.Count - 1, editor.Workflow.IndexOf(targetNode));
+            assertIsReversible();
+        }
+
+        [TestMethod]
+        public void ConnectGraphNode_ComponentWithHigherIndexIntoLowerIndex_ReorderComponentNodes()
+        {
+            var workflowBuilder = LoadEmbeddedWorkflow("ConnectComponentWithHigherIndexIntoLowerIndex.bonsai");
+            var (editor, assertIsReversible) = CreateMockEditor(workflowBuilder.Workflow);
+
+            // connect D onto C
+            var sourceNode = editor.Workflow[3];
+            var targetNode = editor.Workflow[2];
+            var nodes = new[] { editor.FindGraphNode(sourceNode.Value) };
+            var target = editor.FindGraphNode(targetNode.Value);
+
+            editor.ConnectGraphNodes(nodes, target);
+            Assert.AreEqual(expected: editor.Workflow.Count - 1, editor.Workflow.IndexOf(targetNode));
+
+            // ensure disconnect is consistent
+            editor.DisconnectGraphNodes(nodes, target);
+            Assert.AreEqual(expected: editor.Workflow.Count - 1, editor.Workflow.IndexOf(sourceNode));
+
             assertIsReversible();
         }
     }

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1007,8 +1007,8 @@ namespace Bonsai.Editor
             var workflow = model.Workflow;
             if (model.GraphView.SelectedNodes.Count() > 0)
             {
-                var selectedElements = model.GraphView.SelectedNodes.ToWorkflow();
-                workflow = selectedElements;
+                var selectedElements = model.GraphView.SelectedNodes.SortSelection(workflow);
+                workflow = selectedElements.ToWorkflow();
             }
 
             var extension = Path.GetExtension(fileName);

--- a/Bonsai.Editor/GraphModel/ElementStore.cs
+++ b/Bonsai.Editor/GraphModel/ElementStore.cs
@@ -16,6 +16,16 @@ namespace Bonsai.Editor.GraphModel
             Indent = true
         };
 
+        public static WorkflowBuilder LoadWorkflow(string fileName)
+        {
+            return LoadWorkflow(fileName, out _);
+        }
+
+        public static WorkflowBuilder LoadWorkflow(XmlReader reader)
+        {
+            return LoadWorkflow(reader, out _);
+        }
+
         public static WorkflowBuilder LoadWorkflow(string fileName, out SemanticVersion version)
         {
             using var reader = XmlReader.Create(fileName);

--- a/Bonsai.Editor/GraphModel/GraphNode.cs
+++ b/Bonsai.Editor/GraphModel/GraphNode.cs
@@ -42,8 +42,8 @@ namespace Bonsai.Editor.GraphModel
                 }
 
                 if (obsolete) Flags |= NodeFlags.Obsolete;
+                if (expressionBuilder.IsBuildDependency()) Flags |= NodeFlags.BuildDependency;
                 Category = elementCategoryAttribute.Category;
-                IsBuildDependency = expressionBuilder.IsBuildDependency();
                 Icon = new ElementIcon(workflowElement);
                 if (workflowElement is IWorkflowExpressionBuilder)
                 {
@@ -65,7 +65,7 @@ namespace Bonsai.Editor.GraphModel
             {
                 if (successor.Node.Value == null)
                 {
-                    successor.Node.IsBuildDependency = IsBuildDependency;
+                    if (IsBuildDependency) successor.Node.Flags |= NodeFlags.BuildDependency;
                     successor.Node.InitializeDummySuccessors();
                 }
             }
@@ -134,7 +134,7 @@ namespace Bonsai.Editor.GraphModel
 
         public ElementIcon Icon { get; private set; }
 
-        public bool IsBuildDependency { get; private set; }
+        public bool IsBuildDependency => (Flags & NodeFlags.BuildDependency) != 0;
 
         public bool IsAnnotation => (Flags & NodeFlags.Annotation) != 0;
 
@@ -172,9 +172,10 @@ namespace Bonsai.Editor.GraphModel
             Highlight = 0x1,
             Obsolete = 0x2,
             Disabled = 0x4,
-            NestedScope = 0x8,
-            NestedGroup = 0x10,
-            Annotation = 0x20
+            BuildDependency = 0x8,
+            NestedScope = 0x10,
+            NestedGroup = 0x20,
+            Annotation = 0x40
         }
 
         static class CategoryColors

--- a/Bonsai.Editor/GraphModel/GraphNode.cs
+++ b/Bonsai.Editor/GraphModel/GraphNode.cs
@@ -15,6 +15,7 @@ namespace Bonsai.Editor.GraphModel
 
         public GraphNode(ExpressionBuilder value, int layer, IEnumerable<GraphEdge> successors)
         {
+            Index = -1;
             Value = value;
             Layer = layer;
             Successors = successors;

--- a/Bonsai.Editor/GraphModel/GraphNode.cs
+++ b/Bonsai.Editor/GraphModel/GraphNode.cs
@@ -73,6 +73,8 @@ namespace Bonsai.Editor.GraphModel
 
         private NodeFlags Flags { get; set; }
 
+        public int Index { get; internal set; }
+
         public int Layer { get; internal set; }
 
         public int LayerIndex { get; internal set; }

--- a/Bonsai.Editor/GraphModel/IGraphView.cs
+++ b/Bonsai.Editor/GraphModel/IGraphView.cs
@@ -7,5 +7,7 @@ namespace Bonsai.Editor.GraphModel
         IEnumerable<GraphNodeGrouping> Nodes { get; }
 
         IEnumerable<GraphNode> SelectedNodes { get; }
+
+        GraphNode CursorNode { get; }
     }
 }

--- a/Bonsai.Editor/GraphModel/IGraphView.cs
+++ b/Bonsai.Editor/GraphModel/IGraphView.cs
@@ -4,7 +4,7 @@ namespace Bonsai.Editor.GraphModel
 {
     interface IGraphView
     {
-        IEnumerable<GraphNodeGrouping> Nodes { get; }
+        IReadOnlyList<GraphNodeGrouping> Nodes { get; }
 
         IEnumerable<GraphNode> SelectedNodes { get; }
 

--- a/Bonsai.Editor/GraphModel/LayeredGraphExtensions.cs
+++ b/Bonsai.Editor/GraphModel/LayeredGraphExtensions.cs
@@ -230,7 +230,7 @@ namespace Bonsai.Editor.GraphModel
             }
         }
 
-        public static IList<ConnectedComponent> FindConnectedComponents(this ExpressionBuilderGraph source)
+        public static IReadOnlyList<ConnectedComponent> FindConnectedComponents(this ExpressionBuilderGraph source)
         {
             var connectedComponents = new List<ConnectedComponent>();
             var connectedSet = new HashSet<Node<ExpressionBuilder, ExpressionBuilderArgument>>();

--- a/Bonsai.Editor/GraphModel/LayeredGraphExtensions.cs
+++ b/Bonsai.Editor/GraphModel/LayeredGraphExtensions.cs
@@ -258,7 +258,7 @@ namespace Bonsai.Editor.GraphModel
             return connectedComponents;
         }
 
-        public static IEnumerable<GraphNodeGrouping> ConnectedComponentLayering(this ExpressionBuilderGraph source)
+        public static IReadOnlyList<GraphNodeGrouping> ConnectedComponentLayering(this ExpressionBuilderGraph source)
         {
             int layerOffset = 0;
             GraphNodeGrouping singletonLayer = null;

--- a/Bonsai.Editor/GraphModel/LayeredGraphExtensions.cs
+++ b/Bonsai.Editor/GraphModel/LayeredGraphExtensions.cs
@@ -289,7 +289,28 @@ namespace Bonsai.Editor.GraphModel
             }
 
             MergeSingletonComponentLayers(ref singletonLayer, layers, ref layerOffset);
+            SetLayeredNodeIndices(layers, source);
             return layers;
+        }
+
+        static void SetLayeredNodeIndices(IEnumerable<GraphNodeGrouping> layers, ExpressionBuilderGraph workflow)
+        {
+            var nodeMap = new Dictionary<Node<ExpressionBuilder, ExpressionBuilderArgument>, int>(workflow.Count);
+            for (int i = 0; i < workflow.Count; i++)
+            {
+                nodeMap[workflow[i]] = i;
+            }
+
+            foreach (var layer in layers)
+            {
+                foreach (var node in layer)
+                {
+                    if (node.Tag is Node<ExpressionBuilder, ExpressionBuilderArgument> tag)
+                    {
+                        node.Index = nodeMap[tag];
+                    }
+                }
+            }
         }
 
         static void MergeSingletonComponentLayers(ref GraphNodeGrouping singletonLayer, List<GraphNodeGrouping> layers, ref int layerOffset)

--- a/Bonsai.Editor/GraphModel/LayeredGraphExtensions.cs
+++ b/Bonsai.Editor/GraphModel/LayeredGraphExtensions.cs
@@ -58,10 +58,10 @@ namespace Bonsai.Editor.GraphModel
             }
         }
 
-        static IEnumerable<GraphNode> ComputeLongestPathLayering(this ExpressionBuilderGraph source)
+        static IEnumerable<GraphNode> ComputeLongestPathLayering(this ConnectedComponent source)
         {
             var layerMap = new Dictionary<Node<ExpressionBuilder, ExpressionBuilderArgument>, GraphNode>();
-            foreach (var node in source.TopologicalSort().Reverse())
+            foreach (var node in source.Reverse())
             {
                 var layer = 0;
                 foreach (var successor in node.Successors)
@@ -93,7 +93,7 @@ namespace Bonsai.Editor.GraphModel
             }
         }
 
-        public static IEnumerable<GraphNodeGrouping> LongestPathLayering(this ExpressionBuilderGraph source)
+        public static IEnumerable<GraphNodeGrouping> LongestPathLayering(this ConnectedComponent source)
         {
             Dictionary<int, GraphNodeGrouping> layers = new Dictionary<int, GraphNodeGrouping>();
             foreach (var layeredNode in ComputeLongestPathLayering(source))
@@ -224,57 +224,33 @@ namespace Bonsai.Editor.GraphModel
 
         public class ConnectedComponent : ExpressionBuilderGraph
         {
-            public ConnectedComponent(int index)
+            public ConnectedComponent(IEnumerable<Node<ExpressionBuilder, ExpressionBuilderArgument>> nodes)
             {
-                Index = index;
+                InsertRange(0, nodes);
             }
-
-            public int Index { get; private set; }
         }
 
         public static IList<ConnectedComponent> FindConnectedComponents(this ExpressionBuilderGraph source)
         {
             var connectedComponents = new List<ConnectedComponent>();
-            var connectedComponentMap = new Dictionary<Node<ExpressionBuilder, ExpressionBuilderArgument>, ConnectedComponent>();
-            var visited = new Queue<Node<ExpressionBuilder, ExpressionBuilderArgument>>();
-            foreach (var node in source)
+            var connectedSet = new HashSet<Node<ExpressionBuilder, ExpressionBuilderArgument>>();
+            var currentComponent = new List<Node<ExpressionBuilder, ExpressionBuilderArgument>>();
+            foreach (var node in source.TopologicalSort())
             {
-                if (!connectedComponentMap.TryGetValue(node, out ConnectedComponent component))
+                currentComponent.Add(node);
+                connectedSet.Remove(node);
+                if (node.Successors.Count == 0 && connectedSet.Count == 0)
                 {
-                    foreach (var successor in node.DepthFirstSearch())
+                    // node is the last sink in the connected component
+                    connectedComponents.Add(new ConnectedComponent(currentComponent));
+                    currentComponent.Clear();
+                }
+                else
+                {
+                    // all the node successors are members of the connected component
+                    foreach (var successor in node.Successors)
                     {
-                        if (connectedComponentMap.TryGetValue(successor, out ConnectedComponent successorComponent))
-                        {
-                            if (component != null && component != successorComponent)
-                            {
-                                // Merge connected components
-                                foreach (var componentNode in component)
-                                {
-                                    successorComponent.Add(componentNode);
-                                    connectedComponentMap[componentNode] = successorComponent;
-                                }
-                                connectedComponents.Remove(component);
-                            }
-
-                            component = successorComponent;
-                        }
-                        else if (!visited.Contains(successor))
-                        {
-                            visited.Enqueue(successor);
-                        }
-                    }
-
-                    if (component == null)
-                    {
-                        component = new ConnectedComponent(connectedComponents.Count);
-                        connectedComponents.Add(component);
-                    }
-
-                    while (visited.Count > 0)
-                    {
-                        var componentNode = visited.Dequeue();
-                        component.Add(componentNode);
-                        connectedComponentMap.Add(componentNode, component);
+                        connectedSet.Add(successor.Target);
                     }
                 }
             }

--- a/Bonsai.Editor/GraphModel/LayeredGraphExtensions.cs
+++ b/Bonsai.Editor/GraphModel/LayeredGraphExtensions.cs
@@ -20,6 +20,18 @@ namespace Bonsai.Editor.GraphModel
                          .FromInspectableGraph(recurse);
         }
 
+        public static IEnumerable<GraphNode> SortSelection(this IEnumerable<GraphNode> source, ExpressionBuilderGraph workflow)
+        {
+            var nodeMap = source.ToDictionary(node => node.Value);
+            for (int i = 0; i < workflow.Count; i++)
+            {
+                if (nodeMap.TryGetValue(workflow[i].Value, out GraphNode node))
+                {
+                    yield return node;
+                }
+            }
+        }
+
         public static IEnumerable<GraphNode> LayeredNodes(this IEnumerable<GraphNodeGrouping> source)
         {
             return source.SelectMany(layer => layer).Where(node => node.Value != null);

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -703,17 +703,20 @@ namespace Bonsai.Editor.GraphModel
                 else // reorder connected components
                 {
                     var targetIndex = workflow.IndexOf(targetComponent[0]);
-                    var restoreComponentIndex = components.IndexOf(sourceComponent) + 1;
-                    var restoreAnchor = restoreComponentIndex < components.Count
-                        ? components[restoreComponentIndex][0]
-                        : null;
-                    commandExecutor.Execute(
-                    () => workflow.InsertRange(targetIndex, sourceComponent),
-                    () =>
+                    var reorderedComponents = sourceComponent.Convert(builder => builder, recurse: false);
+                    foreach (var node in sourceComponent)
                     {
-                        var restoreIndex = restoreAnchor != null ? workflow.IndexOf(restoreAnchor) : workflow.Count;
-                        workflow.InsertRange(restoreIndex, sourceComponent);
-                    });
+                        DeleteGraphNode(node, replaceEdges: true);
+                    }
+
+                    InsertGraphElements(
+                        targetIndex,
+                        reorderedComponents,
+                        selectedNodes: Array.Empty<GraphNode>(),
+                        CreateGraphNodeType.Successor,
+                        branch: false,
+                        EmptyAction,
+                        EmptyAction);
                 }
             }
         }

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -783,13 +783,13 @@ namespace Bonsai.Editor.GraphModel
                 }
                 else // reorder connected components
                 {
-                    var targetIndex = workflow.IndexOf(targetComponent[0]);
                     var reorderedComponents = sourceComponent.Convert(builder => builder, recurse: false);
                     foreach (var node in sourceComponent)
                     {
                         DeleteGraphNode(node, replaceEdges: true);
                     }
 
+                    var targetIndex = workflow.IndexOf(targetComponent[0]);
                     InsertGraphElements(
                         targetIndex,
                         reorderedComponents,

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -308,8 +308,11 @@ namespace Bonsai.Editor.GraphModel
                                 var predecessorEdge = predecessor.Item2;
                                 var predecessorNode = predecessor.Item1;
                                 var edgeIndex = predecessor.Item3;
-                                addConnection += () => { workflow.SetEdge(predecessorNode, edgeIndex, sourceNode, predecessorEdge.Label); };
-                                removeConnection += () => { workflow.SetEdge(predecessorNode, edgeIndex, predecessorEdge); };
+                                if (!predecessorNode.Value.IsBuildDependency())
+                                {
+                                    addConnection += () => { workflow.SetEdge(predecessorNode, edgeIndex, sourceNode, predecessorEdge.Label); };
+                                    removeConnection += () => { workflow.SetEdge(predecessorNode, edgeIndex, predecessorEdge); };
+                                }
                             }
                         }
 

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -87,7 +87,8 @@ namespace Bonsai.Editor.GraphModel
         private int GetInsertIndexFromCursor(ExpressionBuilderGraph workflow, ExpressionBuilder builder, CreateGraphNodeType nodeType, bool branch)
         {
             var allowConnection = builder != null && GetBuilderMaxConnectionCount(builder) > 0;
-            var insertComponent = branch || graphView.SelectedNodes.Count() == 0 || !allowConnection;
+            var forwardBranch = branch && nodeType == CreateGraphNodeType.Successor;
+            var insertComponent = forwardBranch || graphView.SelectedNodes.Count() == 0 || !allowConnection;
 
             var target = graphView.CursorNode;
             if (insertComponent && target != null)

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -1274,7 +1274,7 @@ namespace Bonsai.Editor.GraphModel
             commandExecutor.BeginCompositeCommand();
             commandExecutor.Execute(EmptyAction, updateGraphLayout);
 
-            var elements = nodes.ToWorkflow().ToInspectableGraph();
+            var elements = nodes.SortSelection(Workflow).ToWorkflow().ToInspectableGraph();
             var buildDependencies = (from item in nodes.Zip(elements, (node, element) => new { node, element })
                                      from predecessor in Workflow.PredecessorEdges(GetGraphNodeTag(Workflow, item.node))
                                      where predecessor.Item1.Value.IsBuildDependency() && !elements.Any(node => node.Value == item.node.Value)
@@ -1352,7 +1352,7 @@ namespace Bonsai.Editor.GraphModel
             var workflow = this.Workflow;
             GraphNode replacementNode = null;
             var nodeType = CreateGraphNodeType.Successor;
-            var selectedElements = nodes.ToWorkflow(recurse: false);
+            var selectedElements = nodes.SortSelection(workflow).ToWorkflow(recurse: false);
             if (!CanGroup(nodes, selectedElements))
             {
                 error.OnNext(new InvalidOperationException(Resources.GroupBrokenBranches_Error));

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -102,7 +102,7 @@ namespace Bonsai.Editor.GraphModel
             return insertIndex;
         }
 
-        private int GetInsertIndexFromCursor(
+        private int GetInsertIndex(
             ExpressionBuilderGraph workflow,
             ExpressionBuilder builder,
             GraphNode target,
@@ -110,10 +110,10 @@ namespace Bonsai.Editor.GraphModel
             bool branch)
         {
             var targetNode = target != null ? GetGraphNodeTag(workflow, target) : null;
-            return GetInsertIndexFromCursor(workflow, builder, targetNode, nodeType, branch);
+            return GetInsertIndex(workflow, builder, targetNode, nodeType, branch);
         }
 
-        private int GetInsertIndexFromCursor(
+        private int GetInsertIndex(
             ExpressionBuilderGraph workflow,
             ExpressionBuilder builder,
             Node<ExpressionBuilder, ExpressionBuilderArgument> target,
@@ -1157,10 +1157,10 @@ namespace Bonsai.Editor.GraphModel
             var restoreSelectedNodes = CreateUpdateSelectionDelegate(targetNodes);
             if (insertIndex < 0)
             {
-                var cursor = targetNodes.Length > 0
+                var target = targetNodes.Length > 0
                     ? targetNodes[targetNodes.Length - 1]
                     : GetGraphNodeTag(graphView.CursorNode);
-                insertIndex = GetInsertIndexFromCursor(workflow, inspectBuilder, cursor, nodeType, branch);
+                insertIndex = GetInsertIndex(workflow, inspectBuilder, target, nodeType, branch);
             }
 
             builder = inspectBuilder.Builder;
@@ -1248,7 +1248,7 @@ namespace Bonsai.Editor.GraphModel
             }
 
             var sourceBuilder = elements.Sources().FirstOrDefault()?.Value;
-            var insertIndex = GetInsertIndexFromCursor(Workflow, sourceBuilder, graphView.CursorNode, nodeType, branch);
+            var insertIndex = GetInsertIndex(Workflow, sourceBuilder, graphView.CursorNode, nodeType, branch);
             InsertGraphElements(insertIndex, elements, nodeType, branch);
         }
 
@@ -1495,7 +1495,7 @@ namespace Bonsai.Editor.GraphModel
             commandExecutor.Execute(reorder.Command, EmptyAction);
 
             var sourceBuilder = elements[0].Value;
-            var insertIndex = GetInsertIndexFromCursor(Workflow, sourceBuilder, target, nodeType, branch);
+            var insertIndex = GetInsertIndex(Workflow, sourceBuilder, target, nodeType, branch);
             Action addConnection = () => Array.ForEach(buildDependencies, dependency => Workflow.AddEdge(dependency.predecessor.Item1, dependency.edge));
             Action removeConnection = () => Array.ForEach(buildDependencies, dependency => Workflow.RemoveEdge(dependency.predecessor.Item1, dependency.edge));
             InsertGraphElements(insertIndex, elements, selectedNodes, nodeType, branch, addConnection, removeConnection);

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -814,6 +814,7 @@ namespace Bonsai.Editor.GraphModel
             for (int i = 0; i < reorderCommands.Count; i++)
             {
                 var node = reorderCommands[i];
+                if (!Workflow.Contains(node)) continue;
                 try { ReorderGraphNode(node, targetNode); }
                 catch (InvalidOperationException ex)
                 {

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -1157,10 +1157,7 @@ namespace Bonsai.Editor.GraphModel
             var restoreSelectedNodes = CreateUpdateSelectionDelegate(targetNodes);
             if (insertIndex < 0)
             {
-                var target = targetNodes.Length > 0
-                    ? targetNodes[targetNodes.Length - 1]
-                    : GetGraphNodeTag(graphView.CursorNode);
-                insertIndex = GetInsertIndex(workflow, inspectBuilder, target, nodeType, branch);
+                insertIndex = GetInsertIndex(workflow, inspectBuilder, graphView.CursorNode, nodeType, branch);
             }
 
             builder = inspectBuilder.Builder;

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -721,10 +721,18 @@ namespace Bonsai.Editor.GraphModel
                             {
                                 // common ancestor
                                 var ancestor = GetGraphNodeTag(workflow, sourceTrace.node);
-                                var sourceEdge = ancestor.Successors[sourceTrace.index];
                                 var targetEdge = ancestor.Successors[targetTrace.index];
-                                var sourceBranch = RangeIndices(workflow, sourceEdge.Target.DepthFirstSearch());
                                 var targetIndex = workflow.IndexOf(targetEdge.Target);
+                                var successorSet = new HashSet<Node<ExpressionBuilder, ExpressionBuilderArgument>>();
+                                foreach (var successorEdge in ancestor.Successors)
+                                {
+                                    if (successorEdge == targetEdge) continue;
+                                    var successorBranch = successorEdge.Target.DepthFirstSearch().ToHashSet();
+                                    if (!successorBranch.Contains(source)) continue;
+                                    successorSet.UnionWith(successorBranch);
+                                }
+
+                                var sourceBranch = RangeIndices(workflow, successorSet);
                                 var ancestorEdges = ancestor.Successors
                                     .Select((edge, index) => (edge, index))
                                     .Where(x => sourceBranch.ContainsKey(x.edge.Target))

--- a/Bonsai.Editor/GraphView/GraphViewControl.cs
+++ b/Bonsai.Editor/GraphView/GraphViewControl.cs
@@ -78,7 +78,7 @@ namespace Bonsai.Editor.GraphView
         readonly LayoutNodeCollection layoutNodes = new LayoutNodeCollection();
         readonly HashSet<GraphNode> selectedNodes = new HashSet<GraphNode>();
         readonly SvgRendererState iconRendererState = new SvgRendererState();
-        IEnumerable<GraphNodeGrouping> nodes;
+        IReadOnlyList<GraphNodeGrouping> nodes;
         GraphNode pivot;
         GraphNode hot;
 
@@ -240,7 +240,7 @@ namespace Bonsai.Editor.GraphView
 
         public Image GraphicsProvider { get; set; }
 
-        public IEnumerable<GraphNodeGrouping> Nodes
+        public IReadOnlyList<GraphNodeGrouping> Nodes
         {
             get { return nodes; }
             set
@@ -866,7 +866,7 @@ namespace Bonsai.Editor.GraphView
             {
                 using (var graphics = CreateVectorGraphics())
                 {
-                    var layerCount = model.Count();
+                    var layerCount = model.Count;
                     foreach (var layer in model)
                     {
                         var maxRow = 0;

--- a/Bonsai.Editor/GraphView/GraphViewControl.cs
+++ b/Bonsai.Editor/GraphView/GraphViewControl.cs
@@ -686,8 +686,6 @@ namespace Bonsai.Editor.GraphView
             point.X += canvas.HorizontalScroll.Value;
             point.Y += canvas.VerticalScroll.Value;
 
-            var rightMost = PointF.Empty;
-            var closestNode = default(GraphNode);
             foreach (var layout in layoutNodes)
             {
                 if (layout.Node.Value == null) continue;
@@ -699,21 +697,9 @@ namespace Bonsai.Editor.GraphView
                 {
                     return layout.Node;
                 }
-                else if (point.Y > boundingRectangle.Top &&
-                         (boundingRectangle.Bottom > rightMost.Y ||
-                          boundingRectangle.Right > rightMost.X))
-                {
-                    rightMost = new PointF(boundingRectangle.Right, boundingRectangle.Bottom);
-                    closestNode = layout.Node;
-                }
             }
 
-            while (closestNode?.Successors.FirstOrDefault() is GraphEdge successor)
-            {
-                closestNode = successor.Node;
-            }
-
-            return closestNode;
+            return GetLastNode();
         }
 
         public GraphNode GetNodeAt(Point point)
@@ -729,6 +715,17 @@ namespace Bonsai.Editor.GraphView
                 {
                     return layout.Node;
                 }
+            }
+
+            return null;
+        }
+
+        GraphNode GetLastNode()
+        {
+            if (nodes.Count > 0)
+            {
+                var layer = nodes[0];
+                return layer[layer.Count - 1];
             }
 
             return null;
@@ -894,11 +891,7 @@ namespace Bonsai.Editor.GraphView
                     size.Width = layerCount * NodeAirspace;
                 }
 
-                if (CursorNode == null && model.Count > 0)
-                {
-                    var layer = model[0];
-                    CursorNode = layer[layer.Count - 1];
-                }
+                CursorNode ??= GetLastNode();
                 pivot = CursorNode;
             }
 

--- a/Bonsai.Editor/GraphView/GraphViewControl.cs
+++ b/Bonsai.Editor/GraphView/GraphViewControl.cs
@@ -245,7 +245,6 @@ namespace Bonsai.Editor.GraphView
             get { return nodes; }
             set
             {
-                CursorNode = null;
                 pivot = null;
                 nodes = value;
                 hot = null;
@@ -862,6 +861,8 @@ namespace Bonsai.Editor.GraphView
             layoutNodes.Clear();
             var model = Nodes;
             var size = SizeF.Empty;
+            var cursorIndex = CursorNode?.Index;
+            CursorNode = null;
             if (model != null)
             {
                 using (var graphics = CreateVectorGraphics())
@@ -873,7 +874,11 @@ namespace Bonsai.Editor.GraphView
                         var column = layerCount - layer.Key - 1;
                         foreach (var node in layer)
                         {
-                            if (pivot == null) pivot = CursorNode = node;
+                            if (node.Index == cursorIndex)
+                            {
+                                CursorNode = node;
+                            }
+
                             var row = node.LayerIndex;
                             var location = new PointF(column * NodeAirspace + 2 * PenWidth, row * NodeAirspace + 2 * PenWidth);
                             var layout = new LayoutNode(this, node, location);
@@ -888,6 +893,13 @@ namespace Bonsai.Editor.GraphView
 
                     size.Width = layerCount * NodeAirspace;
                 }
+
+                if (CursorNode == null && model.Count > 0)
+                {
+                    var layer = model[0];
+                    CursorNode = layer[layer.Count - 1];
+                }
+                pivot = CursorNode;
             }
 
             canvas.AutoScrollMinSize = Size.Truncate(size);
@@ -1280,7 +1292,7 @@ namespace Bonsai.Editor.GraphView
             if (hot != null)
             {
                 SetCursor(hot);
-                if (Control.ModifierKeys.HasFlag(Keys.Shift))
+                if (ModifierKeys.HasFlag(Keys.Shift))
                 {
                     mouseDownHandled = true;
                     SelectRange(hot, ModifierKeys.HasFlag(Keys.Control));

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -259,7 +259,8 @@ namespace Bonsai.Editor.GraphView
 
         private void StoreWorkflowElements()
         {
-            var text = ElementStore.StoreWorkflowElements(selectionModel.SelectedNodes.ToWorkflow());
+            var selection = selectionModel.SelectedNodes.SortSelection(Workflow);
+            var text = ElementStore.StoreWorkflowElements(selection.ToWorkflow());
             if (!string.IsNullOrEmpty(text))
             {
                 Clipboard.SetText(text);
@@ -358,9 +359,7 @@ namespace Bonsai.Editor.GraphView
 
         public void SelectAllGraphNodes()
         {
-            var graphNodes = graphView.Nodes
-                .SelectMany(layer => layer)
-                .Where(node => node.Value != null);
+            var graphNodes = graphView.Nodes.LayeredNodes();
             graphView.SelectedNodes = graphNodes;
         }
 

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1304,7 +1304,7 @@ namespace Bonsai.Editor.GraphView
                     .Where(node =>
                     {
                         var nodeBuilder = WorkflowEditor.GetGraphNodeBuilder(node);
-                        return selection.Any(builder => workflow.Comparer.Compare(builder, nodeBuilder) == 0);
+                        return selection.Any(builder => ExpressionBuilder.Unwrap(builder) == nodeBuilder);
                     });
             });
         }

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1528,7 +1528,9 @@ namespace Bonsai.Editor.GraphView
                             element.Name,
                             element.FullyQualifiedName,
                             ~ElementCategory.Combinator,
-                            CreateGraphNodeType.Successor,
+                            ModifierKeys.HasFlag(Keys.Shift)
+                                ? CreateGraphNodeType.Predecessor
+                                : CreateGraphNodeType.Successor,
                             branch: false,
                             group: true));
                         ownerItem.DropDownItems.Add(menuItem);

--- a/Bonsai.Editor/Properties/AssemblyInfo.cs
+++ b/Bonsai.Editor/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
-﻿using Bonsai;
+﻿using System.Runtime.CompilerServices;
+using Bonsai;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: WorkflowNamespaceIcon("Bonsai.Editor.Scripting", "Bonsai:ElementIcon.CSharp")]
+[assembly: InternalsVisibleTo("Bonsai.Editor.Tests")]

--- a/Bonsai.Editor/WorkflowExporter.cs
+++ b/Bonsai.Editor/WorkflowExporter.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Windows.Forms;
-using System.Xml;
-using System.Xml.Serialization;
+using Bonsai.Editor.GraphModel;
 using Bonsai.Editor.GraphView;
 
 namespace Bonsai.Editor
@@ -26,14 +25,7 @@ namespace Bonsai.Editor
                 throw new ArgumentException("No output image file is specified.", nameof(imageFileName));
             }
 
-            WorkflowBuilder workflowBuilder;
-            using (var reader = XmlReader.Create(fileName))
-            {
-                reader.MoveToContent();
-                var serializer = new XmlSerializer(typeof(WorkflowBuilder), reader.NamespaceURI);
-                workflowBuilder = (WorkflowBuilder)serializer.Deserialize(reader);
-            }
-
+            var workflowBuilder = ElementStore.LoadWorkflow(fileName);
             var iconRenderer = new SvgRendererFactory();
             var extension = Path.GetExtension(imageFileName);
             if (extension == ".svg")

--- a/Bonsai.Editor/WorkflowRunner.cs
+++ b/Bonsai.Editor/WorkflowRunner.cs
@@ -1,4 +1,5 @@
-using Bonsai.Design;
+﻿using Bonsai.Design;
+using Bonsai.Editor.GraphModel;
 using Bonsai.Expressions;
 using System;
 using System.Collections.Generic;
@@ -8,7 +9,6 @@ using System.Reactive.Linq;
 using System.Threading;
 using System.Windows.Forms;
 using System.Xml;
-using System.Xml.Serialization;
 
 namespace Bonsai.Editor
 {
@@ -128,14 +128,7 @@ namespace Bonsai.Editor
                 throw new ArgumentException("Specified workflow file does not exist.", nameof(fileName));
             }
 
-            WorkflowBuilder workflowBuilder;
-            using (var reader = XmlReader.Create(fileName))
-            {
-                reader.MoveToContent();
-                var serializer = new XmlSerializer(typeof(WorkflowBuilder), reader.NamespaceURI);
-                workflowBuilder = (WorkflowBuilder)serializer.Deserialize(reader);
-            }
-
+            var workflowBuilder = ElementStore.LoadWorkflow(fileName);
             layoutPath ??= LayoutHelper.GetLayoutPath(fileName);
             if (visualizerProvider != null && File.Exists(layoutPath))
             {

--- a/Bonsai.Player/Bonsai.Player.csproj
+++ b/Bonsai.Player/Bonsai.Player.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Player Rx Reactive Extensions</PackageTags>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>2.7.1</VersionPrefix>
+    <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13">

--- a/Bonsai.sln
+++ b/Bonsai.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai", "Bonsai\Bonsai.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Editor", "Bonsai.Editor\Bonsai.Editor.csproj", "{C7FDC11D-066A-4B2B-9A52-27A5E793BEFB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Editor.Tests", "Bonsai.Editor.Tests\Bonsai.Editor.Tests.csproj", "{AA001CB8-FB7C-4D4A-8710-47363CA39016}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Vision", "Bonsai.Vision\Bonsai.Vision.csproj", "{C226E461-6A82-49A7-9CAF-0CF872A1C91B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Design", "Bonsai.Design\Bonsai.Design.csproj", "{765D928A-B147-46FF-8A59-BDE73F88A844}"
@@ -102,6 +104,18 @@ Global
 		{C7FDC11D-066A-4B2B-9A52-27A5E793BEFB}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{C7FDC11D-066A-4B2B-9A52-27A5E793BEFB}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{C7FDC11D-066A-4B2B-9A52-27A5E793BEFB}.Release|x64.ActiveCfg = Release|Any CPU
+		{AA001CB8-FB7C-4D4A-8710-47363CA39016}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA001CB8-FB7C-4D4A-8710-47363CA39016}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA001CB8-FB7C-4D4A-8710-47363CA39016}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{AA001CB8-FB7C-4D4A-8710-47363CA39016}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{AA001CB8-FB7C-4D4A-8710-47363CA39016}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AA001CB8-FB7C-4D4A-8710-47363CA39016}.Debug|x64.Build.0 = Debug|Any CPU
+		{AA001CB8-FB7C-4D4A-8710-47363CA39016}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA001CB8-FB7C-4D4A-8710-47363CA39016}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA001CB8-FB7C-4D4A-8710-47363CA39016}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{AA001CB8-FB7C-4D4A-8710-47363CA39016}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{AA001CB8-FB7C-4D4A-8710-47363CA39016}.Release|x64.ActiveCfg = Release|Any CPU
+		{AA001CB8-FB7C-4D4A-8710-47363CA39016}.Release|x64.Build.0 = Release|Any CPU
 		{C226E461-6A82-49A7-9CAF-0CF872A1C91B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C226E461-6A82-49A7-9CAF-0CF872A1C91B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C226E461-6A82-49A7-9CAF-0CF872A1C91B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU

--- a/Bonsai32/Bonsai32.csproj
+++ b/Bonsai32/Bonsai32.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <TargetFramework>net472</TargetFramework>
     <PlatformTarget>x86</PlatformTarget>
-    <VersionPrefix>2.7.2</VersionPrefix>
+    <VersionPrefix>2.8.0</VersionPrefix>
     <OutputType>Exe</OutputType>
     <OutputPath>..\Bonsai\bin\$(Configuration)\</OutputPath>
     <ApplicationIcon>..\Bonsai.Editor\Bonsai.ico</ApplicationIcon>


### PR DESCRIPTION
This PR refactors the workflow graph representation as a collection where nodes can be individually accessed by index. This allows much faster reordering of workflow nodes, and enables ordered insertion at cursor position.

It also lays down the foundation for interpreting the workflow directly as an expression tree, where the roots are sinks, i.e. nodes with no successors, and leaves are sources.

Branch points are interpreted as anonymous scoped publish operators. The publish closure for each branch is resolved by taking the smallest subset of nodes dependent on the branching source. A node is dependent on a branching source if it lies on a direct dependency path from the node to the source, and there exists at least one other node in the workflow which also lies in a direct dependency path to the same branching source, and there are no shared nodes between the two paths except for the branching source itself.

In other words, a publish branch is closed when all branches are merged back to a common trunk. If there is no such common trunk, the branch is closed around the connected set of nodes to which the branch belongs. Nodes belonging to disjoint sets are not affected by this branching behavior.

Fixes #1014
Fixes #1129 
Fixes #1317 
Fixes #1345 