### PR TITLE
Allow lazy initialization of webview panel

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2336,7 +2336,7 @@ namespace Bonsai.Editor
                 var editorControl = selectionModel.SelectedView.EditorControl;
                 var url = await documentationProvider.GetDocumentationAsync(assemblyName, uid);
                 if (!ModifierKeys.HasFlag(Keys.Control) &&
-                    editorControl.AnnotationPanel.WebViewInitialized)
+                    editorControl.AnnotationPanel.HasWebView)
                 {
                     editorControl.AnnotationPanel.Navigate(url.AbsoluteUri);
                     var nameSeparator = uid.LastIndexOf(ExpressionHelper.MemberSeparator);


### PR DESCRIPTION
The WebView2 control is significantly costly to initialize as it relies on full-blown chromium. Since each of the workflow editor windows may have one of these, it is best to delay the complete initialization call for when the annotation panel actually loads to make for a smoother editor startup experience.