### PR TITLE
Add support for in-editor docs browser

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -30,6 +30,7 @@ namespace Bonsai.Editor
     public partial class EditorForm : Form
     {
         const float DefaultEditorScale = 1.0f;
+        const string EditorUid = "editor";
         const string BonsaiExtension = ".bonsai";
         const string BonsaiPackageName = "Bonsai";
         const string ExtensionsDirectory = "Extensions";
@@ -2323,7 +2324,7 @@ namespace Bonsai.Editor
                         var categoryName = GetPackageDisplayName(uid.Substring(0, nameSeparator));
                         editorControl.ExpandWebView(label: $"{name} ({categoryName})");
                     }
-                    else editorControl.ExpandWebView(label: uid);
+                    else editorControl.ExpandWebView(label: uid == EditorUid ? Resources.Editor_HelpLabel : uid);
                 }
                 else EditorDialog.OpenUrl(url);
             }
@@ -2388,7 +2389,8 @@ namespace Bonsai.Editor
                 }
             }
 
-            EditorDialog.ShowDocs();
+            var editorAssemblyName = GetType().Assembly.GetName().Name;
+            await OpenDocumentationAsync(editorAssemblyName, EditorUid);
         }
 
         private void forumToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2331,6 +2331,11 @@ namespace Bonsai.Editor
 
         private async Task OpenDocumentationAsync(Type type)
         {
+            if (type.IsGenericType && !type.IsGenericTypeDefinition)
+            {
+                type = type.GetGenericTypeDefinition();
+            }
+
             var uid = type.FullName;
             var assemblyName = type.Assembly.GetName().Name;
             await OpenDocumentationAsync(assemblyName, uid);

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2001,6 +2001,7 @@ namespace Bonsai.Editor
                             renameSubjectToolStripMenuItem.Visible = false;
                             goToDefinitionToolStripMenuItem.Visible = false;
                             insertBeforeToolStripMenuItem.Visible = true;
+                            toolboxDocsToolStripMenuItem.Visible = true;
                         }
                         toolboxContextMenuStrip.Show(toolboxTreeView, e.X, e.Y);
                     }

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -254,11 +254,15 @@ namespace Bonsai.Editor
 
             WindowState = EditorSettings.Instance.WindowState;
             themeRenderer.ActiveTheme = EditorSettings.Instance.EditorTheme;
+            editorControl.WebViewSplitterDistance = (int)Math.Round(
+                EditorSettings.Instance.WebViewSize * scaleFactor.Width);
         }
 
         void CloseEditorForm()
         {
             Application.RemoveMessageFilter(hotKeys);
+            EditorSettings.Instance.WebViewSize = (int)Math.Round(
+                editorControl.WebViewSplitterDistance * inverseScaleFactor.Width);
             var desktopBounds = WindowState != FormWindowState.Normal ? RestoreBounds : Bounds;
             EditorSettings.Instance.DesktopBounds = ScaleBounds(desktopBounds, inverseScaleFactor);
             if (WindowState == FormWindowState.Minimized)

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2346,8 +2346,14 @@ namespace Bonsai.Editor
 
             try
             {
+                var editorControl = selectionModel.SelectedView.EditorControl;
                 var url = await documentationProvider.GetDocumentationAsync(assemblyName, uid);
-                EditorDialog.OpenUrl(url);
+                if (editorControl.WebViewInitialized)
+                {
+                    editorControl.WebView.CoreWebView2.Navigate(url.AbsoluteUri);
+                    editorControl.ExpandWebView();
+                }
+                else EditorDialog.OpenUrl(url);
             }
             catch (ArgumentException ex) when (ex.ParamName == nameof(assemblyName))
             {

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2353,7 +2353,7 @@ namespace Bonsai.Editor
             {
                 var editorControl = selectionModel.SelectedView.EditorControl;
                 var url = await documentationProvider.GetDocumentationAsync(assemblyName, uid);
-                if (editorControl.WebViewInitialized)
+                if (!ModifierKeys.HasFlag(Keys.Control) && editorControl.WebViewInitialized)
                 {
                     editorControl.WebView.CoreWebView2.Navigate(url.AbsoluteUri);
                     editorControl.ExpandWebView();
@@ -2383,7 +2383,7 @@ namespace Bonsai.Editor
 
         private async void docsToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (ModifierKeys != Keys.None)
+            if (ModifierKeys != Keys.None && ModifierKeys != Keys.Control)
             {
                 return;
             }

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -254,7 +254,7 @@ namespace Bonsai.Editor
 
             WindowState = EditorSettings.Instance.WindowState;
             themeRenderer.ActiveTheme = EditorSettings.Instance.EditorTheme;
-            editorControl.WebViewSplitterDistance = (int)Math.Round(
+            editorControl.WebViewSize = (int)Math.Round(
                 EditorSettings.Instance.WebViewSize * scaleFactor.Width);
         }
 
@@ -262,7 +262,7 @@ namespace Bonsai.Editor
         {
             Application.RemoveMessageFilter(hotKeys);
             EditorSettings.Instance.WebViewSize = (int)Math.Round(
-                editorControl.WebViewSplitterDistance * inverseScaleFactor.Width);
+                editorControl.WebViewSize * inverseScaleFactor.Width);
             var desktopBounds = WindowState != FormWindowState.Normal ? RestoreBounds : Bounds;
             EditorSettings.Instance.DesktopBounds = ScaleBounds(desktopBounds, inverseScaleFactor);
             if (WindowState == FormWindowState.Minimized)

--- a/Bonsai.Editor/EditorSettings.cs
+++ b/Bonsai.Editor/EditorSettings.cs
@@ -12,17 +12,6 @@ namespace Bonsai.Editor
     sealed class EditorSettings
     {
         const int MaxRecentFiles = 25;
-        const string RecentlyUsedFilesElement = "RecentlyUsedFiles";
-        const string DesktopBoundsElement = "DesktopBounds";
-        const string WindowStateElement = "WindowState";
-        const string RecentlyUsedFileElement = "RecentlyUsedFile";
-        const string FileTimestampElement = "Timestamp";
-        const string FileNameElement = "Name";
-        const string RectangleXElement = "X";
-        const string RectangleYElement = "Y";
-        const string RectangleWidthElement = "Width";
-        const string RectangleHeightElement = "Height";
-        const string EditorThemeElement = "EditorTheme";
         const string SettingsFileName = "Bonsai.exe.settings";
         static readonly string SettingsPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), SettingsFileName);
         static readonly Lazy<EditorSettings> instance = new Lazy<EditorSettings>(Load);
@@ -62,39 +51,39 @@ namespace Bonsai.Editor
                         while (reader.Read())
                         {
                             if (reader.NodeType != XmlNodeType.Element) continue;
-                            if (reader.Name == WindowStateElement)
+                            if (reader.Name == nameof(WindowState))
                             {
                                 Enum.TryParse(reader.ReadElementContentAsString(), out FormWindowState windowState);
                                 settings.WindowState = windowState;
                             }
-                            else if (reader.Name == EditorThemeElement)
+                            else if (reader.Name == nameof(EditorTheme))
                             {
                                 Enum.TryParse(reader.ReadElementContentAsString(), out ColorTheme editorTheme);
                                 settings.EditorTheme = editorTheme;
                             }
-                            else if (reader.Name == DesktopBoundsElement)
+                            else if (reader.Name == nameof(DesktopBounds))
                             {
-                                reader.ReadToFollowing(RectangleXElement);
+                                reader.ReadToFollowing(nameof(Rectangle.X));
                                 int.TryParse(reader.ReadElementContentAsString(), out int x);
-                                reader.ReadToFollowing(RectangleYElement);
+                                reader.ReadToFollowing(nameof(Rectangle.Y));
                                 int.TryParse(reader.ReadElementContentAsString(), out int y);
-                                reader.ReadToFollowing(RectangleWidthElement);
+                                reader.ReadToFollowing(nameof(Rectangle.Width));
                                 int.TryParse(reader.ReadElementContentAsString(), out int width);
-                                reader.ReadToFollowing(RectangleHeightElement);
+                                reader.ReadToFollowing(nameof(Rectangle.Height));
                                 int.TryParse(reader.ReadElementContentAsString(), out int height);
                                 settings.DesktopBounds = new Rectangle(x, y, width, height);
                             }
-                            else if (reader.Name == RecentlyUsedFilesElement)
+                            else if (reader.Name == nameof(RecentlyUsedFiles))
                             {
                                 var fileReader = reader.ReadSubtree();
-                                while (fileReader.ReadToFollowing(RecentlyUsedFileElement))
+                                while (fileReader.ReadToFollowing(nameof(RecentlyUsedFile)))
                                 {
-                                    if (fileReader.Name == RecentlyUsedFileElement)
+                                    if (fileReader.Name == nameof(RecentlyUsedFile))
                                     {
                                         string fileName;
-                                        fileReader.ReadToFollowing(FileTimestampElement);
+                                        fileReader.ReadToFollowing(nameof(RecentlyUsedFile.Timestamp));
                                         DateTimeOffset.TryParse(fileReader.ReadElementContentAsString(), out DateTimeOffset timestamp);
-                                        fileReader.ReadToFollowing(FileNameElement);
+                                        fileReader.ReadToFollowing(nameof(RecentlyUsedFile.Name));
                                         fileName = fileReader.ReadElementContentAsString();
                                         settings.recentlyUsedFiles.Add(timestamp, fileName);
                                     }
@@ -114,24 +103,24 @@ namespace Bonsai.Editor
             using (var writer = XmlWriter.Create(SettingsPath, new XmlWriterSettings { Indent = true }))
             {
                 writer.WriteStartElement(typeof(EditorSettings).Name);
-                writer.WriteElementString(WindowStateElement, WindowState.ToString());
-                writer.WriteElementString(EditorThemeElement, EditorTheme.ToString());
+                writer.WriteElementString(nameof(WindowState), WindowState.ToString());
+                writer.WriteElementString(nameof(EditorTheme), EditorTheme.ToString());
 
-                writer.WriteStartElement(DesktopBoundsElement);
-                writer.WriteElementString(RectangleXElement, DesktopBounds.X.ToString(CultureInfo.InvariantCulture));
-                writer.WriteElementString(RectangleYElement, DesktopBounds.Y.ToString(CultureInfo.InvariantCulture));
-                writer.WriteElementString(RectangleWidthElement, DesktopBounds.Width.ToString(CultureInfo.InvariantCulture));
-                writer.WriteElementString(RectangleHeightElement, DesktopBounds.Height.ToString(CultureInfo.InvariantCulture));
+                writer.WriteStartElement(nameof(DesktopBounds));
+                writer.WriteElementString(nameof(Rectangle.X), DesktopBounds.X.ToString(CultureInfo.InvariantCulture));
+                writer.WriteElementString(nameof(Rectangle.Y), DesktopBounds.Y.ToString(CultureInfo.InvariantCulture));
+                writer.WriteElementString(nameof(Rectangle.Width), DesktopBounds.Width.ToString(CultureInfo.InvariantCulture));
+                writer.WriteElementString(nameof(Rectangle.Height), DesktopBounds.Height.ToString(CultureInfo.InvariantCulture));
                 writer.WriteEndElement();
 
                 if (recentlyUsedFiles.Count > 0)
                 {
-                    writer.WriteStartElement(RecentlyUsedFilesElement);
+                    writer.WriteStartElement(nameof(RecentlyUsedFiles));
                     foreach (var file in recentlyUsedFiles)
                     {
-                        writer.WriteStartElement(RecentlyUsedFileElement);
-                        writer.WriteElementString(FileTimestampElement, file.Timestamp.ToString("o"));
-                        writer.WriteElementString(FileNameElement, file.FileName);
+                        writer.WriteStartElement(nameof(RecentlyUsedFile));
+                        writer.WriteElementString(nameof(RecentlyUsedFile.Timestamp), file.Timestamp.ToString("o"));
+                        writer.WriteElementString(nameof(RecentlyUsedFile.Name), file.FileName);
                         writer.WriteEndElement();
                     }
                     writer.WriteEndElement();

--- a/Bonsai.Editor/EditorSettings.cs
+++ b/Bonsai.Editor/EditorSettings.cs
@@ -33,6 +33,8 @@ namespace Bonsai.Editor
 
         public ColorTheme EditorTheme { get; set; }
 
+        public int WebViewSize { get; set; }
+
         public RecentlyUsedFileCollection RecentlyUsedFiles
         {
             get { return recentlyUsedFiles; }
@@ -60,6 +62,11 @@ namespace Bonsai.Editor
                             {
                                 Enum.TryParse(reader.ReadElementContentAsString(), out ColorTheme editorTheme);
                                 settings.EditorTheme = editorTheme;
+                            }
+                            else if (reader.Name == nameof(WebViewSize))
+                            {
+                                int.TryParse(reader.ReadElementContentAsString(), out int webViewSize);
+                                settings.WebViewSize = webViewSize;
                             }
                             else if (reader.Name == nameof(DesktopBounds))
                             {
@@ -105,6 +112,7 @@ namespace Bonsai.Editor
                 writer.WriteStartElement(typeof(EditorSettings).Name);
                 writer.WriteElementString(nameof(WindowState), WindowState.ToString());
                 writer.WriteElementString(nameof(EditorTheme), EditorTheme.ToString());
+                writer.WriteElementString(nameof(WebViewSize), WebViewSize.ToString(CultureInfo.InvariantCulture));
 
                 writer.WriteStartElement(nameof(DesktopBounds));
                 writer.WriteElementString(nameof(Rectangle.X), DesktopBounds.X.ToString(CultureInfo.InvariantCulture));

--- a/Bonsai.Editor/EditorSettings.cs
+++ b/Bonsai.Editor/EditorSettings.cs
@@ -20,6 +20,7 @@ namespace Bonsai.Editor
 
         internal EditorSettings()
         {
+            WebViewSize = 400;
         }
 
         public static EditorSettings Instance

--- a/Bonsai.Editor/GraphModel/ElementHelper.cs
+++ b/Bonsai.Editor/GraphModel/ElementHelper.cs
@@ -1,0 +1,57 @@
+﻿using System.ComponentModel;
+using Bonsai.Expressions;
+
+namespace Bonsai.Editor.GraphModel
+{
+    static class ElementHelper
+    {
+        public static string GetElementName(object component)
+        {
+            var name = ExpressionBuilder.GetElementDisplayName(component);
+            if (component is ExternalizedProperty workflowProperty &&
+                !string.IsNullOrWhiteSpace(workflowProperty.Name) &&
+                workflowProperty.Name != workflowProperty.MemberName)
+            {
+                return name + " (" + workflowProperty.MemberName + ")";
+            }
+
+            var componentType = component.GetType();
+            if (component is BinaryOperatorBuilder binaryOperator && binaryOperator.Operand != null)
+            {
+                var operandType = binaryOperator.Operand.GetType();
+                if (operandType.IsGenericType) operandType = operandType.GetGenericArguments()[0];
+                return name + " (" + ExpressionBuilder.GetElementDisplayName(operandType) + ")";
+            }
+            else if (component is SubscribeSubject subscribeSubject && componentType.IsGenericType)
+            {
+                componentType = componentType.GetGenericArguments()[0];
+                if (string.IsNullOrWhiteSpace(subscribeSubject.Name))
+                {
+                    name = name.Substring(0, name.IndexOf("`"));
+                }
+                return name + " (" + ExpressionBuilder.GetElementDisplayName(componentType) + ")";
+            }
+            else
+            {
+                if (component is INamedElement namedExpressionBuilder && !string.IsNullOrWhiteSpace(namedExpressionBuilder.Name))
+                {
+                    name += " (" + ExpressionBuilder.GetElementDisplayName(componentType) + ")";
+                }
+
+                return name;
+            }
+        }
+
+        public static string GetElementDescription(object component)
+        {
+            if (component is WorkflowExpressionBuilder workflowExpressionBuilder)
+            {
+                var description = workflowExpressionBuilder.Description;
+                if (!string.IsNullOrEmpty(description)) return description;
+            }
+
+            var descriptionAttribute = (DescriptionAttribute)TypeDescriptor.GetAttributes(component)[typeof(DescriptionAttribute)];
+            return descriptionAttribute.Description;
+        }
+    }
+}

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.Designer.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.Designer.cs
@@ -96,6 +96,7 @@
             this.splitContainer.SplitterDistance = 300;
             this.splitContainer.SplitterWidth = 3;
             this.splitContainer.TabIndex = 1;
+            this.splitContainer.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.splitContainer_SplitterMoved);
             // 
             // tabControl
             // 

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.Designer.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.Designer.cs
@@ -93,7 +93,7 @@
             // 
             this.splitContainer.Panel2.Controls.Add(this.tabControl);
             this.splitContainer.Size = new System.Drawing.Size(300, 200);
-            this.splitContainer.SplitterDistance = 100;
+            this.splitContainer.SplitterDistance = 300;
             this.splitContainer.SplitterWidth = 3;
             this.splitContainer.TabIndex = 1;
             // 

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.Designer.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.Designer.cs
@@ -33,16 +33,22 @@
             this.closeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.closeAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.splitContainer = new System.Windows.Forms.SplitContainer();
-            this.webView = new Microsoft.Web.WebView2.WinForms.WebView2();
             this.tabControl = new Bonsai.Editor.GraphView.WorkflowEditorTabControl();
             this.workflowTabPage = new System.Windows.Forms.TabPage();
+            this.browserLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.webView = new Microsoft.Web.WebView2.WinForms.WebView2();
+            this.browserTitlePanel = new System.Windows.Forms.Panel();
+            this.closeBrowserButton = new System.Windows.Forms.Button();
+            this.browserLabel = new System.Windows.Forms.Label();
             this.tabContextMenuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).BeginInit();
             this.splitContainer.Panel1.SuspendLayout();
             this.splitContainer.Panel2.SuspendLayout();
             this.splitContainer.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.webView)).BeginInit();
             this.tabControl.SuspendLayout();
+            this.browserLayoutPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.webView)).BeginInit();
+            this.browserTitlePanel.SuspendLayout();
             this.SuspendLayout();
             // 
             // tabContextMenuStrip
@@ -76,34 +82,20 @@
             this.splitContainer.Location = new System.Drawing.Point(0, 0);
             this.splitContainer.Margin = new System.Windows.Forms.Padding(2);
             this.splitContainer.Name = "splitContainer";
-            this.splitContainer.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            this.splitContainer.Orientation = System.Windows.Forms.Orientation.Vertical;
             // 
             // splitContainer.Panel1
             // 
-            this.splitContainer.Panel1.Controls.Add(this.tabControl);
+            this.splitContainer.Panel1.Controls.Add(this.browserLayoutPanel);
+            this.splitContainer.Panel1Collapsed = true;
             // 
             // splitContainer.Panel2
             // 
-            this.splitContainer.Panel2.Controls.Add(this.webView);
-            this.splitContainer.Panel2Collapsed = true;
+            this.splitContainer.Panel2.Controls.Add(this.tabControl);
             this.splitContainer.Size = new System.Drawing.Size(300, 200);
             this.splitContainer.SplitterDistance = 100;
             this.splitContainer.SplitterWidth = 3;
             this.splitContainer.TabIndex = 1;
-            // 
-            // webView
-            // 
-            this.webView.AllowExternalDrop = true;
-            this.webView.CreationProperties = null;
-            this.webView.DefaultBackgroundColor = System.Drawing.Color.White;
-            this.webView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.webView.Location = new System.Drawing.Point(0, 0);
-            this.webView.Margin = new System.Windows.Forms.Padding(2);
-            this.webView.Name = "webView";
-            this.webView.Size = new System.Drawing.Size(300, 97);
-            this.webView.TabIndex = 0;
-            this.webView.ZoomFactor = 1D;
-            this.webView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.webView_KeyDown);
             // 
             // tabControl
             // 
@@ -126,10 +118,77 @@
             this.workflowTabPage.Location = new System.Drawing.Point(4, 28);
             this.workflowTabPage.Name = "workflowTabPage";
             this.workflowTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.workflowTabPage.Size = new System.Drawing.Size(292, 168);
+            this.workflowTabPage.Size = new System.Drawing.Size(292, 68);
             this.workflowTabPage.TabIndex = 0;
             this.workflowTabPage.Text = "Workflow";
             this.workflowTabPage.UseVisualStyleBackColor = true;
+            // 
+            // browserLayoutPanel
+            // 
+            this.browserLayoutPanel.ColumnCount = 1;
+            this.browserLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.browserLayoutPanel.Controls.Add(this.webView, 0, 1);
+            this.browserLayoutPanel.Controls.Add(this.browserTitlePanel, 0, 0);
+            this.browserLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.browserLayoutPanel.Location = new System.Drawing.Point(0, 0);
+            this.browserLayoutPanel.Name = "browserLayoutPanel";
+            this.browserLayoutPanel.RowCount = 2;
+            this.browserLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 23F));
+            this.browserLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.browserLayoutPanel.Size = new System.Drawing.Size(300, 97);
+            this.browserLayoutPanel.TabIndex = 1;
+            // 
+            // webView
+            // 
+            this.webView.AllowExternalDrop = true;
+            this.webView.CreationProperties = null;
+            this.webView.DefaultBackgroundColor = System.Drawing.Color.White;
+            this.webView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.webView.Location = new System.Drawing.Point(2, 25);
+            this.webView.Margin = new System.Windows.Forms.Padding(2);
+            this.webView.Name = "webView";
+            this.webView.Size = new System.Drawing.Size(296, 70);
+            this.webView.TabIndex = 0;
+            this.webView.ZoomFactor = 1D;
+            this.webView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.webView_KeyDown);
+            // 
+            // browserTitlePanel
+            // 
+            this.browserTitlePanel.Controls.Add(this.closeBrowserButton);
+            this.browserTitlePanel.Controls.Add(this.browserLabel);
+            this.browserTitlePanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.browserTitlePanel.Location = new System.Drawing.Point(0, 0);
+            this.browserTitlePanel.Margin = new System.Windows.Forms.Padding(0);
+            this.browserTitlePanel.Name = "browserTitlePanel";
+            this.browserTitlePanel.Size = new System.Drawing.Size(300, 23);
+            this.browserTitlePanel.TabIndex = 1;
+            // 
+            // closeBrowserButton
+            // 
+            this.closeBrowserButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.closeBrowserButton.BackColor = System.Drawing.SystemColors.ScrollBar;
+            this.closeBrowserButton.FlatAppearance.BorderSize = 0;
+            this.closeBrowserButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.closeBrowserButton.Location = new System.Drawing.Point(271, 0);
+            this.closeBrowserButton.Name = "closeBrowserButton";
+            this.closeBrowserButton.Size = new System.Drawing.Size(25, 23);
+            this.closeBrowserButton.TabIndex = 5;
+            this.closeBrowserButton.Text = "✕";
+            this.closeBrowserButton.UseVisualStyleBackColor = false;
+            this.closeBrowserButton.Click += new System.EventHandler(this.closeBrowserButton_Click);
+            // 
+            // browserLabel
+            // 
+            this.browserLabel.BackColor = System.Drawing.SystemColors.ScrollBar;
+            this.browserLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.browserLabel.Location = new System.Drawing.Point(0, 0);
+            this.browserLabel.Margin = new System.Windows.Forms.Padding(0, 0, 3, 0);
+            this.browserLabel.Name = "browserLabel";
+            this.browserLabel.Size = new System.Drawing.Size(300, 23);
+            this.browserLabel.TabIndex = 4;
+            this.browserLabel.Text = "Browser";
+            this.browserLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // WorkflowEditorControl
             // 
@@ -144,8 +203,10 @@
             this.splitContainer.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).EndInit();
             this.splitContainer.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.webView)).EndInit();
             this.tabControl.ResumeLayout(false);
+            this.browserLayoutPanel.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.webView)).EndInit();
+            this.browserTitlePanel.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -159,5 +220,9 @@
         private System.Windows.Forms.ToolStripMenuItem closeAllToolStripMenuItem;
         private System.Windows.Forms.SplitContainer splitContainer;
         private Microsoft.Web.WebView2.WinForms.WebView2 webView;
+        private System.Windows.Forms.TableLayoutPanel browserLayoutPanel;
+        private System.Windows.Forms.Panel browserTitlePanel;
+        private System.Windows.Forms.Button closeBrowserButton;
+        private System.Windows.Forms.Label browserLabel;
     }
 }

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -87,6 +87,7 @@ namespace Bonsai.Editor.GraphView
         {
             browserLabel.Text = label;
             splitContainer.Panel1Collapsed = false;
+            EnsureWebViewSize();
         }
 
         public void CollapseWebView()
@@ -264,6 +265,12 @@ namespace Bonsai.Editor.GraphView
             base.OnLoad(e);
         }
 
+        protected override void OnSizeChanged(EventArgs e)
+        {
+            EnsureWebViewSize();
+            base.OnSizeChanged(e);
+        }
+
         protected override void OnKeyDown(KeyEventArgs e)
         {
             editorService.OnKeyDown(e);
@@ -436,6 +443,21 @@ namespace Bonsai.Editor.GraphView
                 var adjustH = displayX - marginLeft - 1;
                 var adjustV = displayX - marginTop - displayX / 2 - 1;
                 adjustMargin = new Padding(adjustH, adjustV, adjustH, adjustH);
+            }
+            splitContainer.SplitterDistance = (int)Math.Round(splitContainer.SplitterDistance * factor.Width);
+            splitContainer.Panel1MinSize = splitContainer.SplitterDistance / 2;
+            splitContainer.FixedPanel = FixedPanel.Panel1;
+        }
+
+        private void EnsureWebViewSize()
+        {
+            if (splitContainer.FixedPanel != FixedPanel.None)
+            {
+                if (Width < 4 * splitContainer.Panel1MinSize)
+                {
+                    splitContainer.SplitterDistance = Width / 2;
+                }
+                else splitContainer.SplitterDistance = 2 * splitContainer.Panel1MinSize - splitContainer.SplitterWidth;
             }
         }
 

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -65,6 +65,12 @@ namespace Bonsai.Editor.GraphView
             get { return splitContainer.Panel1Collapsed; }
         }
 
+        public int WebViewSplitterDistance
+        {
+            get { return splitContainer.SplitterDistance; }
+            set { splitContainer.SplitterDistance = value; }
+        }
+
         public VisualizerLayout VisualizerLayout
         {
             get { return WorkflowGraphView.VisualizerLayout; }

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -7,6 +7,7 @@ using Bonsai.Design;
 using Bonsai.Editor.Themes;
 using Microsoft.Web.WebView2.WinForms;
 using Microsoft.Web.WebView2.Core;
+using Bonsai.Editor.GraphModel;
 
 namespace Bonsai.Editor.GraphView
 {
@@ -76,16 +77,16 @@ namespace Bonsai.Editor.GraphView
             set { WorkflowGraphView.Workflow = value; }
         }
 
-        public void ExpandWebView()
-        {
-            splitContainer.Panel1Collapsed = false;
-        }
-
         public void ExpandWebView(ExpressionBuilder builder)
         {
             webView.Tag = builder;
-            browserLabel.Text = $"Browser ({ExpressionBuilder.GetElementDisplayName(builder)})";
-            ExpandWebView();
+            ExpandWebView(ElementHelper.GetElementName(builder));
+        }
+
+        public void ExpandWebView(string label)
+        {
+            browserLabel.Text = label;
+            splitContainer.Panel1Collapsed = false;
         }
 
         public void CollapseWebView()

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -65,10 +65,14 @@ namespace Bonsai.Editor.GraphView
             get { return splitContainer.Panel1Collapsed; }
         }
 
-        public int WebViewSplitterDistance
+        public int WebViewSize
         {
             get { return splitContainer.SplitterDistance; }
-            set { splitContainer.SplitterDistance = value; }
+            set
+            {
+                splitContainer.SplitterDistance = value;
+                splitContainer.Panel1MinSize = splitContainer.SplitterDistance / 2;
+            }
         }
 
         public VisualizerLayout VisualizerLayout
@@ -450,8 +454,7 @@ namespace Bonsai.Editor.GraphView
                 var adjustV = displayX - marginTop - displayX / 2 - 1;
                 adjustMargin = new Padding(adjustH, adjustV, adjustH, adjustH);
             }
-            splitContainer.SplitterDistance = (int)Math.Round(splitContainer.SplitterDistance * factor.Width);
-            splitContainer.Panel1MinSize = splitContainer.SplitterDistance / 2;
+            WebViewSize = (int)Math.Round(splitContainer.SplitterDistance * factor.Width);
             splitContainer.FixedPanel = FixedPanel.Panel1;
         }
 
@@ -469,6 +472,15 @@ namespace Bonsai.Editor.GraphView
                         2 * splitContainer.Panel1MinSize - splitContainer.SplitterWidth,
                         splitContainer.SplitterDistance);
                 }
+            }
+        }
+
+        private void splitContainer_SplitterMoved(object sender, SplitterEventArgs e)
+        {
+            var delta = PointToClient(MousePosition).X - e.X;
+            if (delta == 0)
+            {
+                WebViewSize = e.SplitX;
             }
         }
 

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -71,7 +71,7 @@ namespace Bonsai.Editor.GraphView
             set
             {
                 splitContainer.SplitterDistance = value;
-                splitContainer.Panel1MinSize = splitContainer.SplitterDistance / 2;
+                splitContainer.Panel1MinSize = value / 2;
             }
         }
 
@@ -277,8 +277,8 @@ namespace Bonsai.Editor.GraphView
 
         protected override void OnSizeChanged(EventArgs e)
         {
-            EnsureWebViewSize();
             base.OnSizeChanged(e);
+            EnsureWebViewSize();
         }
 
         protected override void OnKeyDown(KeyEventArgs e)

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -57,7 +57,7 @@ namespace Bonsai.Editor.GraphView
 
         public bool WebViewCollapsed
         {
-            get { return splitContainer.Panel2Collapsed; }
+            get { return splitContainer.Panel1Collapsed; }
         }
 
         public VisualizerLayout VisualizerLayout
@@ -74,12 +74,19 @@ namespace Bonsai.Editor.GraphView
 
         public void ExpandWebView()
         {
-            splitContainer.Panel2Collapsed = false;
+            splitContainer.Panel1Collapsed = false;
+        }
+
+        public void ExpandWebView(ExpressionBuilder builder)
+        {
+            webView.Tag = builder;
+            browserLabel.Text = $"Browser ({ExpressionBuilder.GetElementDisplayName(builder)})";
+            ExpandWebView();
         }
 
         public void CollapseWebView()
         {
-            splitContainer.Panel2Collapsed = true;
+            splitContainer.Panel1Collapsed = true;
             webView.Tag = null;
         }
 
@@ -462,6 +469,11 @@ namespace Bonsai.Editor.GraphView
                         break;
                 }
             }
+        }
+
+        private void closeBrowserButton_Click(object sender, EventArgs e)
+        {
+            CollapseWebView();
         }
     }
 }

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -472,6 +472,13 @@ namespace Bonsai.Editor.GraphView
             else adjustRectangle.Bottom = adjustRectangle.Left;
             tabControl.AdjustRectangle = adjustRectangle;
 
+            var labelOffset = browserLabel.Height - ItemHeight + 1;
+            if (themeRenderer.ActiveTheme == ColorTheme.Light && labelOffset < 0)
+            {
+                labelOffset += 1;
+            }
+            browserLayoutPanel.RowStyles[0].Height -= labelOffset;
+
             var colorTable = themeRenderer.ToolStripRenderer.ColorTable;
             browserLabel.BackColor = closeBrowserButton.BackColor = colorTable.SeparatorDark;
             browserLabel.ForeColor = closeBrowserButton.ForeColor = colorTable.ControlForeColor;

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -457,7 +457,12 @@ namespace Bonsai.Editor.GraphView
                 {
                     splitContainer.SplitterDistance = Width / 2;
                 }
-                else splitContainer.SplitterDistance = 2 * splitContainer.Panel1MinSize - splitContainer.SplitterWidth;
+                else
+                {
+                    splitContainer.SplitterDistance = Math.Max(
+                        2 * splitContainer.Panel1MinSize - splitContainer.SplitterWidth,
+                        splitContainer.SplitterDistance);
+                }
             }
         }
 

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -484,8 +484,7 @@ namespace Bonsai.Editor.GraphView
             {
                 var html = MarkdownConvert.ToHtml(Font, annotationBuilder.Text);
                 EditorControl.WebView.NavigateToString(html);
-                EditorControl.WebView.Tag = annotationBuilder;
-                EditorControl.ExpandWebView();
+                EditorControl.ExpandWebView(annotationBuilder);
                 return;
             }
 

--- a/Bonsai.Editor/Properties/Resources.Designer.cs
+++ b/Bonsai.Editor/Properties/Resources.Designer.cs
@@ -193,6 +193,15 @@ namespace Bonsai.Editor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Help.
+        /// </summary>
+        internal static string Editor_HelpLabel {
+            get {
+                return ResourceManager.GetString("Editor_HelpLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The workflow needs to be saved before proceeding. Do you want to save the workflow?.
         /// </summary>
         internal static string EnsureSavedWorkflow_Question {

--- a/Bonsai.Editor/Properties/Resources.resx
+++ b/Bonsai.Editor/Properties/Resources.resx
@@ -338,4 +338,7 @@ NOTE: You will have to restart Bonsai for any changes to take effect.</value>
   <data name="SubjectDefinitionNotFound_Error" xml:space="preserve">
     <value>The specified subject definition could not be found.</value>
   </data>
+  <data name="Editor_HelpLabel" xml:space="preserve">
+    <value>Help</value>
+  </data>
 </root>

--- a/Bonsai.Editor/RecentlyUsedFile.cs
+++ b/Bonsai.Editor/RecentlyUsedFile.cs
@@ -16,6 +16,8 @@ namespace Bonsai.Editor
         public DateTimeOffset Timestamp { get; private set; }
 
         public string FileName { get; private set; }
+
+        internal string Name => FileName;
     }
 
     class RecentlyUsedFileCollection : IEnumerable<RecentlyUsedFile>


### PR DESCRIPTION
This PR extends the WebView panel functionality used to render annotations to support in-editor browsing of operator documentation. This allows for convenient access to technical references and tutorial examples rendered inline with the workflow.

Support for setting a preferred browser color theme is provided, although it is up to the docs website to support theming. Access to browsing the docs outside of the editor is still supported by using the `Ctrl` modifier, e.g. `Ctrl+F1` will open the docs for the relevant operator in a new external browser tab.

Fixes #1208 