### PR TITLE
Improve support for high-frequency visualizers

### DIFF
--- a/Bonsai.Design.Visualizers/BarGraphVisualizer.cs
+++ b/Bonsai.Design.Visualizers/BarGraphVisualizer.cs
@@ -8,7 +8,7 @@ namespace Bonsai.Design.Visualizers
     /// <summary>
     /// Provides a type visualizer to display an object as a bar graph.
     /// </summary>
-    public class BarGraphVisualizer : DialogTypeVisualizer
+    public class BarGraphVisualizer : BufferedVisualizer
     {
         BarGraphBuilder.VisualizerController controller;
         BarGraphView view;

--- a/Bonsai.Design.Visualizers/Bonsai.Design.Visualizers.csproj
+++ b/Bonsai.Design.Visualizers/Bonsai.Design.Visualizers.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Visualizers</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ZedGraph" Version="5.1.7" />

--- a/Bonsai.Design.Visualizers/BufferedVisualizer.cs
+++ b/Bonsai.Design.Visualizers/BufferedVisualizer.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Windows.Forms;
+
+namespace Bonsai.Design.Visualizers
+{
+    /// <summary>
+    /// Provides an abstract base class for type visualizers with an update
+    /// frequency potentially much higher than the screen refresh rate.
+    /// </summary>
+    public abstract class BufferedVisualizer : DialogTypeVisualizer
+    {
+        const int TargetInterval = 1000 / 50;
+
+        internal BufferedVisualizer()
+        {
+        }
+
+        /// <inheritdoc/>
+        public override IObservable<object> Visualize(IObservable<IObservable<object>> source, IServiceProvider provider)
+        {
+            if (provider.GetService(typeof(IDialogTypeVisualizerService)) is not Control visualizerControl)
+            {
+                return source;
+            }
+
+            return Observable.Using(
+                () => new Timer(),
+                timer =>
+                {
+                    timer.Interval = TargetInterval;
+                    var timerTick = Observable.FromEventPattern<EventHandler, EventArgs>(
+                        handler => timer.Tick += handler,
+                        handler => timer.Tick -= handler);
+                    timer.Start();
+                    var mergedSource = source.SelectMany(xs => xs.Do(
+                        _ => { },
+                        () => visualizerControl.BeginInvoke((Action)SequenceCompleted)));
+                    return mergedSource
+                        .Timestamp(HighResolutionScheduler.Default)
+                        .Buffer(() => timerTick)
+                        .Do(buffer =>
+                        {
+                            foreach (var timestamped in buffer)
+                            {
+                                var time = timestamped.Timestamp.LocalDateTime;
+                                Show(time, timestamped.Value);
+                            }
+                        }).Finally(timer.Stop);
+                });
+        }
+
+        /// <summary>
+        /// Updates the type visualizer to display a buffered value object
+        /// received at the specified time.
+        /// </summary>
+        /// <param name="time">The time at which the value was received.</param>
+        /// <param name="value">The value to visualize.</param>
+        protected virtual void Show(DateTime time, object value)
+        {
+            Show(value);
+        }
+    }
+}

--- a/Bonsai.Design.Visualizers/GraphHelper.cs
+++ b/Bonsai.Design.Visualizers/GraphHelper.cs
@@ -80,6 +80,11 @@ namespace Bonsai.Design.Visualizers
 
         internal static Expression SelectIndexMember(Expression expression, string indexSelector, out string indexLabel)
         {
+            return SelectIndexMember(time: null, expression, indexSelector, out indexLabel);
+        }
+
+        internal static Expression SelectIndexMember(Expression time, Expression expression, string indexSelector, out string indexLabel)
+        {
             Expression selectedIndex;
             if (!string.IsNullOrEmpty(indexSelector))
             {
@@ -88,14 +93,14 @@ namespace Bonsai.Design.Visualizers
             }
             else
             {
-                selectedIndex = Expression.Property(null, typeof(DateTime), nameof(DateTime.Now));
+                selectedIndex = time ?? Expression.Property(null, typeof(DateTime), nameof(DateTime.Now));
                 indexLabel = "Time";
             }
 
             if (selectedIndex.Type == typeof(DateTimeOffset)) selectedIndex = Expression.Property(selectedIndex, nameof(DateTimeOffset.DateTime));
             if (selectedIndex.Type == typeof(DateTime))
             {
-                selectedIndex = Expression.Convert(selectedIndex, typeof(ZedGraph.XDate));
+                selectedIndex = Expression.Convert(selectedIndex, typeof(XDate));
             }
 
             return selectedIndex;

--- a/Bonsai.Design.Visualizers/LineGraphVisualizer.cs
+++ b/Bonsai.Design.Visualizers/LineGraphVisualizer.cs
@@ -8,7 +8,7 @@ namespace Bonsai.Design.Visualizers
     /// <summary>
     /// Provides a type visualizer to display an object as a line graph.
     /// </summary>
-    public class LineGraphVisualizer : DialogTypeVisualizer
+    public class LineGraphVisualizer : BufferedVisualizer
     {
         LineGraphBuilder.VisualizerController controller;
         LineGraphView view;

--- a/Bonsai.Design.Visualizers/RollingGraphVisualizer.cs
+++ b/Bonsai.Design.Visualizers/RollingGraphVisualizer.cs
@@ -8,7 +8,7 @@ namespace Bonsai.Design.Visualizers
     /// <summary>
     /// Provides a type visualizer to display an object as a rolling graph.
     /// </summary>
-    public class RollingGraphVisualizer : DialogTypeVisualizer
+    public class RollingGraphVisualizer : BufferedVisualizer
     {
         static readonly TimeSpan TargetElapsedTime = TimeSpan.FromSeconds(1.0 / 30);
         RollingGraphBuilder.VisualizerController controller;
@@ -127,8 +127,13 @@ namespace Bonsai.Design.Visualizers
         /// <inheritdoc/>
         public override void Show(object value)
         {
-            var time = DateTime.Now;
-            controller.AddValues(value, this);
+            Show(DateTime.Now, value);
+        }
+
+        /// <inheritdoc/>
+        protected override void Show(DateTime time, object value)
+        {
+            controller.AddValues(time, value, this);
             if ((time - updateTime) > TargetElapsedTime)
             {
                 view.Graph.Invalidate();

--- a/Bonsai.Design.Visualizers/TimeSeriesVisualizer.cs
+++ b/Bonsai.Design.Visualizers/TimeSeriesVisualizer.cs
@@ -125,7 +125,7 @@ namespace Bonsai.Design.Visualizers
     /// Provides a base class for rolling graph visualizers of multi-dimensional
     /// time series data.
     /// </summary>
-    public class TimeSeriesVisualizerBase : DialogTypeVisualizer
+    public class TimeSeriesVisualizerBase : BufferedVisualizer
     {
         static readonly TimeSpan TargetElapsedTime = TimeSpan.FromSeconds(1.0 / 30);
         internal RollingGraphView view;
@@ -192,6 +192,16 @@ namespace Bonsai.Design.Visualizers
         public override void Show(object value)
         {
             AddValue(DateTime.Now, Convert.ToDouble(value));
+        }
+
+        /// <inheritdoc/>
+        protected override void Show(DateTime time, object value)
+        {
+            if (value is IConvertible convertible)
+            {
+                AddValue(time, convertible.ToDouble(null));
+            }
+            else Show(value);
         }
 
         /// <inheritdoc/>

--- a/Bonsai.Design.Visualizers/TimestampedTimeSeriesVisualizer.cs
+++ b/Bonsai.Design.Visualizers/TimestampedTimeSeriesVisualizer.cs
@@ -40,5 +40,11 @@ namespace Bonsai.Design.Visualizers
             }
             else AddValue(timestamped.Timestamp.DateTime, Convert.ToDouble(timestamped.Value));
         }
+
+        /// <inheritdoc/>
+        protected override void Show(DateTime time, object value)
+        {
+            Show(value);
+        }
     }
 }


### PR DESCRIPTION
This PR introduces a new abstract visualizer class for automatically buffering value updates. This significantly reduces the number of updates to the UI thread coming from high-frequency visualizers, which also prevents crashing X11 services on the cross-platform Linux editor.

All values are still timestamped in the original notification thread before being buffered. The new backwards-compatible virtual call allows access to the original timestamps where needed.