### PR TITLE
Add keyboard shortcut for changing history length

### DIFF
--- a/Bonsai.Dsp.Design/Bonsai.Dsp.Design.csproj
+++ b/Bonsai.Dsp.Design/Bonsai.Dsp.Design.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Dsp Visualizers</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.Design.Visualizers\Bonsai.Design.Visualizers.csproj" />

--- a/Bonsai.Dsp.Design/WaveformView.cs
+++ b/Bonsai.Dsp.Design/WaveformView.cs
@@ -322,6 +322,18 @@ namespace Bonsai.Dsp.Design
                 SelectedPage--;
             }
 
+            if (modifiers.HasFlag(Keys.Control) && keyCode == Keys.Oemplus)
+            {
+                var factor = modifiers.HasFlag(Keys.Shift) ? 10 : 1;
+                HistoryLength += factor;
+            }
+
+            if (modifiers.HasFlag(Keys.Control) && keyCode == Keys.OemMinus)
+            {
+                var factor = modifiers.HasFlag(Keys.Shift) ? 10 : 1;
+                HistoryLength = Math.Max(1, HistoryLength - factor);
+            }
+
             return base.ProcessDialogKey(keyData);
         }
 

--- a/Bonsai.Dsp/Bonsai.Dsp.csproj
+++ b/Bonsai.Dsp/Bonsai.Dsp.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Dsp Signal Processing</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenCV.Net" Version="3.4.1" />


### PR DESCRIPTION
Changing the history length of the buffered visualizers for high-frequency waveforms is a common operation for monitoring signals over longer time periods. The only way to do it interactively is currently through the UI of the `MatVisualizer`, by right-clicking the window to bring up the status bar, then selecting a small arrow drop-down at the bottom-right corner and changing a number by hand in a text box.

This PR simplifies this operation by introducing a keyboard shortcut (`Ctrl + Plus` and `Ctrl + Minus` respectively) to step up and down history length by 1. Holding `Ctrl + Shift + Plus` or `Ctrl + Shift + Minus` will increase/decrease the history length by 10.