### PR TITLE
Limit group context menu to core nested operators

### DIFF
--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1767,7 +1767,8 @@ namespace Bonsai.Editor.GraphView
                 var selectedNode = selectedNodes.Length == 1 ? selectedNodes[0] : null;
                 var workflowBuilder = selectedNode != null ? WorkflowEditor.GetGraphNodeBuilder(selectedNode) as WorkflowExpressionBuilder : null;
                 foreach (var element in from element in toolboxService.GetToolboxElements()
-                                        where element.ElementTypes.Contains(ElementCategory.Nested)
+                                        where element.ElementTypes.Contains(ElementCategory.Nested) &&
+                                              element.FullyQualifiedName.Contains(typeof(WorkflowExpressionBuilder).Assembly.FullName)
                                         select element)
                 {
                     ToolStripMenuItem menuItem = null;


### PR DESCRIPTION
This PR restricts the group context menu to display only core nested operators. There is currently no easy way to visually scale the context menu to an arbitrary number of items, and as the number of nested operators is expected to increase there is now a concrete possibility for this menu to become cluttered.

As we explore different ways to assist discovery of nested operators defined in external packages, we are for the moment restricting their display in the group context menu. Any nested operator can still be placed directly from the toolbox, simply by searching the operator name, as with any other operator, and then either right-clicking and selecting the group option, or using `Ctrl+Enter`.

Fixes #1347 