### PR TITLE
Redirect headless exceptions to stderr

### DIFF
--- a/Bonsai.Editor/WorkflowRunner.cs
+++ b/Bonsai.Editor/WorkflowRunner.cs
@@ -81,7 +81,7 @@ namespace Bonsai.Editor
                 Application.Exit();
             }).Subscribe(
                 unit => { },
-                ex => { Console.WriteLine(ex); },
+                ex => { Console.Error.WriteLine(ex); },
                 () => { },
                 cts.Token);
             Application.Run();
@@ -93,7 +93,7 @@ namespace Bonsai.Editor
             var workflowCompleted = new ManualResetEvent(false);
             workflowBuilder.Workflow.BuildObservable().Subscribe(
                 unit => { },
-                ex => { Console.WriteLine(ex); workflowCompleted.Set(); },
+                ex => { Console.Error.WriteLine(ex); workflowCompleted.Set(); },
                 () => workflowCompleted.Set());
             workflowCompleted.WaitOne();
         }

--- a/Bonsai.Player/Program.cs
+++ b/Bonsai.Player/Program.cs
@@ -34,7 +34,7 @@ namespace Bonsai.Player
             var workflowCompleted = new ManualResetEvent(false);
             workflowBuilder.Workflow.BuildObservable().Subscribe(
                 unit => { },
-                ex => { Console.WriteLine(ex); workflowCompleted.Set(); },
+                ex => { Console.Error.WriteLine(ex); workflowCompleted.Set(); },
                 () => workflowCompleted.Set());
             workflowCompleted.WaitOne();
         }


### PR DESCRIPTION
This PR redirects the stack traces for all unhandled exceptions in headless runners (e.g. player or --no-editor flag) to stderr. This allows for an easier separation of outputs for CLI applications. For example, from powershell the following will log only the errors to a file:

```powershell
bonsai --no-editor workflow.bonsai 2>> log.file
``` 

Fixes #1410 
