### PR TITLE
Avoid returning resources declared inside disabled nodes

### DIFF
--- a/Bonsai.System/IO/Ports/PortNameConverter.cs
+++ b/Bonsai.System/IO/Ports/PortNameConverter.cs
@@ -20,6 +20,7 @@ namespace Bonsai.IO
                 if (workflowBuilder != null)
                 {
                     var portNames = (from builder in workflowBuilder.Workflow.Descendants()
+                                     where builder is not DisableBuilder
                                      let createPort = ExpressionBuilder.GetWorkflowElement(builder) as CreateSerialPort
                                      where createPort != null && !string.IsNullOrEmpty(createPort.PortName)
                                      select !string.IsNullOrEmpty(createPort.Name) ? createPort.Name : createPort.PortName)

--- a/Bonsai.System/Resources/ResourceNameConverter.cs
+++ b/Bonsai.System/Resources/ResourceNameConverter.cs
@@ -48,6 +48,7 @@ namespace Bonsai.Resources
             foreach (var node in source)
             {
                 var element = ExpressionBuilder.Unwrap(node.Value);
+                if (element is DisableBuilder) continue;
                 yield return element;
 
                 var workflowBuilder = element as IWorkflowExpressionBuilder;


### PR DESCRIPTION
The base abstract resource name converter class is modified to filter out resources which are declared inside disabled nodes. This avoids listing in the converter drop-down any resources that will not be available at runtime.

Fixes #1438 