### PR TITLE
Add support for using System.Numerics namespace in local scripts

### DIFF
--- a/Bonsai.Configuration/ScriptExtensions.cs
+++ b/Bonsai.Configuration/ScriptExtensions.cs
@@ -105,6 +105,7 @@ namespace Bonsai.Configuration
             yield return "System.dll";
             yield return "System.Core.dll";
             yield return "System.Drawing.dll";
+            yield return "System.Numerics.dll";
             yield return "System.Reactive.Linq.dll";
             yield return "System.Xml.dll";
             yield return "Bonsai.Core.dll";


### PR DESCRIPTION
This PR adds [`System.Numerics`](https://learn.microsoft.com/en-us/dotnet/api/system.numerics) to the set of default assembly references included when building local scripts. This allows access to this small yet powerful SIMD-accelerated library for vector and matrix computations.