### PR TITLE
Improved support for editing annotations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,10 @@ indent_size = 2
 [*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
 indent_size = 2
 
+# HTML / CSS files
+[*.{html,css}]
+indent_size = 2
+
 # Code files
 [*.{cs,csx}]
 indent_size = 4

--- a/Bonsai.Core/Expressions/AnnotationBuilder.cs
+++ b/Bonsai.Core/Expressions/AnnotationBuilder.cs
@@ -35,6 +35,7 @@ namespace Bonsai.Expressions
         [Externalizable(false)]
         [Category(nameof(CategoryAttribute.Design))]
         [Description("The text associated with this annotation.")]
+        [Editor("Bonsai.Design.AnnotationTextEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         public string Text { get; set; }
 
         /// <summary>

--- a/Bonsai.Design/AnnotationBuilderEditorDialog.Designer.cs
+++ b/Bonsai.Design/AnnotationBuilderEditorDialog.Designer.cs
@@ -41,7 +41,7 @@
             this.scintilla.Location = new System.Drawing.Point(12, 12);
             this.scintilla.Name = "scintilla";
             this.scintilla.Size = new System.Drawing.Size(600, 229);
-            this.scintilla.TabIndex = 3;
+            this.scintilla.TabIndex = 1;
             this.scintilla.TabWidth = 2;
             this.scintilla.UseTabs = false;
             this.scintilla.WrapMode = ScintillaNET.WrapMode.Word;
@@ -55,7 +55,7 @@
             this.okButton.Location = new System.Drawing.Point(456, 247);
             this.okButton.Name = "okButton";
             this.okButton.Size = new System.Drawing.Size(75, 23);
-            this.okButton.TabIndex = 1;
+            this.okButton.TabIndex = 2;
             this.okButton.Text = "OK";
             this.okButton.UseVisualStyleBackColor = true;
             // 
@@ -66,7 +66,7 @@
             this.cancelButton.Location = new System.Drawing.Point(537, 247);
             this.cancelButton.Name = "cancelButton";
             this.cancelButton.Size = new System.Drawing.Size(75, 23);
-            this.cancelButton.TabIndex = 2;
+            this.cancelButton.TabIndex = 3;
             this.cancelButton.Text = "Cancel";
             this.cancelButton.UseVisualStyleBackColor = true;
             // 

--- a/Bonsai.Design/AnnotationTextEditor.cs
+++ b/Bonsai.Design/AnnotationTextEditor.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.ComponentModel;
+using System.Drawing.Design;
+using System.Windows.Forms;
+using System.Windows.Forms.Design;
+
+namespace Bonsai.Design
+{
+    /// <summary>
+    /// Provides a user interface editor that displays a dialog box for editing
+    /// the annotation text.
+    /// </summary>
+    public class AnnotationTextEditor : UITypeEditor
+    {
+        /// <inheritdoc/>
+        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
+        {
+            return UITypeEditorEditStyle.Modal;
+        }
+
+        /// <inheritdoc/>
+        public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+        {
+            if (provider != null)
+            {
+                var editorService = (IWindowsFormsEditorService)provider.GetService(typeof(IWindowsFormsEditorService));
+                if (editorService != null)
+                {
+                    using var editorDialog = new AnnotationBuilderEditorDialog();
+                    editorDialog.Annotation = value as string;
+                    if (editorService.ShowDialog(editorDialog) == DialogResult.OK)
+                    {
+                        return editorDialog.Annotation;
+                    }
+                }
+            }
+
+            return base.EditValue(context, provider, value);
+        }
+    }
+}

--- a/Bonsai.Editor/Bonsai.Editor.csproj
+++ b/Bonsai.Editor/Bonsai.Editor.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.svg" />
+    <EmbeddedResource Include="**\*.css" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SvgNet" Version="3.2.0" />

--- a/Bonsai.Editor/GraphView/MarkdownConvert.cs
+++ b/Bonsai.Editor/GraphView/MarkdownConvert.cs
@@ -25,7 +25,7 @@ namespace Bonsai.Editor.GraphView
                 writer.Flush();
 
                 var html = writer.ToString();
-                return $@"<div style=""font-family: '{font.Name}'; line-height: 1em;"">{html}</div>";
+                return $@"<div style=""font-family: '{font.Name}'"">{html}</div>";
             }
 
             return string.Empty;

--- a/Bonsai.Editor/GraphView/MarkdownConvert.cs
+++ b/Bonsai.Editor/GraphView/MarkdownConvert.cs
@@ -9,6 +9,7 @@ namespace Bonsai.Editor.GraphView
     class MarkdownConvert
     {
         public const string DefaultUrl = "path.localhost";
+        public const string EmbeddedUrl = "path.embedded";
 
         public static string ToHtml(Font font, string text)
         {
@@ -25,7 +26,17 @@ namespace Bonsai.Editor.GraphView
                 writer.Flush();
 
                 var html = writer.ToString();
-                return $@"<div style=""font-family: '{font.Name}'"">{html}</div>";
+                return $@"
+<html>
+  <head>
+    <link rel=""stylesheet"" href=""https://{EmbeddedUrl}/light-theme.css"">
+    <link rel=""stylesheet"" href=""https://{EmbeddedUrl}/dark-theme.css"">
+    <link rel=""stylesheet"" href=""https://{EmbeddedUrl}/base.css"">
+  </head>
+  <body>
+    <div style=""font-family: '{font.Name}'"">{html}</div>
+  </body>
+</html>";
             }
 
             return string.Empty;

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -477,10 +477,13 @@ namespace Bonsai.Editor.GraphView
 
         private void splitContainer_SplitterMoved(object sender, SplitterEventArgs e)
         {
-            var delta = PointToClient(MousePosition).X - e.X;
-            if (delta == 0)
+            if (IsHandleCreated)
             {
-                WebViewSize = e.SplitX;
+                var delta = PointToClient(MousePosition).X - e.X;
+                if (delta == 0)
+                {
+                    WebViewSize = e.SplitX;
+                }
             }
         }
 

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -808,6 +808,13 @@ namespace Bonsai.Editor.GraphView
         void RefreshEditorNode(GraphNode node)
         {
             graphView.Invalidate(node);
+            var builder = WorkflowEditor.GetGraphNodeBuilder(node);
+            if (builder is AnnotationBuilder annotationBuilder &&
+                EditorControl.WebView.Tag == annotationBuilder)
+            {
+                LaunchVisualizer(node);
+            }
+
             var editor = GetWorkflowEditorLauncher(node);
             if (editor != null && editor.Visible)
             {

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -437,42 +437,52 @@ namespace Bonsai.Editor.GraphView
                 if (workflowBuilder is IncludeWorkflowBuilder) return;
                 LaunchWorkflowView(node);
             }
-            else if (builder != null)
+            else if (builder != null && LaunchBuilderEditor(builder))
             {
-                var workflowElement = ExpressionBuilder.GetWorkflowElement(builder);
-                try
+                if (!editorState.WorkflowRunning)
                 {
-                    if (!uiService.CanShowComponentEditor(workflowElement) || !uiService.ShowComponentEditor(workflowElement, this))
+                    editorService.ValidateWorkflow();
+                }
+
+                RefreshEditorNode(node);
+            }
+        }
+
+        private bool LaunchBuilderEditor(ExpressionBuilder builder)
+        {
+            var workflowElement = ExpressionBuilder.GetWorkflowElement(builder);
+            try
+            {
+                if (uiService.CanShowComponentEditor(workflowElement))
+                {
+                    return uiService.ShowComponentEditor(workflowElement, this);
+                }
+
+                var defaultProperty = TypeDescriptor.GetDefaultProperty(workflowElement);
+                if (defaultProperty != null)
+                {
+                    var editor = (UITypeEditor)defaultProperty.GetEditor(typeof(UITypeEditor));
+                    if (editor != null && editor.GetEditStyle() == UITypeEditorEditStyle.Modal)
                     {
-                        var defaultProperty = TypeDescriptor.GetDefaultProperty(workflowElement);
-                        if (defaultProperty != null)
+                        var graphViewEditorService = new WorkflowGraphViewEditorService(this, serviceProvider);
+                        var context = new TypeDescriptorContext(workflowElement, defaultProperty, graphViewEditorService);
+                        var currentValue = defaultProperty.GetValue(workflowElement);
+                        var value = editor.EditValue(context, graphViewEditorService, currentValue);
+                        if (value != currentValue && !defaultProperty.IsReadOnly)
                         {
-                            var editor = (UITypeEditor)defaultProperty.GetEditor(typeof(UITypeEditor));
-                            if (editor != null && editor.GetEditStyle() == UITypeEditorEditStyle.Modal)
-                            {
-                                var graphViewEditorService = new WorkflowGraphViewEditorService(this, serviceProvider);
-                                var context = new TypeDescriptorContext(workflowElement, defaultProperty, graphViewEditorService);
-                                var currentValue = defaultProperty.GetValue(workflowElement);
-                                var value = editor.EditValue(context, graphViewEditorService, currentValue);
-                                if (value != currentValue && !defaultProperty.IsReadOnly)
-                                {
-                                    defaultProperty.SetValue(workflowElement, value);
-                                }
-
-                                if (!editorState.WorkflowRunning)
-                                {
-                                    editorService.ValidateWorkflow();
-                                }
-
-                                RefreshEditorNode(node);
-                            }
+                            defaultProperty.SetValue(workflowElement, value);
                         }
+
+                        return true;
                     }
                 }
-                catch (Exception ex)
-                {
-                    uiService.ShowError(ex);
-                }
+
+                return false;
+            }
+            catch (Exception ex)
+            {
+                uiService.ShowError(ex);
+                return false;
             }
         }
 

--- a/Bonsai.Editor/Resources/WebView/base.css
+++ b/Bonsai.Editor/Resources/WebView/base.css
@@ -1,0 +1,15 @@
+body {
+  color: var(--color);
+  background: var(--background);
+  background-color: var(--background);
+  font: 100% system-ui;
+}
+
+a {
+  color: var(--link-color);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}

--- a/Bonsai.Editor/Resources/WebView/dark-theme.css
+++ b/Bonsai.Editor/Resources/WebView/dark-theme.css
@@ -1,0 +1,7 @@
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color: #eee;
+    --background: #1e1e1e;
+    --link-color: #2f81f7;
+  }
+}

--- a/Bonsai.Editor/Resources/WebView/light-theme.css
+++ b/Bonsai.Editor/Resources/WebView/light-theme.css
@@ -1,0 +1,7 @@
+@media (prefers-color-scheme: light) {
+  :root {
+    --color: #222;
+    --background: #fff;
+    --link-color: #0969da;
+  }
+}


### PR DESCRIPTION
This PR improves the experience of editing annotations:
- The markdown editor now starts selected on launch, to allow immediate typing.
- If an annotation is currently rendered it will also be refreshed after editing.
- The converter now avoids overriding the default line height.
- UI type editor is added to the `Text` property.
- Add basic support for dark theme.

Fixes #1360 