### PR TITLE
Add assembly reference for data serialization

### DIFF
--- a/Bonsai.Configuration/ScriptExtensions.cs
+++ b/Bonsai.Configuration/ScriptExtensions.cs
@@ -106,6 +106,7 @@ namespace Bonsai.Configuration
             yield return "System.Drawing.dll";
             yield return "System.Numerics.dll";
             yield return "System.Reactive.Linq.dll";
+            yield return "System.Runtime.Serialization.dll";
             yield return "System.Xml.dll";
             yield return "Bonsai.Core.dll";
             yield return "Microsoft.CSharp.dll";


### PR DESCRIPTION
This PR adds an assembly reference for `System.Runtime.Serialization` containing data contract serializer types.