### PR TITLE
Ensure output of Normalize is bounded between zero and one

### DIFF
--- a/Bonsai.Vision/Normalize.cs
+++ b/Bonsai.Vision/Normalize.cs
@@ -30,7 +30,7 @@ namespace Bonsai.Vision
 
                 var range = max - min;
                 var scale = range > 0 ? 1.0 / range : 0;
-                var shift = range > 0 ? -min : 0;
+                var shift = range > 0 ? -min * scale : 0;
                 CV.ConvertScale(input, output, scale, shift);
                 return output;
             });


### PR DESCRIPTION
Fixes #1399 .

The current version of `Normalize` implements ConvertScale with `shift` in "raw", unscaled, units.

https://github.com/bonsai-rx/bonsai/blob/404b092b501fbd9a0db5ccce76bf695623e6ba7c/Bonsai.Vision/Normalize.cs#LL34C17-L34C32
```csharp
                var range = max - min;
                var scale = range > 0 ? 1.0 / range : 0;
                var shift = range > 0 ? -min : 0;
                CV.ConvertScale(input, output, scale, shift);
```

However, the [native function from opencv](https://docs.opencv.org/3.4/d2/df8/group__core__c.html#ga3a6c66666ac8c30f639c85dd18df9f67) seems to follow algebraic order of operations (i.e. Multiplication -> Addition), resulting in applying the scaling first and the shift second.

![image](https://github.com/bonsai-rx/bonsai/assets/7049351/fb9a89fd-b230-4538-875d-48b4add6e594)

It seems the easiest way to correct this would be to normalize the shift by the range:
```csharp
var shift = range > 0 ? -min*scale : 0;
```
