### PR TITLE
Regression testing for sorting and editor changes

### DIFF
--- a/Bonsai.Core.Tests/TopologicalSortTests.cs
+++ b/Bonsai.Core.Tests/TopologicalSortTests.cs
@@ -253,5 +253,19 @@ namespace Bonsai.Core.Tests
                      { 'C', 'D', 'B' },
             }, string.Empty);
         }
+
+        [TestMethod]
+        public void TopologicalSort_CrossedDependencyRoots_ConnectedComponentOrder()
+        {
+            AssertOrder(new TestGraph(16)
+            {
+                { 'A', 'B', 'D' },
+                {      'C', 'D' },
+                {      'E', 'F', 'K', 'L' },
+                {      'B', 'I', 'J', 'K' },
+                {           'F', 'M', 'N', 'P' },
+                {           'G', 'H', 'O', 'P' },
+            }, "ABCDEFIJKLMNGHOP");
+        }
     }
 }

--- a/Bonsai.Core/Dag/TopologicalSort.cs
+++ b/Bonsai.Core/Dag/TopologicalSort.cs
@@ -56,7 +56,7 @@ namespace Bonsai.Dag
                             {
                                 var rank = source.Count - rootIndices[current.Node];
                                 nodeMark.Rank = rank;
-                                nodeMark.Component = new ConnectedComponent(rank) { nodeMark };
+                                nodeMark.Component = new ConnectedComponent(rank, nodeMark);
                                 orderedRoots.Add(nodeMark);
                             }
                             else
@@ -157,7 +157,7 @@ namespace Bonsai.Dag
                 dependencies.Add(nodeDependency);
                 if (dependency.Component == null)
                 {
-                    dependency.Component = Component;
+                    dependency.Component = Component.Principal.Component;
                 }
                 else if (Component != dependency.Component)
                 {
@@ -242,12 +242,16 @@ namespace Bonsai.Dag
 
         class ConnectedComponent : HashSet<SortedNode>
         {
-            internal ConnectedComponent(int rank)
+            internal ConnectedComponent(int rank, SortedNode principal)
             {
                 Rank = rank;
+                Principal = principal;
+                Add(principal);
             }
 
             internal int Rank { get; }
+
+            internal SortedNode Principal { get; }
         }
     }
 }

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -177,6 +177,23 @@ namespace Bonsai.Editor.Tests
             AssertIsSequenceEqual(nodes, editor.GetGraphValues());
             assertIsReversible();
         }
+
+        [TestMethod]
+        public void UngroupGraphNodes_NestedPassthrough_KeepOuterEdges()
+        {
+            var workflow = EditorHelper.CreateEditorGraph("A", "C");
+            var (editor, assertIsReversible) = CreateMockEditor(workflow);
+            var sourceNode = editor.FindNode("A");
+            editor.CreateGraphNode(
+                new GroupWorkflowBuilder { Name = "B" },
+                sourceNode,
+                CreateGraphNodeType.Successor,
+                branch: false);
+            editor.ConnectNodes("B", "C");
+            var nodesToUngroup = new[] { editor.FindNode("B") };
+            editor.UngroupGraphNodes(nodesToUngroup);
+            assertIsReversible();
+        }
     }
 
     static class WorkflowEditorHelper

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -1943,7 +1943,7 @@ namespace Bonsai.Editor.GraphModel
             // Connect output sources to external targets
             var outputConnections = groupOutputs
                 .Select(edge => edge.Item1)
-                .Where(xs => xs != null)
+                .Where(xs => xs != null && groupWorkflow.Contains(xs))
                 .SelectMany(xs => successors.Select(successor =>
                     (source: xs, target: successor)));
             foreach (var (source, target) in outputConnections)


### PR DESCRIPTION
This PR adds regression tests for edge cases involving topological sorting and specific editor actions such as ungrouping passthrough nested nodes. Fixes are also pushed for each case.