### PR TITLE
Simplify qualified name for workflow element icons

### DIFF
--- a/Bonsai.Core/Expressions/AsyncSubjectBuilder.cs
+++ b/Bonsai.Core/Expressions/AsyncSubjectBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Reactive.Subjects;
 using System.Xml.Serialization;
@@ -10,8 +10,8 @@ namespace Bonsai.Expressions
     /// </summary>
     [Obsolete]
     [ProxyType(typeof(Reactive.AsyncSubject))]
+    [WorkflowElementIcon(nameof(AsyncSubjectBuilder))]
     [XmlType("AsyncSubject", Namespace = Constants.XmlNamespace)]
-    [WorkflowElementIcon(typeof(AsyncSubjectBuilder), nameof(AsyncSubjectBuilder))]
     [Description("Broadcasts the last value of an observable sequence to all subscribed and future observers using a shared subject.")]
     public class AsyncSubjectBuilder : Reactive.AsyncSubject
     {
@@ -27,8 +27,8 @@ namespace Bonsai.Expressions
     /// <typeparam name="T">The type of the result stored by the subject.</typeparam>
     [Obsolete]
     [ProxyType(typeof(Reactive.AsyncSubject<>))]
+    [WorkflowElementIcon(nameof(AsyncSubjectBuilder))]
     [XmlType("AsyncSubject", Namespace = Constants.XmlNamespace)]
-    [WorkflowElementIcon(typeof(AsyncSubjectBuilder), nameof(AsyncSubjectBuilder))]
     [Description("Broadcasts the result of the first observable sequence to complete to all subscribed and future observers.")]
     public class AsyncSubjectBuilder<T> : SubjectBuilder<T>
     {

--- a/Bonsai.Core/Expressions/BehaviorSubjectBuilder.cs
+++ b/Bonsai.Core/Expressions/BehaviorSubjectBuilder.cs
@@ -10,8 +10,8 @@ namespace Bonsai.Expressions
     /// </summary>
     [Obsolete]
     [ProxyType(typeof(Reactive.BehaviorSubject))]
+    [WorkflowElementIcon(nameof(BehaviorSubjectBuilder))]
     [XmlType("BehaviorSubject", Namespace = Constants.XmlNamespace)]
-    [WorkflowElementIcon(typeof(BehaviorSubjectBuilder), nameof(BehaviorSubjectBuilder))]
     [Description("Broadcasts the latest value of an observable sequence to all subscribed and future observers using a shared subject.")]
     public class BehaviorSubjectBuilder : Reactive.BehaviorSubject
     {
@@ -27,8 +27,8 @@ namespace Bonsai.Expressions
     /// <typeparam name="T">The type of the elements processed by the subject.</typeparam>
     [Obsolete]
     [ProxyType(typeof(Reactive.BehaviorSubject<>))]
+    [WorkflowElementIcon(nameof(BehaviorSubjectBuilder))]
     [XmlType("BehaviorSubject", Namespace = Constants.XmlNamespace)]
-    [WorkflowElementIcon(typeof(BehaviorSubjectBuilder), nameof(BehaviorSubjectBuilder))]
     [Description("Broadcasts the latest value from other observable sequences to all subscribed and future observers.")]
     public class BehaviorSubjectBuilder<T> : SubjectBuilder<T>
     {

--- a/Bonsai.Core/Expressions/PublishSubjectBuilder.cs
+++ b/Bonsai.Core/Expressions/PublishSubjectBuilder.cs
@@ -10,8 +10,8 @@ namespace Bonsai.Expressions
     /// </summary>
     [Obsolete]
     [ProxyType(typeof(Reactive.PublishSubject))]
+    [WorkflowElementIcon(nameof(PublishSubjectBuilder))]
     [XmlType("PublishSubject", Namespace = Constants.XmlNamespace)]
-    [WorkflowElementIcon(typeof(PublishSubjectBuilder), nameof(PublishSubjectBuilder))]
     [Description("Broadcasts the values of an observable sequence to multiple subscribers using a shared subject.")]
     public class PublishSubjectBuilder : Reactive.PublishSubject
     {
@@ -23,8 +23,8 @@ namespace Bonsai.Expressions
     /// <typeparam name="T">The type of the elements processed by the subject.</typeparam>
     [Obsolete]
     [ProxyType(typeof(Reactive.PublishSubject<>))]
+    [WorkflowElementIcon(nameof(PublishSubjectBuilder))]
     [XmlType("PublishSubject", Namespace = Constants.XmlNamespace)]
-    [WorkflowElementIcon(typeof(PublishSubjectBuilder), nameof(PublishSubjectBuilder))]
     [Description("Broadcasts the values from other observable sequences to multiple subscribers.")]
     public class PublishSubjectBuilder<T> : SubjectBuilder<T>
     {

--- a/Bonsai.Core/Expressions/ReplaySubjectBuilder.cs
+++ b/Bonsai.Core/Expressions/ReplaySubjectBuilder.cs
@@ -12,8 +12,8 @@ namespace Bonsai.Expressions
     /// </summary>
     [Obsolete]
     [ProxyType(typeof(Reactive.ReplaySubject))]
+    [WorkflowElementIcon(nameof(ReplaySubjectBuilder))]
     [XmlType("ReplaySubject", Namespace = Constants.XmlNamespace)]
-    [WorkflowElementIcon(typeof(ReplaySubjectBuilder), nameof(ReplaySubjectBuilder))]
     [Description("Replays the values of an observable sequence to all subscribed and future observers using a shared subject.")]
     public class ReplaySubjectBuilder : SubjectBuilder
     {
@@ -90,8 +90,8 @@ namespace Bonsai.Expressions
     /// <typeparam name="T">The type of the elements processed by the subject.</typeparam>
     [Obsolete]
     [ProxyType(typeof(Reactive.ReplaySubject<>))]
+    [WorkflowElementIcon(nameof(ReplaySubjectBuilder))]
     [XmlType("ReplaySubject", Namespace = Constants.XmlNamespace)]
-    [WorkflowElementIcon(typeof(ReplaySubjectBuilder), nameof(ReplaySubjectBuilder))]
     [Description("Replays the values of other observable sequences to all subscribed and future observers.")]
     public class ReplaySubjectBuilder<T> : SubjectBuilder<T>
     {

--- a/Bonsai.Core/Expressions/ResourceSubjectBuilder.cs
+++ b/Bonsai.Core/Expressions/ResourceSubjectBuilder.cs
@@ -10,8 +10,8 @@ namespace Bonsai.Expressions
     /// </summary>
     [Obsolete]
     [ProxyType(typeof(Reactive.ResourceSubject))]
+    [WorkflowElementIcon(nameof(ResourceSubjectBuilder))]
     [XmlType("ResourceSubject", Namespace = Constants.XmlNamespace)]
-    [WorkflowElementIcon(typeof(ResourceSubjectBuilder), nameof(ResourceSubjectBuilder))]
     [Description("Stores a disposable resource and shares it with all subscribed and future observers.")]
     public class ResourceSubjectBuilder : Reactive.ResourceSubject
     {
@@ -27,8 +27,8 @@ namespace Bonsai.Expressions
     /// <typeparam name="T">The type of the disposable resource stored by the subject.</typeparam>
     [Obsolete]
     [ProxyType(typeof(Reactive.ResourceSubject<>))]
+    [WorkflowElementIcon(nameof(ResourceSubjectBuilder))]
     [XmlType("ResourceSubject", Namespace = Constants.XmlNamespace)]
-    [WorkflowElementIcon(typeof(ResourceSubjectBuilder), nameof(ResourceSubjectBuilder))]
     [Description("Stores a disposable resource and shares it with all subscribed and future observers.")]
     public class ResourceSubjectBuilder<T> : SubjectBuilder<T> where T : class, IDisposable
     {

--- a/Bonsai.Core/Expressions/SubjectExpressionBuilder.cs
+++ b/Bonsai.Core/Expressions/SubjectExpressionBuilder.cs
@@ -6,7 +6,7 @@ namespace Bonsai.Expressions
     /// Provides a base class for expression builders that declare shared subjects. This is an abstract class.
     /// </summary>
     [DefaultProperty(nameof(Name))]
-    [WorkflowElementIcon(typeof(SubjectExpressionBuilder), nameof(SubjectExpressionBuilder))]
+    [WorkflowElementIcon(nameof(SubjectExpressionBuilder))]
     public abstract class SubjectExpressionBuilder : VariableArgumentExpressionBuilder, INamedElement
     {
         /// <summary>

--- a/Bonsai.Core/Expressions/SubscribeSubject.cs
+++ b/Bonsai.Core/Expressions/SubscribeSubject.cs
@@ -84,7 +84,7 @@ namespace Bonsai.Expressions
     /// </summary>
     /// <typeparam name="T">The type of the elements processed by the subject.</typeparam>
     [XmlType(Namespace = Constants.XmlNamespace)]
-    [WorkflowElementIcon(typeof(SubscribeSubject), nameof(SubscribeSubject))]
+    [WorkflowElementIcon(nameof(SubscribeSubject))]
     public class SubscribeSubject<T> : SubscribeSubject
     {
         /// <summary>

--- a/Bonsai.Core/Expressions/VisualizerMappingBuilder.cs
+++ b/Bonsai.Core/Expressions/VisualizerMappingBuilder.cs
@@ -12,8 +12,8 @@ namespace Bonsai.Expressions
     /// in a mashup visualizer.
     /// </summary>
     [WorkflowElementCategory(ElementCategory.Property)]
+    [WorkflowElementIcon("Bonsai:ElementIcon.Visualizer")]
     [XmlType("VisualizerMapping", Namespace = Constants.XmlNamespace)]
-    [WorkflowElementIcon(typeof(ElementCategory), "ElementIcon.Visualizer")]
     [Description("Specifies an observable sequence to be combined in a mashup visualizer.")]
     public sealed class VisualizerMappingBuilder : SingleArgumentExpressionBuilder, INamedElement, IArgumentBuilder, ISerializableElement
     {

--- a/Bonsai.Core/Expressions/WorkflowInputBuilder.cs
+++ b/Bonsai.Core/Expressions/WorkflowInputBuilder.cs
@@ -66,8 +66,8 @@ namespace Bonsai.Expressions
     /// <typeparam name="TSource">
     /// The type of the elements in the generated observable sequence.
     /// </typeparam>
+    [WorkflowElementIcon(nameof(WorkflowInputBuilder))]
     [XmlType("WorkflowInput", Namespace = Constants.XmlNamespace)]
-    [WorkflowElementIcon(typeof(WorkflowInputBuilder), nameof(WorkflowInputBuilder))]
     public class WorkflowInputBuilder<TSource> : WorkflowInputBuilder
     {
         /// <inheritdoc/>

--- a/Bonsai.Core/Reactive/Subjects/AsyncSubject.cs
+++ b/Bonsai.Core/Reactive/Subjects/AsyncSubject.cs
@@ -11,8 +11,8 @@ namespace Bonsai.Reactive
     /// Represents an expression builder that broadcasts the last value of an observable
     /// sequence to all subscribed and future observers using a shared subject.
     /// </summary>
+    [WorkflowElementIcon(nameof(AsyncSubject))]
     [XmlType(Namespace = Constants.ReactiveXmlNamespace)]
-    [WorkflowElementIcon(typeof(AsyncSubject), nameof(AsyncSubject))]
     [Description("Broadcasts the last value of an observable sequence to all subscribed and future observers using a shared subject.")]
     public class AsyncSubject : SubjectBuilder
     {
@@ -35,8 +35,8 @@ namespace Bonsai.Reactive
     /// sequence to complete to all subscribed and future observers.
     /// </summary>
     /// <typeparam name="T">The type of the result stored by the subject.</typeparam>
+    [WorkflowElementIcon(nameof(AsyncSubject))]
     [XmlType(Namespace = Constants.ReactiveXmlNamespace)]
-    [WorkflowElementIcon(typeof(AsyncSubject), nameof(AsyncSubject))]
     [Description("Broadcasts the result of the first observable sequence to complete to all subscribed and future observers.")]
     public class AsyncSubject<T> : SubjectBuilder<T>
     {

--- a/Bonsai.Core/Reactive/Subjects/BehaviorSubject.cs
+++ b/Bonsai.Core/Reactive/Subjects/BehaviorSubject.cs
@@ -12,8 +12,8 @@ namespace Bonsai.Reactive
     /// Represents an expression builder that broadcasts the latest value of an observable
     /// sequence to all subscribed and future observers using a shared subject.
     /// </summary>
+    [WorkflowElementIcon(nameof(BehaviorSubject))]
     [XmlType(Namespace = Constants.ReactiveXmlNamespace)]
-    [WorkflowElementIcon(typeof(BehaviorSubject), nameof(BehaviorSubject))]
     [Description("Broadcasts the latest value of an observable sequence to all subscribed and future observers using a shared subject.")]
     public class BehaviorSubject : SubjectBuilder
     {
@@ -36,8 +36,8 @@ namespace Bonsai.Reactive
     /// sequences to all subscribed and future observers.
     /// </summary>
     /// <typeparam name="T">The type of the elements processed by the subject.</typeparam>
+    [WorkflowElementIcon(nameof(BehaviorSubject))]
     [XmlType(Namespace = Constants.ReactiveXmlNamespace)]
-    [WorkflowElementIcon(typeof(BehaviorSubject), nameof(BehaviorSubject))]
     [Description("Broadcasts the latest value from other observable sequences to all subscribed and future observers.")]
     public class BehaviorSubject<T> : SubjectBuilder<T>
     {

--- a/Bonsai.Core/Reactive/Subjects/PublishSubject.cs
+++ b/Bonsai.Core/Reactive/Subjects/PublishSubject.cs
@@ -10,8 +10,8 @@ namespace Bonsai.Reactive
     /// Represents an expression builder that broadcasts the values of an observable
     /// sequence to multiple subscribers using a shared subject.
     /// </summary>
+    [WorkflowElementIcon(nameof(PublishSubject))]
     [XmlType(Namespace = Constants.ReactiveXmlNamespace)]
-    [WorkflowElementIcon(typeof(PublishSubject), nameof(PublishSubject))]
     [Description("Broadcasts the values of an observable sequence to multiple subscribers using a shared subject.")]
     public class PublishSubject : SubjectBuilder
     {
@@ -28,8 +28,8 @@ namespace Bonsai.Reactive
     /// sequences to multiple subscribers.
     /// </summary>
     /// <typeparam name="T">The type of the elements processed by the subject.</typeparam>
+    [WorkflowElementIcon(nameof(PublishSubject))]
     [XmlType(Namespace = Constants.ReactiveXmlNamespace)]
-    [WorkflowElementIcon(typeof(PublishSubject), nameof(PublishSubject))]
     [Description("Broadcasts the values from other observable sequences to multiple subscribers.")]
     public class PublishSubject<T> : SubjectBuilder<T>
     {

--- a/Bonsai.Core/Reactive/Subjects/ReplaySubject.cs
+++ b/Bonsai.Core/Reactive/Subjects/ReplaySubject.cs
@@ -13,8 +13,8 @@ namespace Bonsai.Reactive
     /// Represents an expression builder that replays the values of an observable
     /// sequence to all subscribed and future observers using a shared subject.
     /// </summary>
+    [WorkflowElementIcon(nameof(ReplaySubject))]
     [XmlType(Namespace = Constants.ReactiveXmlNamespace)]
-    [WorkflowElementIcon(typeof(ReplaySubject), nameof(ReplaySubject))]
     [Description("Replays the values of an observable sequence to all subscribed and future observers using a shared subject.")]
     public class ReplaySubject : SubjectBuilder
     {
@@ -81,8 +81,8 @@ namespace Bonsai.Reactive
     /// sequences to all subscribed and future observers.
     /// </summary>
     /// <typeparam name="T">The type of the elements processed by the subject.</typeparam>
+    [WorkflowElementIcon(nameof(ReplaySubject))]
     [XmlType(Namespace = Constants.ReactiveXmlNamespace)]
-    [WorkflowElementIcon(typeof(ReplaySubject), nameof(ReplaySubject))]
     [Description("Replays the values of other observable sequences to all subscribed and future observers.")]
     public class ReplaySubject<T> : SubjectBuilder<T>
     {

--- a/Bonsai.Core/Reactive/Subjects/ResourceSubject.cs
+++ b/Bonsai.Core/Reactive/Subjects/ResourceSubject.cs
@@ -13,8 +13,8 @@ namespace Bonsai.Reactive
     /// value of an observable sequence to all subscribed and future observers. The value
     /// is disposed when the containing context is closed.
     /// </summary>
+    [WorkflowElementIcon(nameof(ResourceSubject))]
     [XmlType(Namespace = Constants.ReactiveXmlNamespace)]
-    [WorkflowElementIcon(typeof(ResourceSubject), nameof(ResourceSubject))]
     [Description("Stores a disposable resource and shares it with all subscribed and future observers.")]
     public class ResourceSubject : SubjectBuilder
     {
@@ -38,8 +38,8 @@ namespace Bonsai.Reactive
     /// is disposed when the containing context is closed.
     /// </summary>
     /// <typeparam name="T">The type of the disposable resource stored by the subject.</typeparam>
+    [WorkflowElementIcon(nameof(ResourceSubject))]
     [XmlType(Namespace = Constants.ReactiveXmlNamespace)]
-    [WorkflowElementIcon(typeof(ResourceSubject), nameof(ResourceSubject))]
     [Description("Stores a disposable resource and shares it with all subscribed and future observers.")]
     public class ResourceSubject<T> : SubjectBuilder<T> where T : class, IDisposable
     {

--- a/Bonsai.Editor/GraphModel/ElementIcon.cs
+++ b/Bonsai.Editor/GraphModel/ElementIcon.cs
@@ -57,7 +57,15 @@ namespace Bonsai.Editor.GraphModel
         {
             var iconAttribute = workflowElementType.GetCustomAttribute<WorkflowElementIconAttribute>() ?? WorkflowElementIconAttribute.Default;
             resourceQualifier = Type.GetType(iconAttribute.TypeName ?? string.Empty, false) ?? workflowElementType;
-            if (!string.IsNullOrEmpty(iconAttribute.Name)) defaultName = iconAttribute.Name;
+            if (!string.IsNullOrEmpty(iconAttribute.Name))
+            {
+                defaultName = iconAttribute.Name;
+                if (defaultName.IndexOf(AssemblySeparator) >= 0)
+                {
+                    resourceQualifier = null;
+                    return;
+                }
+            }
             else defaultName = resourceQualifier.Name;
             if (resourceQualifier.Namespace != null)
             {

--- a/Bonsai.Vision/Bonsai.Vision.csproj
+++ b/Bonsai.Vision/Bonsai.Vision.csproj
@@ -5,7 +5,7 @@
     <Description>Bonsai Vision Library containing reactive algorithms for computer vision and image processing.</Description>
     <PackageTags>Bonsai Rx Image Processing Computer Vision</PackageTags>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenCV.Net" Version="3.4.1" />

--- a/Bonsai.Vision/CameraCapture.cs
+++ b/Bonsai.Vision/CameraCapture.cs
@@ -11,7 +11,7 @@ namespace Bonsai.Vision
     /// the specified camera.
     /// </summary>
     [DefaultProperty(nameof(Index))]
-    [WorkflowElementIcon(typeof(ElementCategory), "ElementIcon.Video")]
+    [WorkflowElementIcon("Bonsai:ElementIcon.Video")]
     [Description("Generates a sequence of images acquired from the specified camera.")]
     public class CameraCapture : Source<IplImage>
     {

--- a/Bonsai.Vision/FileCapture.cs
+++ b/Bonsai.Vision/FileCapture.cs
@@ -14,7 +14,7 @@ namespace Bonsai.Vision
     /// specified movie file.
     /// </summary>
     [DefaultProperty(nameof(FileName))]
-    [WorkflowElementIcon(typeof(ElementCategory), "ElementIcon.Video")]
+    [WorkflowElementIcon("Bonsai:ElementIcon.Video")]
     [Description("Generates a sequence of images from the specified movie file.")]
     public class FileCapture : Source<IplImage>
     {

--- a/Bonsai.Vision/VideoWriter.cs
+++ b/Bonsai.Vision/VideoWriter.cs
@@ -10,7 +10,7 @@ namespace Bonsai.Vision
     /// <summary>
     /// Represents an operator that writes a sequence of images into a compressed AVI file.
     /// </summary>
-    [WorkflowElementIcon(typeof(ElementCategory), "ElementIcon.Video")]
+    [WorkflowElementIcon("Bonsai:ElementIcon.Video")]
     [Description("Writes a sequence of images into a compressed AVI file.")]
     public class VideoWriter : FileSink<IplImage, VideoWriterDisposable>
     {


### PR DESCRIPTION
This PR unifies the qualified name syntax for workflow element icons between `WorkflowElementIcon` and `WorkflowNamespaceIcon` attributes. The qualified name can now be prefixed with the assembly name in both cases.

The resource qualifier may also be omitted either when providing an assembly name or when an icon matching the full name of the type is already provided by the editor assembly.