### PR TITLE
Ensure replaced nodes keep the same index

### DIFF
--- a/Bonsai.Editor.Tests/EditorHelper.cs
+++ b/Bonsai.Editor.Tests/EditorHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Bonsai.Editor.GraphModel;
 using Bonsai.Expressions;
 
@@ -46,6 +47,11 @@ namespace Bonsai.Editor.Tests
         {
             var builder = CreateBuilder(name);
             editor.CreateGraphNode(builder, selectedNode, nodeType, branch);
+        }
+
+        internal static IEnumerable<string> GetGraphValues(this WorkflowEditor editor)
+        {
+            return editor.Workflow.Select(n => ExpressionBuilder.GetElementDisplayName(n.Value));
         }
     }
 }

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -158,6 +158,25 @@ namespace Bonsai.Editor.Tests
 
             assertIsReversible();
         }
+
+        [TestMethod]
+        public void DisableGraphNodes_AllNodesInBranch_KeepNodeIndices()
+        {
+            var nodes = new[] { "A", "B", "C", "D" };
+            var workflow = EditorHelper.CreateEditorGraph(nodes);
+            var (editor, assertIsReversible) = CreateMockEditor(workflow);
+            var nodeSequence = editor.Workflow.ToArray();
+            editor.ConnectNodes("A", "B");
+            editor.ConnectNodes("B", "C");
+            editor.ConnectNodes("A", "D");
+            Assert.AreEqual(expected: nodes.Length, editor.Workflow.Count);
+            AssertIsSequenceEqual(nodeSequence, editor.Workflow);
+
+            var nodesToDisable = new[] { editor.FindNode("B"), editor.FindNode("C") };
+            editor.DisableGraphNodes(nodesToDisable);
+            AssertIsSequenceEqual(nodes, editor.GetGraphValues());
+            assertIsReversible();
+        }
     }
 
     static class WorkflowEditorHelper

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -29,18 +29,15 @@ namespace Bonsai.Editor.Tests
             return ElementStore.LoadWorkflow(reader);
         }
 
-        static void AssertIsSequenceEqual(
-            IEnumerable<Node<ExpressionBuilder, ExpressionBuilderArgument>> expected,
-            IEnumerable<Node<ExpressionBuilder, ExpressionBuilderArgument>> actual)
+        static void AssertIsSequenceEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual)
         {
             expected = expected.ToArray();
             actual = actual.ToArray();
             if (!expected.SequenceEqual(actual))
             {
-                static string ToString(IEnumerable<Node<ExpressionBuilder, ExpressionBuilderArgument>> sequence)
+                static string ToString(IEnumerable<T> sequence)
                 {
-                    return string.Join(",", sequence.Select(
-                        node => ExpressionBuilder.GetElementDisplayName(node.Value)));
+                    return string.Join(",", sequence);
                 }
                 var expectedString = ToString(expected);
                 var actualString = ToString(actual);
@@ -58,7 +55,7 @@ namespace Bonsai.Editor.Tests
             editor.UpdateSelection.Subscribe(graphView.UpdateSelection);
             editor.Workflow = graphView.Workflow;
 
-            var nodeSequence = editor.Workflow.ToArray();
+            var nodeSequence = editor.GetGraphValues().ToArray();
             return (editor, assertIsReversible: () =>
             {
                 while (graphView.CommandExecutor.CanUndo)
@@ -66,7 +63,7 @@ namespace Bonsai.Editor.Tests
                     graphView.CommandExecutor.Undo();
                 }
 
-                AssertIsSequenceEqual(nodeSequence, editor.Workflow);
+                AssertIsSequenceEqual(nodeSequence, editor.GetGraphValues());
             });
         }
 

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -1506,7 +1506,7 @@ namespace Bonsai.Editor.GraphModel
         private void ReplaceNode(Node<ExpressionBuilder, ExpressionBuilderArgument> node, ExpressionBuilder builder)
         {
             var index = Workflow.IndexOf(node);
-            CreateGraphNode(builder, node, CreateGraphNodeType.Successor, branch: false, validate: false);
+            CreateGraphNode(builder, node, CreateGraphNodeType.Successor, branch: false, validate: false, index);
             DeleteGraphNode(node, replaceEdges: true, index);
         }
 


### PR DESCRIPTION
This PR fixes a subtle issue where replaced nodes would be assigned a different index in the order. The issue was caused by assigning an index to the delete operation, but not to the creation operation. Nodes might therefore be inserted at the end of the workflow and cause an index mismatch in the corresponding delete operation.