### PR TITLE
Cache configuration parameters for each async call in LoadImage operator

### DIFF
--- a/Bonsai.Shaders.Design/Bonsai.Shaders.Design.csproj
+++ b/Bonsai.Shaders.Design/Bonsai.Shaders.Design.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Shaders Design Graphics OpenGL</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>0.26.0</VersionPrefix>
+    <VersionPrefix>0.27.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="jacobslusser.ScintillaNET" Version="3.6.3" />

--- a/Bonsai.Shaders/Bonsai.Shaders.csproj
+++ b/Bonsai.Shaders/Bonsai.Shaders.csproj
@@ -5,7 +5,7 @@
     <Description>Bonsai Shaders Library containing modules for dynamic control of shader primitives.</Description>
     <PackageTags>Bonsai Rx Shaders Graphics OpenGL</PackageTags>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>0.26.0</VersionPrefix>
+    <VersionPrefix>0.27.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenCV.Net" Version="3.4.1" />

--- a/Bonsai.Shaders/LoadImage.cs
+++ b/Bonsai.Shaders/LoadImage.cs
@@ -185,7 +185,7 @@ namespace Bonsai.Shaders
         public IObservable<Texture> Generate<TSource>(IObservable<TSource> source)
         {
             var update = updateFrame.Generate();
-            return ShaderManager.WindowSource.SelectMany(window =>
+            return ShaderManager.WindowSource.Take(1).SelectMany(window =>
                 source.Select(_ => CloneImageConfiguration())
                       .Buffer(update)
                       .SelectMany(xs => xs)


### PR DESCRIPTION
To avoid inconsistent access to shared state, this PR now clones the image configuration prior to the asynchronous call to load and upload the buffer to the GL texture memory.

This will allow dynamic modifications to any properties of the `LoadImage` operator as long as they are done synchronously with notifications coming from the input source sequence.

Fixes #1417