### PR TITLE
Update package template debug settings for new bootstrapper

### DIFF
--- a/Bonsai.Templates/Bonsai.PackageTemplate/launchSettings.json
+++ b/Bonsai.Templates/Bonsai.PackageTemplate/launchSettings.json
@@ -3,7 +3,8 @@
     "Bonsai": {
       "commandName": "Executable",
       "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Goncalo Lopes\\Bonsai@InstallDir)Bonsai.exe",
-      "commandLineArgs": "--lib:\"$(TargetDir).\""
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/Bonsai.Templates/Bonsai.PackageTemplate/launchSettings.json
+++ b/Bonsai.Templates/Bonsai.PackageTemplate/launchSettings.json
@@ -3,7 +3,7 @@
     "Bonsai": {
       "commandName": "Executable",
       "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Goncalo Lopes\\Bonsai@InstallDir)Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "commandLineArgs": "--lib:\"$(TargetDir).\""
     }
   }
 }


### PR DESCRIPTION
This PR updates the default debugger launch settings in the package project template to make it easier to debug custom packages against the new bootstrapper. The main difference from the previous settings is enabling the native debugger, which is now required for attaching breakpoints to the child processes initiated by the bootstrapper. Child processes are now used instead of managed AppDomain instances to improve the cross-platform experience and to start migrating into the new .NET Core world which does not allow for multiple AppDomain instances at all.

Fixes #1402 