### PR TITLE
Rewrite bootstrapper logic to avoid relying on AppDomain

### DIFF
--- a/Bonsai.Configuration/CommandLineParser.cs
+++ b/Bonsai.Configuration/CommandLineParser.cs
@@ -68,7 +68,10 @@ namespace Bonsai.Configuration
                     {
                         var argument = string.Empty;
                         if (options.Length > 1) argument = options[1];
-                        else if (args.Length > i + 1) argument = args[++i];
+                        else if (args.Length > i + 1 && !args[i + 1].StartsWith(CommandPrefix))
+                        {
+                            argument = args[++i];
+                        }
                         command(argument);
                     }
                 }

--- a/Bonsai.Editor/TypeDefinitionProvider.cs
+++ b/Bonsai.Editor/TypeDefinitionProvider.cs
@@ -29,8 +29,9 @@ namespace Bonsai.Editor
 
         static CodeAttributeDeclaration GetAttributeDeclaration(CustomAttributeData attribute, HashSet<string> importNamespaces)
         {
-            importNamespaces.Add(attribute.AttributeType.Namespace);
-            var attributeName = attribute.AttributeType.Name;
+            var attributeType = attribute.Constructor.DeclaringType;
+            importNamespaces.Add(attributeType.Namespace);
+            var attributeName = attributeType.Name;
             var suffix = attributeName.LastIndexOf(nameof(Attribute));
             attributeName = suffix >= 0 ? attributeName.Substring(0, suffix) : attributeName;
             var reference = new CodeTypeReference(attributeName);

--- a/Bonsai.Editor/TypeVisualizerDescriptor.cs
+++ b/Bonsai.Editor/TypeVisualizerDescriptor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 
 namespace Bonsai.Editor
 {
@@ -7,6 +8,33 @@ namespace Bonsai.Editor
     {
         public string VisualizerTypeName;
         public string TargetTypeName;
+
+        public TypeVisualizerDescriptor(CustomAttributeData attribute)
+        {
+            if (attribute.ConstructorArguments.Count > 0)
+            {
+                var constructorArgument = attribute.ConstructorArguments[0];
+                if (constructorArgument.ArgumentType.AssemblyQualifiedName == typeof(string).AssemblyQualifiedName)
+                {
+                    VisualizerTypeName = (string)constructorArgument.Value;
+                }
+                else VisualizerTypeName = ((Type)constructorArgument.Value).AssemblyQualifiedName;
+            }
+
+            for (int i = 0; i < attribute.NamedArguments.Count; i++)
+            {
+                var namedArgument = attribute.NamedArguments[i];
+                switch (namedArgument.MemberName)
+                {
+                    case nameof(TypeVisualizerAttribute.TargetTypeName):
+                        TargetTypeName = (string)namedArgument.TypedValue.Value;
+                        break;
+                    case nameof(TypeVisualizerAttribute.Target):
+                        TargetTypeName = ((Type)namedArgument.TypedValue.Value).AssemblyQualifiedName;
+                        break;
+                }
+            }
+        }
 
         public TypeVisualizerDescriptor(TypeVisualizerAttribute typeVisualizer)
         {

--- a/Bonsai/AppResult.cs
+++ b/Bonsai/AppResult.cs
@@ -44,19 +44,14 @@ namespace Bonsai
 
         public static TResult GetResult<TResult>()
         {
-            if (Values == null)
-            {
-                throw new InvalidOperationException("No output stream has been opened for reading.");
-            }
-
-            if (Values.TryGetValue(typeof(TResult).FullName, out string value))
+            if (Values != null && Values.TryGetValue(typeof(TResult).FullName, out string value))
             {
                 if (typeof(TResult).IsEnum)
                 {
                     return (TResult)Enum.Parse(typeof(TResult), value);
                 }
 
-                return (TResult)(object)value;
+                return (TResult)Convert.ChangeType(value, typeof(TResult));
             }
 
             return default;

--- a/Bonsai/AppResult.cs
+++ b/Bonsai/AppResult.cs
@@ -1,34 +1,67 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reactive.Disposables;
+using Newtonsoft.Json;
 
 namespace Bonsai
 {
     static class AppResult
     {
-        public static TResult GetResult<TResult>(AppDomain domain)
+        static readonly JsonSerializer Serializer = JsonSerializer.CreateDefault();
+        static Dictionary<string, string> Values;
+
+        public static IDisposable OpenWrite(Stream stream)
         {
-            var resultHolder = (ResultHolder<TResult>)domain.CreateInstanceAndUnwrap(
-                typeof(ResultHolder<TResult>).Assembly.FullName,
-                typeof(ResultHolder<TResult>).FullName);
-            return resultHolder.Result;
+            Values = new();
+            if (stream == null)
+            {
+                return Disposable.Empty;
+            }
+
+            var writer = new JsonTextWriter(new StreamWriter(stream));
+            return Disposable.Create(() =>
+            {
+                try { Serializer.Serialize(writer, Values); }
+                finally { writer.Close(); }
+            });
+        }
+
+        public static IDisposable OpenRead(Stream stream)
+        {
+            using var reader = new JsonTextReader(new StreamReader(stream));
+            Values = Serializer.Deserialize<Dictionary<string, string>>(reader);
+            return Disposable.Empty;
+        }
+
+        public static TResult GetResult<TResult>()
+        {
+            if (Values == null)
+            {
+                throw new InvalidOperationException("No output stream has been opened for reading.");
+            }
+
+            if (Values.TryGetValue(typeof(TResult).FullName, out string value))
+            {
+                if (typeof(TResult).IsEnum)
+                {
+                    return (TResult)Enum.Parse(typeof(TResult), value);
+                }
+
+                return (TResult)(object)value;
+            }
+
+            return default;
         }
 
         public static void SetResult<TResult>(TResult result)
         {
-            ResultHolder<TResult>.ResultValue = result;
-        }
-
-        class ResultHolder<TResult> : MarshalByRefObject
-        {
-            public static TResult ResultValue;
-
-            public ResultHolder()
+            if (Values == null)
             {
+                throw new InvalidOperationException("No output stream has been opened for writing.");
             }
 
-            public TResult Result
-            {
-                get { return ResultValue; }
-            }
+            Values[typeof(TResult).FullName] = result.ToString();
         }
     }
 }

--- a/Bonsai/Bonsai.csproj
+++ b/Bonsai/Bonsai.csproj
@@ -14,6 +14,7 @@
     <ApplicationManifest>App.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
     <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Bonsai/Bonsai.csproj
+++ b/Bonsai/Bonsai.csproj
@@ -14,7 +14,7 @@
     <ApplicationManifest>App.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="7.0.0" PrivateAssets="all" />
     <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -45,6 +45,13 @@
       <WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\$(TargetFramework)</WorkingDirectory>
     </PropertyGroup>
     <ItemGroup>
+      <InputAssemblies Include="System.Buffers.dll" />
+      <InputAssemblies Include="System.Memory.dll" />
+      <InputAssemblies Include="System.Numerics.Vectors.dll" />
+      <InputAssemblies Include="System.Collections.Immutable.dll" />
+      <InputAssemblies Include="System.Reflection.Metadata.dll" />
+      <InputAssemblies Include="System.Reflection.MetadataLoadContext.dll" />
+      <InputAssemblies Include="System.Runtime.CompilerServices.Unsafe.dll" />
       <InputAssemblies Include="Bonsai.Configuration.dll" />
       <InputAssemblies Include="Bonsai.NuGet.dll" />
       <InputAssemblies Include="Bonsai.NuGet.Design.dll" />

--- a/Bonsai/Launcher.cs
+++ b/Bonsai/Launcher.cs
@@ -109,7 +109,8 @@ namespace Bonsai
                 if (scriptExtensions.DebugScripts) editorFlags |= EditorFlags.DebugScripts;
                 AppResult.SetResult(editorFlags);
                 AppResult.SetResult(mainForm.FileName);
-                return (int)mainForm.EditorResult;
+                AppResult.SetResult((int)mainForm.EditorResult);
+                return Program.NormalExitCode;
             }
             finally { cancellation.Cancel(); }
         }

--- a/Bonsai/PackageAssemblyResolver.cs
+++ b/Bonsai/PackageAssemblyResolver.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Bonsai.Configuration;
+
+namespace Bonsai
+{
+    internal class PackageAssemblyResolver : PathAssemblyResolver
+    {
+        public PackageAssemblyResolver(PackageConfiguration configuration, IEnumerable<string> assemblyPaths)
+            : base(assemblyPaths)
+        {
+            Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            ConfigurationRoot = ConfigurationHelper.GetConfigurationRoot(configuration);
+        }
+
+        private PackageConfiguration Configuration { get; }
+
+        private string ConfigurationRoot { get; }
+
+        public override Assembly Resolve(MetadataLoadContext context, AssemblyName assemblyName)
+        {
+            var assembly = base.Resolve(context, assemblyName);
+            if (assembly != null) return assembly;
+
+            var assemblyLocation = Configuration.GetAssemblyLocation(assemblyName.Name);
+            if (assemblyLocation != null)
+            {
+                if (assemblyLocation.StartsWith(Uri.UriSchemeFile) &&
+                    Uri.TryCreate(assemblyLocation, UriKind.Absolute, out Uri uri))
+                {
+                    return context.LoadFromAssemblyPath(uri.LocalPath);
+                }
+
+                if (!Path.IsPathRooted(assemblyLocation))
+                {
+                    assemblyLocation = Path.Combine(ConfigurationRoot, assemblyLocation);
+                }
+
+                if (File.Exists(assemblyLocation))
+                {
+                    return context.LoadFromAssemblyPath(assemblyLocation);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -205,8 +205,6 @@ namespace Bonsai
                     setupInfo.FileName = Assembly.GetEntryAssembly().Location;
                     setupInfo.Arguments = string.Join(" ", editorArgs);
                     setupInfo.WorkingDirectory = Environment.CurrentDirectory;
-                    setupInfo.RedirectStandardOutput = true;
-                    setupInfo.RedirectStandardError = true;
                     setupInfo.UseShellExecute = false;
                     var process = Process.Start(setupInfo);
                     process.WaitForExit();

--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -3,8 +3,10 @@ using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.IO.Pipes;
 using System.Reflection;
 
 namespace Bonsai
@@ -27,6 +29,7 @@ namespace Bonsai
         const string ExportImageCommand = "--export-image";
         const string ReloadEditorCommand = "--reload-editor";
         const string GalleryCommand = "--gallery";
+        const string PipeCommand = "--@pipe";
         const string EditorDomainName = "EditorDomain";
         const string RepositoryPath = "Packages";
         const string ExtensionsPath = "Extensions";
@@ -51,6 +54,7 @@ namespace Bonsai
             var launchResult = default(EditorResult);
             var initialFileName = default(string);
             var imageFileName = default(string);
+            var pipeHandle = default(string);
             var layoutPath = default(string);
             var libFolders = new List<string>();
             var propertyAssignments = new Dictionary<string, string>();
@@ -62,6 +66,7 @@ namespace Bonsai
             parser.RegisterCommand(DebugScriptCommand, () => debugScripts = true);
             parser.RegisterCommand(SuppressBootstrapCommand, () => bootstrap = false);
             parser.RegisterCommand(SuppressEditorCommand, () => launchEditor = false);
+            parser.RegisterCommand(PipeCommand, pipeName => pipeHandle = pipeName);
             parser.RegisterCommand(ExportImageCommand, fileName => { imageFileName = fileName; exportImage = true; });
             parser.RegisterCommand(ExportPackageCommand, () => { launchResult = EditorResult.ExportPackage; bootstrap = false; });
             parser.RegisterCommand(ReloadEditorCommand, () => { launchResult = EditorResult.ReloadEditor; bootstrap = false; });
@@ -93,6 +98,8 @@ namespace Bonsai
             var packageConfiguration = ConfigurationHelper.Load();
             if (!bootstrap)
             {
+                using var pipeClient = pipeHandle != null ? new AnonymousPipeClientStream(PipeDirection.Out, pipeHandle) : null;
+                using var pipeWriter = AppResult.OpenWrite(pipeClient);
                 if (launchResult == EditorResult.Exit)
                 {
                     if (!string.IsNullOrEmpty(initialFileName)) launchResult = EditorResult.ReloadEditor;
@@ -170,40 +177,42 @@ namespace Bonsai
                 args = Array.FindAll(args, arg => arg != DebugScriptCommand);
                 do
                 {
-                    string[] editorArgs;
+                    var editorArgs = new List<string>(args);
                     if (launchEditor && startScreen) launchResult = EditorResult.Exit;
-                    if (launchResult == EditorResult.ExportPackage) editorArgs = new[] { initialFileName, ExportPackageCommand };
-                    else if (launchResult == EditorResult.OpenGallery) editorArgs = new[] { GalleryCommand };
+                    if (launchResult == EditorResult.ExportPackage) editorArgs.AddRange(new[] { initialFileName, ExportPackageCommand });
+                    else if (launchResult == EditorResult.OpenGallery) editorArgs.Add(GalleryCommand);
                     else if (launchResult == EditorResult.ManagePackages)
                     {
-                        editorArgs = updatePackages
+                        editorArgs.AddRange(updatePackages
                             ? new[] { PackageManagerCommand + ":" + PackageManagerUpdates }
-                            : new[] { PackageManagerCommand };
+                            : new[] { PackageManagerCommand });
                     }
                     else
                     {
-                        var extraArgs = new List<string>(args);
-                        if (debugScripts) extraArgs.Add(DebugScriptCommand);
-                        if (launchResult == EditorResult.ReloadEditor) extraArgs.Add(ReloadEditorCommand);
-                        else extraArgs.Add(SuppressBootstrapCommand);
-                        if (!string.IsNullOrEmpty(initialFileName)) extraArgs.Add(initialFileName);
-                        editorArgs = extraArgs.ToArray();
+                        if (debugScripts) editorArgs.Add(DebugScriptCommand);
+                        if (launchResult == EditorResult.ReloadEditor) editorArgs.Add(ReloadEditorCommand);
+                        else editorArgs.Add(SuppressBootstrapCommand);
+                        if (!string.IsNullOrEmpty(initialFileName)) editorArgs.Add(initialFileName);
                     }
 
-                    var setupInfo = new AppDomainSetup();
-                    setupInfo.ApplicationBase = editorFolder;
-                    setupInfo.PrivateBinPath = editorFolder;
-                    var currentEvidence = AppDomain.CurrentDomain.Evidence;
-                    var currentPermissionSet = AppDomain.CurrentDomain.PermissionSet;
-                    var currentPath = Environment.GetEnvironmentVariable(PathEnvironmentVariable);
-                    setupInfo.ConfigurationFile = AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
-                    setupInfo.LoaderOptimization = LoaderOptimization.MultiDomainHost;
-                    var editorDomain = AppDomain.CreateDomain(EditorDomainName, currentEvidence, setupInfo, currentPermissionSet);
-                    var exitCode = (EditorResult)editorDomain.ExecuteAssembly(editorPath, editorArgs);
-                    Environment.SetEnvironmentVariable(PathEnvironmentVariable, currentPath);
+                    using var pipeServer = new AnonymousPipeServerStream(
+                        PipeDirection.In,
+                        HandleInheritability.Inheritable);
+                    var pipeName = pipeServer.GetClientHandleAsString();
+                    editorArgs.Add(PipeCommand + ":" + pipeName);
 
-                    var editorFlags = AppResult.GetResult<EditorFlags>(editorDomain);
-                    launchResult = AppResult.GetResult<EditorResult>(editorDomain);
+                    var setupInfo = new ProcessStartInfo();
+                    setupInfo.FileName = Assembly.GetEntryAssembly().Location;
+                    setupInfo.Arguments = string.Join(" ", editorArgs);
+                    setupInfo.WorkingDirectory = Environment.CurrentDirectory;
+                    setupInfo.RedirectStandardOutput = true;
+                    setupInfo.RedirectStandardError = true;
+                    setupInfo.UseShellExecute = false;
+                    var process = Process.Start(setupInfo);
+                    process.WaitForExit();
+
+                    using var pipeReader = AppResult.OpenRead(pipeServer);
+                    launchResult = AppResult.GetResult<EditorResult>();
                     if (launchEditor)
                     {
                         if (launchResult == EditorResult.ReloadEditor) launchEditor = false;
@@ -215,7 +224,7 @@ namespace Bonsai
                         if (launchResult == EditorResult.OpenGallery ||
                             launchResult == EditorResult.ManagePackages)
                         {
-                            var result = AppResult.GetResult<string>(editorDomain);
+                            var result = AppResult.GetResult<string>();
                             if (!string.IsNullOrEmpty(result) && File.Exists(result))
                             {
                                 initialFileName = result;
@@ -226,13 +235,12 @@ namespace Bonsai
                     }
                     else
                     {
+                        var editorFlags = AppResult.GetResult<EditorFlags>();
                         debugScripts = editorFlags.HasFlag(EditorFlags.DebugScripts);
                         updatePackages = editorFlags.HasFlag(EditorFlags.UpdatesAvailable);
-                        initialFileName = AppResult.GetResult<string>(editorDomain);
-                        launchResult = exitCode;
+                        initialFileName = AppResult.GetResult<string>();
+                        launchResult = (EditorResult)process.ExitCode;
                     }
-
-                    AppDomain.Unload(editorDomain);
                 }
                 while (launchResult != EditorResult.Exit);
             }

--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -212,6 +212,7 @@ namespace Bonsai
                     setupInfo.WorkingDirectory = workingDirectory;
                     setupInfo.UseShellExecute = false;
                     var process = Process.Start(setupInfo);
+                    pipeServer.DisposeLocalCopyOfClientHandle();
                     process.WaitForExit();
 
                     using var pipeReader = AppResult.OpenRead(pipeServer);

--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -178,6 +178,7 @@ namespace Bonsai
                 do
                 {
                     var editorArgs = new List<string>(args);
+                    var workingDirectory = Environment.CurrentDirectory;
                     if (launchEditor && startScreen) launchResult = EditorResult.Exit;
                     if (launchResult == EditorResult.ExportPackage) editorArgs.AddRange(new[] { initialFileName, ExportPackageCommand });
                     else if (launchResult == EditorResult.OpenGallery) editorArgs.Add(GalleryCommand);
@@ -192,7 +193,11 @@ namespace Bonsai
                         if (debugScripts) editorArgs.Add(DebugScriptCommand);
                         if (launchResult == EditorResult.ReloadEditor) editorArgs.Add(ReloadEditorCommand);
                         else editorArgs.Add(SuppressBootstrapCommand);
-                        if (!string.IsNullOrEmpty(initialFileName)) editorArgs.Add(initialFileName);
+                        if (!string.IsNullOrEmpty(initialFileName))
+                        {
+                            editorArgs.Add(initialFileName);
+                            workingDirectory = Path.GetDirectoryName(initialFileName);
+                        }
                     }
 
                     using var pipeServer = new AnonymousPipeServerStream(
@@ -204,7 +209,7 @@ namespace Bonsai
                     var setupInfo = new ProcessStartInfo();
                     setupInfo.FileName = Assembly.GetEntryAssembly().Location;
                     setupInfo.Arguments = string.Join(" ", editorArgs);
-                    setupInfo.WorkingDirectory = Environment.CurrentDirectory;
+                    setupInfo.WorkingDirectory = workingDirectory;
                     setupInfo.UseShellExecute = false;
                     var process = Process.Start(setupInfo);
                     process.WaitForExit();
@@ -226,7 +231,6 @@ namespace Bonsai
                             if (!string.IsNullOrEmpty(result) && File.Exists(result))
                             {
                                 initialFileName = result;
-                                Environment.CurrentDirectory = Path.GetDirectoryName(initialFileName);
                             }
                         }
                         launchResult = EditorResult.ReloadEditor;

--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -114,7 +114,8 @@ namespace Bonsai
                         }
                         AppResult.SetResult(EditorResult.Exit);
                         AppResult.SetResult(initialFileName);
-                        return (int)launchResult;
+                        AppResult.SetResult((int)launchResult);
+                        return NormalExitCode;
                     }
                 }
 
@@ -211,6 +212,8 @@ namespace Bonsai
                     pipeServer.WaitForConnection();
                     using var pipeReader = AppResult.OpenRead(pipeServer);
                     process.WaitForExit();
+                    if (process.ExitCode != 0)
+                        return process.ExitCode;
 
                     launchResult = AppResult.GetResult<EditorResult>();
                     if (launchEditor)
@@ -238,7 +241,7 @@ namespace Bonsai
                         debugScripts = editorFlags.HasFlag(EditorFlags.DebugScripts);
                         updatePackages = editorFlags.HasFlag(EditorFlags.UpdatesAvailable);
                         initialFileName = AppResult.GetResult<string>();
-                        launchResult = (EditorResult)process.ExitCode;
+                        launchResult = (EditorResult)AppResult.GetResult<int>();
                     }
                 }
                 while (launchResult != EditorResult.Exit);

--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -13,7 +13,6 @@ namespace Bonsai
 {
     static class Program
     {
-        const string PathEnvironmentVariable = "PATH";
         const string StartCommand = "--start";
         const string LibraryCommand = "--lib";
         const string PropertyCommand = "--property";
@@ -30,7 +29,6 @@ namespace Bonsai
         const string ReloadEditorCommand = "--reload-editor";
         const string GalleryCommand = "--gallery";
         const string PipeCommand = "--@pipe";
-        const string EditorDomainName = "EditorDomain";
         const string RepositoryPath = "Packages";
         const string ExtensionsPath = "Extensions";
         internal const int NormalExitCode = 0;

--- a/Bonsai/Properties/launchSettings.json
+++ b/Bonsai/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Bonsai": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/Bonsai/ReflectionHelper.cs
+++ b/Bonsai/ReflectionHelper.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Bonsai
+{
+    static class ReflectionHelper
+    {
+        public static CustomAttributeData[] GetCustomAttributesData(this Type type, bool inherit)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            var attributeLists = new List<IList<CustomAttributeData>>();
+            while (type != null)
+            {
+                attributeLists.Add(CustomAttributeData.GetCustomAttributes(type));
+                type = inherit ? type.BaseType : null;
+            }
+
+            var offset = 0;
+            var count = attributeLists.Sum(attributes => attributes.Count);
+            var result = new CustomAttributeData[count];
+            for (int i = 0; i < attributeLists.Count; i++)
+            {
+                attributeLists[i].CopyTo(result, offset);
+                offset += attributeLists[i].Count;
+            }
+
+            return result;
+        }
+
+        public static IEnumerable<CustomAttributeData> OfType<TAttribute>(this IEnumerable<CustomAttributeData> customAttributes)
+        {
+            var attributeTypeName = typeof(TAttribute).FullName;
+            return customAttributes.Where(attribute => attribute.AttributeType.FullName == attributeTypeName);
+        }
+
+        public static bool IsDefined(this CustomAttributeData[] customAttributes, Type attributeType)
+        {
+            return GetCustomAttributeData(customAttributes, attributeType) != null;
+        }
+
+        public static CustomAttributeData GetCustomAttributeData(
+            this CustomAttributeData[] customAttributes,
+            Type attributeType)
+        {
+            if (customAttributes == null)
+            {
+                throw new ArgumentNullException(nameof(customAttributes));
+            }
+
+            return Array.Find(
+                customAttributes,
+                attribute => attribute.AttributeType.FullName == attributeType.FullName);
+        }
+
+        public static object GetConstructorArgument(this CustomAttributeData attribute)
+        {
+            if (attribute == null)
+            {
+                throw new ArgumentNullException(nameof(attribute));
+            }
+
+            return attribute.ConstructorArguments.Count > 0 ? attribute.ConstructorArguments[0].Value : null;
+        }
+
+        public static bool IsMatchSubclassOf(this Type type, Type baseType)
+        {
+            var typeName = baseType.AssemblyQualifiedName;
+            if (type.AssemblyQualifiedName == typeName)
+            {
+                return false;
+            }
+
+            while (type != null)
+            {
+                if (type.AssemblyQualifiedName == typeName)
+                {
+                    return true;
+                }
+
+                type = type.BaseType;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Bonsai/ReflectionHelper.cs
+++ b/Bonsai/ReflectionHelper.cs
@@ -17,7 +17,7 @@ namespace Bonsai
             var attributeLists = new List<IList<CustomAttributeData>>();
             while (type != null)
             {
-                attributeLists.Add(CustomAttributeData.GetCustomAttributes(type));
+                attributeLists.Add(type.GetCustomAttributesData());
                 type = inherit ? type.BaseType : null;
             }
 
@@ -36,7 +36,8 @@ namespace Bonsai
         public static IEnumerable<CustomAttributeData> OfType<TAttribute>(this IEnumerable<CustomAttributeData> customAttributes)
         {
             var attributeTypeName = typeof(TAttribute).FullName;
-            return customAttributes.Where(attribute => attribute.AttributeType.FullName == attributeTypeName);
+            return customAttributes.Where(
+                attribute => attribute.Constructor.DeclaringType.FullName == attributeTypeName);
         }
 
         public static bool IsDefined(this CustomAttributeData[] customAttributes, Type attributeType)
@@ -55,7 +56,7 @@ namespace Bonsai
 
             return Array.Find(
                 customAttributes,
-                attribute => attribute.AttributeType.FullName == attributeType.FullName);
+                attribute => attribute.Constructor.DeclaringType.FullName == attributeType.FullName);
         }
 
         public static object GetConstructorArgument(this CustomAttributeData attribute)

--- a/Bonsai/TypeVisualizerLoader.cs
+++ b/Bonsai/TypeVisualizerLoader.cs
@@ -14,7 +14,7 @@ namespace Bonsai
     {
         static IEnumerable<TypeVisualizerDescriptor> GetCustomAttributeTypes(Assembly assembly)
         {
-            var assemblyAttributes = CustomAttributeData.GetCustomAttributes(assembly);
+            var assemblyAttributes = assembly.GetCustomAttributesData();
             var typeVisualizers = assemblyAttributes
                 .OfType<TypeVisualizerAttribute>()
                 .Select(attribute => new TypeVisualizerDescriptor(attribute));

--- a/Bonsai/TypeVisualizerLoader.cs
+++ b/Bonsai/TypeVisualizerLoader.cs
@@ -12,76 +12,57 @@ namespace Bonsai
 {
     sealed class TypeVisualizerLoader : MarshalByRefObject
     {
-        public TypeVisualizerLoader(PackageConfiguration configuration)
+        static IEnumerable<TypeVisualizerDescriptor> GetCustomAttributeTypes(Assembly assembly)
         {
-            ConfigurationHelper.SetAssemblyResolve(configuration);
-        }
+            var assemblyAttributes = CustomAttributeData.GetCustomAttributes(assembly);
+            var typeVisualizers = assemblyAttributes
+                .OfType<TypeVisualizerAttribute>()
+                .Select(attribute => new TypeVisualizerDescriptor(attribute));
 
-        static IEnumerable<TypeVisualizerAttribute> GetCustomAttributeTypes(Assembly assembly)
-        {
-            Type[] types;
-            var typeVisualizers = Enumerable.Empty<TypeVisualizerAttribute>();
-
-            try { types = assembly.GetTypes(); }
-            catch (ReflectionTypeLoadException ex)
-            {
-                Trace.TraceError(string.Join<Exception>(Environment.NewLine, ex.LoaderExceptions));
-                return typeVisualizers;
-            }
-
+            var types = assembly.GetTypes();
             for (int i = 0; i < types.Length; i++)
             {
                 var type = types[i];
                 if (type.IsPublic && !type.IsAbstract && !type.ContainsGenericParameters)
                 {
-                    var visualizerAttributes = Array.ConvertAll(type.GetCustomAttributes(typeof(TypeVisualizerAttribute), true), attribute =>
-                    {
-                        var visualizerAttribute = (TypeVisualizerAttribute)attribute;
-                        visualizerAttribute.TargetTypeName = type.AssemblyQualifiedName;
-                        return visualizerAttribute;
-                    });
-
-                    if (visualizerAttributes.Length > 0)
-                    {
-                        typeVisualizers = typeVisualizers.Concat(visualizerAttributes);
-                    }
+                    var customAttributes = type.GetCustomAttributesData(inherit: true).OfType<TypeVisualizerAttribute>();
+                    typeVisualizers = typeVisualizers.Concat(customAttributes.Select(
+                        attribute => new TypeVisualizerDescriptor(attribute)
+                        {
+                            TargetTypeName = type.AssemblyQualifiedName
+                        }));
                 }
             }
 
             return typeVisualizers;
         }
 
-        TypeVisualizerDescriptor[] GetReflectionTypeVisualizerAttributes(string assemblyRef)
+        static IEnumerable<TypeVisualizerDescriptor> GetReflectionTypeVisualizerTypes(MetadataLoadContext context, string assemblyName)
         {
-            var typeVisualizers = Enumerable.Empty<TypeVisualizerAttribute>();
             try
             {
-                var assembly = Assembly.Load(assemblyRef);
-                var visualizerAttributes = assembly.GetCustomAttributes(typeof(TypeVisualizerAttribute), true).Cast<TypeVisualizerAttribute>();
-                typeVisualizers = typeVisualizers.Concat(visualizerAttributes);
-                typeVisualizers = typeVisualizers.Concat(GetCustomAttributeTypes(assembly));
+                var assembly = context.LoadFromAssemblyName(assemblyName);
+                return GetCustomAttributeTypes(assembly);
             }
             catch (FileLoadException ex) { Trace.TraceError("{0}", ex); }
             catch (FileNotFoundException ex) { Trace.TraceError("{0}", ex); }
             catch (BadImageFormatException ex) { Trace.TraceError("{0}", ex); }
-
-            return typeVisualizers.Distinct().Select(data => new TypeVisualizerDescriptor(data)).ToArray();
+            return Enumerable.Empty<TypeVisualizerDescriptor>();
         }
 
         public static IObservable<TypeVisualizerDescriptor> GetVisualizerTypes(PackageConfiguration configuration)
         {
             if (configuration == null)
             {
-                throw new ArgumentNullException("configuration");
+                throw new ArgumentNullException(nameof(configuration));
             }
 
             var assemblies = configuration.AssemblyReferences.Select(reference => reference.AssemblyName);
             return Observable.Using(
-                () => new LoaderResource<TypeVisualizerLoader>(configuration),
-                resource => from assemblyRef in assemblies.ToObservable()
-                            let typeVisualizers = resource.Loader.GetReflectionTypeVisualizerAttributes(assemblyRef)
-                            from typeVisualizer in typeVisualizers
-                            select typeVisualizer);
+                () => LoaderResource.CreateMetadataLoadContext(configuration),
+                context => from assemblyName in assemblies.ToObservable()
+                           from typeVisualizer in GetReflectionTypeVisualizerTypes(context, assemblyName)
+                           select typeVisualizer);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Building from Source
 1. Install the [Wix Toolset build tools](https://wixtoolset.org/releases/) version 3.11 or greater.
 2. From Visual Studio menu, select `Extensions` > `Manage Extensions` and install the WiX Toolset Visual Studio 2022 Extension.
 
+### Debugging
+
+The new bootstrapper logic makes use of isolated child processes to manage local editor extensions. To make it easier to debug the entire process tree we recommend installing the [Child Process Debugging Power Tool](https://devblogs.microsoft.com/devops/introducing-the-child-process-debugging-power-tool/) extension.
+
 Getting Help
 ------------
 


### PR DESCRIPTION
This PR rewrites several aspects of the bootstrapper executable to avoid depending on `AppDomain`. Instead, assembly metadata is inspected using [MetadataLoadContext](https://learn.microsoft.com/en-us/dotnet/standard/assembly/inspect-contents-using-metadataloadcontext) and isolated editor sessions are implemented using child processes spawned from the top-level executable.

This is expected to improve both the cross-platform experience of the current editor, and facilitate the transition to .NET 6 where support for multiple `AppDomain` instances has been removed entirely. Other benefits include proper cleanup of loaded native dependencies (process tear-down will unload both native and managed dependencies) and also resolution of specific issues with drivers crashing when spawned from child `AppDomain` (currently the workaround was to start these using the `--no-boot` flag which should no longer be necessary). 

Fixes #1383 