### PR TITLE
Bump NuGet.Protocol from 6.3.1 to 6.6.1

### DIFF
--- a/Bonsai.NuGet/Bonsai.NuGet.csproj
+++ b/Bonsai.NuGet/Bonsai.NuGet.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Rx-Main" Version="2.2.5" />
-    <PackageReference Include="NuGet.Protocol" Version="6.3.1" />
-    <PackageReference Include="NuGet.Resolver" Version="6.3.1" />
+    <PackageReference Include="NuGet.Protocol" Version="6.6.1" />
+    <PackageReference Include="NuGet.Resolver" Version="6.6.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">


### PR DESCRIPTION
This PR updates the NuGet protocol version to address the dependabot security advisory:

https://github.com/bonsai-rx/bonsai/security/dependabot/2