### PR TITLE
Fixes and improvements to workflow sort order

### DIFF
--- a/Bonsai.Editor.Tests/EditorHelper.cs
+++ b/Bonsai.Editor.Tests/EditorHelper.cs
@@ -31,6 +31,12 @@ namespace Bonsai.Editor.Tests
             return editor.FindGraphNode(node.Value);
         }
 
+        internal static GraphNode FindNode(this WorkflowEditor editor, ExpressionBuilder builder)
+        {
+            var node = editor.Workflow.First(n => ExpressionBuilder.Unwrap(n.Value) == builder);
+            return editor.FindGraphNode(node.Value);
+        }
+
         internal static void ConnectNodes(this WorkflowEditor editor, string source, string target)
         {
             var sourceNodes = new[] { editor.FindNode(source) };

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -194,6 +194,22 @@ namespace Bonsai.Editor.Tests
             editor.UngroupGraphNodes(nodesToUngroup);
             assertIsReversible();
         }
+
+        [TestMethod]
+        public void DisconnectGraphNodes_TargetIsNotRoot_InsertAfterClosestRoot()
+        {
+            var workflow = EditorHelper.CreateEditorGraph("A", "B", "C", "D");
+            var (editor, assertIsReversible) = CreateMockEditor(workflow);
+            editor.ConnectNodes("A", "C");
+            editor.ConnectNodes("B", "C");
+            editor.ConnectNodes("C", "D");
+            var sourceNode = editor.FindNode("B");
+            var targetNode = editor.FindNode("C");
+            Assert.AreEqual(expected: editor.Workflow.Count - 1, editor.FindNode("D").Index);
+            editor.DisconnectGraphNodes(new[] { sourceNode }, targetNode);
+            Assert.AreEqual(expected: editor.Workflow.Count - 1, editor.FindNode("B").Index);
+            assertIsReversible();
+        }
     }
 
     static class WorkflowEditorHelper

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -210,6 +210,17 @@ namespace Bonsai.Editor.Tests
             Assert.AreEqual(expected: editor.Workflow.Count - 1, editor.FindNode("B").Index);
             assertIsReversible();
         }
+
+        [TestMethod]
+        public void CreateAnnotation_EmptySelection_InsertAfterClosestRoot()
+        {
+            var workflow = EditorHelper.CreateEditorGraph("A");
+            var (editor, assertIsReversible) = CreateMockEditor(workflow);
+            var annotationBuilder = new AnnotationBuilder();
+            editor.CreateGraphNode(annotationBuilder, null, CreateGraphNodeType.Successor, branch: false);
+            Assert.AreEqual(expected: editor.Workflow.Count - 1, editor.FindNode(annotationBuilder).Index);
+            assertIsReversible();
+        }
     }
 
     static class WorkflowEditorHelper

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -153,7 +153,8 @@ namespace Bonsai.Editor.GraphModel
             Node<ExpressionBuilder, ExpressionBuilderArgument> target,
             CreateGraphNodeType nodeType)
         {
-            var insertOffset = target == null || nodeType == CreateGraphNodeType.Successor ? 1 : 0;
+            if (target == null) return workflow.Count;
+            var insertOffset = nodeType == CreateGraphNodeType.Successor ? 1 : 0;
             return workflow.IndexOf(target) + insertOffset;
         }
 

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -1209,7 +1209,7 @@ namespace Bonsai.Editor.GraphModel
                     _ => false
                 }));
 
-            var reorder = GetSimpleSort();
+            var reorder = GetReversibleSort();
             var updateGraphLayout = CreateUpdateGraphLayoutDelegate();
             var updateSelectedNode = CreateUpdateSelectionDelegate(builder);
             var insertCommands = GetInsertGraphNodeCommands(inspectNode, inspectNode, targetNodes, nodeType, branch, validateInsert);

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -198,7 +198,7 @@ namespace Bonsai.Editor.GraphModel
 
         private void SortWorkflow(ExpressionBuilderGraph workflow)
         {
-            Workflow.InsertRange(0, Workflow.TopologicalSort());
+            workflow.InsertRange(0, workflow.TopologicalSort());
         }
 
         private GraphCommand GetSimpleSort()

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -688,7 +688,9 @@ namespace Bonsai.Editor.GraphModel
             }
 
             GraphCommand reorder;
-            var targetIndex = workflow.IndexOf(target) + 1;
+            var components = workflow.FindConnectedComponents();
+            var targetComponent = components.First(component => component.Contains(target));
+            var targetIndex = LastIndexOfComponentNode(workflow, targetComponent) + 1;
             if (sinkNodes != null)
             {
                 reorder = GetReversibleSort();

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -964,12 +964,23 @@ namespace Bonsai.Editor.GraphModel
             return genericType.MakeGenericType(inspectBuilder.ObservableType).AssemblyQualifiedName;
         }
 
-        public void InsertGraphNode(string typeName, ElementCategory elementCategory, CreateGraphNodeType nodeType, bool branch, bool group)
+        public void CreateGraphNode(
+            string typeName,
+            ElementCategory elementCategory,
+            CreateGraphNodeType nodeType,
+            bool branch,
+            bool group)
         {
-            InsertGraphNode(typeName, elementCategory, nodeType, branch, group, null);
+            CreateGraphNode(typeName, elementCategory, nodeType, branch, group, arguments: null);
         }
 
-        public void InsertGraphNode(string typeName, ElementCategory elementCategory, CreateGraphNodeType nodeType, bool branch, bool group, string arguments)
+        public void CreateGraphNode(
+            string typeName,
+            ElementCategory elementCategory,
+            CreateGraphNodeType nodeType,
+            bool branch,
+            bool group,
+            string arguments)
         {
             if (string.IsNullOrEmpty(typeName))
             {
@@ -1019,11 +1030,6 @@ namespace Bonsai.Editor.GraphModel
 
             builder = CreateBuilder(typeName, elementCategory, group);
             ConfigureBuilder(builder, selectedNode, arguments);
-            if (typeName == typeof(ExternalizedMappingBuilder).AssemblyQualifiedName ||
-                typeName == typeof(AnnotationBuilder).AssemblyQualifiedName)
-            {
-                nodeType = CreateGraphNodeType.Predecessor;
-            }
             var commands = GetCreateGraphNodeCommands(builder, selectedNodes.Select(GetGraphNodeTag), nodeType, branch);
             commandExecutor.BeginCompositeCommand();
             commandExecutor.Execute(EmptyAction, commands.updateLayout.Undo);
@@ -1156,6 +1162,13 @@ namespace Bonsai.Editor.GraphModel
             var inspectParameter = new ExpressionBuilderArgument();
 
             var targetNodes = selectedNodes.ToArray();
+            if (targetNodes.Length > 0 &&
+               (builder is ExternalizedMappingBuilder ||
+                builder is AnnotationBuilder))
+            {
+                nodeType = CreateGraphNodeType.Predecessor;
+            }
+
             var restoreSelectedNodes = CreateUpdateSelectionDelegate(targetNodes);
             if (insertIndex < 0)
             {

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -335,7 +335,7 @@ namespace Bonsai.Editor.GraphView
             bool group,
             string arguments)
         {
-            try { Editor.InsertGraphNode(typeName, elementCategory, nodeType, branch, group, arguments); }
+            try { Editor.CreateGraphNode(typeName, elementCategory, nodeType, branch, group, arguments); }
             catch (TargetInvocationException e)
             {
                 var message = string.Format(Resources.CreateTypeNode_Error, name, e.InnerException.Message);

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1692,7 +1692,7 @@ namespace Bonsai.Editor.GraphView
                 valueProperty.SetValue(propertySource, memberValue);
                 propertySource.MemberName = memberName;
 
-                Editor.CreateGraphNode(propertySource, default(GraphNode), CreateGraphNodeType.Predecessor, branch: true);
+                Editor.CreateGraphNode(propertySource, default(GraphNode), CreateGraphNodeType.Successor, branch: true);
                 contextMenuStrip.Close(ToolStripDropDownCloseReason.ItemClicked);
             });
 


### PR DESCRIPTION
This PR addresses a number of edge cases and improvements to ensure correct workflow sort order during edge disconnects and node creation. Specifically, the following edge case is added to regression testing:

```
A        C
C : A -> B
B
```