### PR TITLE
Add support for polymorphic operator docs

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2287,6 +2287,12 @@ namespace Bonsai.Editor
         private async Task OpenDocumentationAsync(ExpressionBuilder builder)
         {
             var selectedElement = ExpressionBuilder.GetWorkflowElement(builder);
+            if (selectedElement is ICustomTypeDescriptor typeDescriptor &&
+                typeDescriptor.GetPropertyOwner(null) is object selectedOperator)
+            {
+                selectedElement = selectedOperator;
+            }
+
             if (selectedElement is IncludeWorkflowBuilder include &&
                 TryGetAssemblyResource(include.Path, out string assemblyName, out string resourceName))
             {


### PR DESCRIPTION
This PR extends documentation search to polymorphic operators. The goal is to provide documentation directly for the currently selected function. This makes it easier to understand and explore reference documentation for existing workflows which make heavy use of the polymorphic operator pattern.

Fixes #1313 