### PR TITLE
Early error checking and file name generation for FileSink

### DIFF
--- a/Bonsai.System/IO/FileSink.cs
+++ b/Bonsai.System/IO/FileSink.cs
@@ -117,6 +117,11 @@ namespace Bonsai.IO
             Func<TElement, TSource> selector,
             string fileName)
         {
+            if (string.IsNullOrEmpty(fileName))
+            {
+                throw new InvalidOperationException("A valid file path must be specified.");
+            }
+
             if (source == null)
             {
                 throw new ArgumentNullException(nameof(source));
@@ -129,6 +134,13 @@ namespace Bonsai.IO
 
             return Observable.Create<TElement>(observer =>
             {
+                PathHelper.EnsureDirectory(fileName);
+                fileName = PathHelper.AppendSuffix(fileName, Suffix);
+                if (File.Exists(fileName) && !Overwrite)
+                {
+                    throw new IOException(string.Format("The file '{0}' already exists.", fileName));
+                }
+
                 var disposable = new WriterDisposable<TWriter>(Buffered);
                 var process = source.Do(element =>
                 {
@@ -140,18 +152,6 @@ namespace Bonsai.IO
                             var runningWriter = disposable.Writer;
                             if (runningWriter == null)
                             {
-                                if (string.IsNullOrEmpty(fileName))
-                                {
-                                    throw new InvalidOperationException("A valid file path must be specified.");
-                                }
-
-                                PathHelper.EnsureDirectory(fileName);
-                                fileName = PathHelper.AppendSuffix(fileName, Suffix);
-                                if (File.Exists(fileName) && !Overwrite)
-                                {
-                                    throw new IOException(string.Format("The file '{0}' already exists.", fileName));
-                                }
-
                                 runningWriter = disposable.Writer = CreateWriter(fileName, input);
                             }
 


### PR DESCRIPTION
`FileSink` writers are used when file creation needs to be deferred until the first element of the observable sequence is provided (e.g. if opening the writer requires knowing the size of a video frame).

Previously, all checks on file name were deferred until this moment. However, for improved consistency with support for early binding of file name provided by #1377, this PR moves most of the checks earlier in the observable lifetime, so that it does not become necessary to wait until a value is finally produced to detect an error in the specified file name. For example, the arrival of the first element can take several hours for infrequent events and can be frustrating to find out only at that time that we forgot to provide a non-empty file name.