### PR TITLE
Refactor arduino interface to avoid event callback

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,7 @@ e12cd15478ef4dd7cc2a391ae74d877f33acee97
 
 # Ensure unix portability of uri launcher
 a949f77d92437690840a24857f421c0f47161d43
+
+# Move arduino package into separate repository
+1804cdb10530babc3146f9c07bc7d23a877a93f5
+1a60ab3cd625cb89e29531895efdd96936c2c271

--- a/Bonsai.Arduino/AnalogInput.cs
+++ b/Bonsai.Arduino/AnalogInput.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Bonsai.Arduino
+{
+    /// <summary>
+    /// Represents an operator that generates a sequence of digitized analog readings
+    /// from the specified Arduino input pin.
+    /// </summary>
+    [DefaultProperty(nameof(Pin))]
+    [Description("Generates a sequence of digitized analog readings from the specified Arduino input pin.")]
+    public class AnalogInput : Source<int>
+    {
+        /// <summary>
+        /// Gets or sets the name of the serial port used to communicate with the Arduino.
+        /// </summary>
+        [TypeConverter(typeof(PortNameConverter))]
+        [Description("The name of the serial port used to communicate with the Arduino.")]
+        public string PortName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the analog input pin number from which to take readings.
+        /// </summary>
+        [Description("The analog input pin number from which to take readings.")]
+        public int Pin { get; set; }
+
+        /// <summary>
+        /// Generates an observable sequence of digitized analog values. 
+        /// </summary>
+        /// <returns>
+        /// A sequence of <see cref="int"/> values that report the digitized analog
+        /// readings from the specified Arduino analog input pin.
+        /// </returns>
+        public override IObservable<int> Generate()
+        {
+            return ObservableArduino.AnalogInput(PortName, Pin);
+        }
+    }
+}

--- a/Bonsai.Arduino/AnalogInputReceivedEventArgs.cs
+++ b/Bonsai.Arduino/AnalogInputReceivedEventArgs.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Bonsai.Arduino
+{
+    /// <summary>
+    /// Provides data for the <see cref="Arduino.AnalogInputReceived"/> event.
+    /// </summary>
+    public class AnalogInputReceivedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AnalogInputReceivedEventArgs"/>
+        /// class using the pin number and analog value received in the analog input message.
+        /// </summary>
+        /// <param name="pin">The pin number from which the analog value was sampled.</param>
+        /// <param name="value">The digitized analog value.</param>
+        public AnalogInputReceivedEventArgs(int pin, int value)
+        {
+            Pin = pin;
+            Value = value;
+        }
+
+        /// <summary>
+        /// Gets the pin number from which the analog value was sampled.
+        /// </summary>
+        public int Pin { get; private set; }
+
+        /// <summary>
+        /// Gets the digitized analog value.
+        /// </summary>
+        public int Value { get; private set; }
+    }
+}

--- a/Bonsai.Arduino/AnalogOutput.cs
+++ b/Bonsai.Arduino/AnalogOutput.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+
+namespace Bonsai.Arduino
+{
+    /// <summary>
+    /// Represents an operator that writes the sequence of numerical values to the
+    /// specified Arduino output pin using PWM.
+    /// </summary>
+    [DefaultProperty(nameof(Pin))]
+    [Description("Writes the sequence of numerical values to the specified Arduino output pin using PWM.")]
+    public class AnalogOutput : Sink<int>
+    {
+        /// <summary>
+        /// Gets or sets the name of the serial port used to communicate with the Arduino.
+        /// </summary>
+        [TypeConverter(typeof(PortNameConverter))]
+        [Description("The name of the serial port used to communicate with the Arduino.")]
+        public string PortName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the digital output (PWM) pin number on which to write values.
+        /// </summary>
+        [Description("The digital output (PWM) pin number on which to write values.")]
+        public int Pin { get; set; }
+
+        /// <summary>
+        /// Writes a sequence of <see cref="int"/> values to the specified Arduino output pin using PWM.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="int"/> values to write into the specified Arduino output pin.
+        /// </param>
+        /// <returns>
+        /// A sequence of the <see cref="int"/> values which have been written into the Arduino
+        /// output pin.
+        /// </returns>
+        /// <remarks>
+        /// This operator only subscribes to the <paramref name="source"/> sequence after initializing
+        /// the connection to the Arduino and configuring the output pin mode to PWM.
+        /// </remarks>
+        public override IObservable<int> Process(IObservable<int> source)
+        {
+            return Observable.Using(
+                cancellationToken => ArduinoManager.ReserveConnectionAsync(PortName),
+                (connection, cancellationToken) =>
+                {
+                    var pin = Pin;
+                    connection.Arduino.PinMode(pin, PinMode.Pwm);
+                    return Task.FromResult(source.Do(value =>
+                    {
+                        lock (connection.Arduino)
+                        {
+                            connection.Arduino.AnalogWrite(pin, value);
+                        }
+                    }));
+                });
+        }
+    }
+}

--- a/Bonsai.Arduino/Arduino.cs
+++ b/Bonsai.Arduino/Arduino.cs
@@ -1,0 +1,606 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO.Ports;
+using System.Threading;
+
+namespace Bonsai.Arduino
+{
+    /// <summary>
+    /// Represents an Arduino board communicating with the host computer using
+    /// the Firmata protocol.
+    /// </summary>
+    public sealed class Arduino : IDisposable
+    {
+        #region Constants
+
+        /// <summary>
+        /// Represents the default serial baud rate used to communicate with the Arduino.
+        /// </summary>
+        public const int DefaultBaudRate = 57600;
+
+        /// <summary>
+        /// Represents the default sampling interval for analog pins.
+        /// </summary>
+        public const int DefaultSamplingInterval = 19;
+
+        const int MaxDataBytes = 32;
+        const int ConnectionDelay = 2000;
+
+        const byte DIGITAL_MESSAGE   = 0x90; // send data for a digital port
+        const byte ANALOG_MESSAGE    = 0xE0; // send data for an analog pin (or PWM)
+        const byte REPORT_ANALOG     = 0xC0; // enable analog input by pin #
+        const byte REPORT_DIGITAL    = 0xD0; // enable digital input by port
+        const byte SET_PIN_MODE      = 0xF4; // set a pin to INPUT/OUTPUT/PWM/etc
+        const byte REPORT_VERSION    = 0xF9; // report firmware version
+        const byte SYSTEM_RESET      = 0xFF; // reset from MIDI
+        const byte START_SYSEX       = 0xF0; // start a MIDI SysEx message
+        const byte END_SYSEX         = 0xF7; // end a MIDI SysEx message
+
+        const byte I2C_REQUEST       = 0x76; // send an I2C request message
+        const byte I2C_REPLY         = 0x77; // receive an I2C reply message
+        const byte I2C_CONFIG        = 0x78; // set an I2C config message
+        const byte SAMPLING_INTERVAL = 0x7A; // set the sampling interval
+
+        #endregion
+
+        bool disposed;
+        bool parsingSysex;
+        int dataToReceive;
+        int multiByteCommand;
+        int multiByteChannel;
+        int sysexBytesRead;
+        readonly Dictionary<int, PinMode> pinModes;
+        readonly SerialPort serialPort;
+        readonly byte[] responseBuffer;
+        readonly byte[] commandBuffer;
+        readonly byte[] sysexBuffer;
+        readonly byte[] readBuffer;
+        int[] reportAnalog;
+        int[] reportDigital;
+        int[] analogInput;
+        byte[] digitalInput;
+        byte[] digitalOutput;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Arduino"/> class using the
+        /// specified port name.
+        /// </summary>
+        /// <param name="portName">The port to use (for example, COM1).</param>
+        public Arduino(string portName)
+            : this(portName, DefaultBaudRate)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Arduino"/> class using the
+        /// specified port name and baud rate.
+        /// </summary>
+        /// <param name="portName">The port to use (for example, COM1).</param>
+        /// <param name="baudRate">The serial baud rate.</param>
+        public Arduino(string portName, int baudRate)
+        {
+            serialPort = new SerialPort(portName);
+            serialPort.DtrEnable = true;
+            serialPort.BaudRate = baudRate;
+            serialPort.Parity = Parity.None;
+            serialPort.StopBits = StopBits.One;
+
+            pinModes = new Dictionary<int, PinMode>();
+            responseBuffer = new byte[2];
+            commandBuffer = new byte[MaxDataBytes];
+            sysexBuffer = new byte[MaxDataBytes];
+            readBuffer = new byte[serialPort.ReadBufferSize];
+            serialPort.DataReceived += new SerialDataReceivedEventHandler(serialPort_DataReceived);
+        }
+
+        /// <summary>
+        /// Occurs when the <see cref="Arduino"/> object receives a new analog input event.
+        /// </summary>
+        public event EventHandler<AnalogInputReceivedEventArgs> AnalogInputReceived;
+
+        /// <summary>
+        /// Occurs when the <see cref="Arduino"/> object receives a new digital input event.
+        /// </summary>
+        public event EventHandler<DigitalInputReceivedEventArgs> DigitalInputReceived;
+
+        /// <summary>
+        /// Occurs when the <see cref="Arduino"/> object receives a new MIDI SysEx message.
+        /// </summary>
+        public event EventHandler<SysexReceivedEventArgs> SysexReceived;
+
+        /// <summary>
+        /// Gets the major version of the Firmata firmware reported by the board on initialization.
+        /// </summary>
+        public int MajorVersion { get; private set; }
+
+        /// <summary>
+        /// Gets the minor version of the Firmata firmware reported by the board on initialization.
+        /// </summary>
+        public int MinorVersion { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating the open or closed status of the <see cref="Arduino"/> object.
+        /// </summary>
+        public bool IsOpen
+        {
+            get { return serialPort.IsOpen; }
+        }
+
+        void OnAnalogInputReceived(AnalogInputReceivedEventArgs e)
+        {
+            AnalogInputReceived?.Invoke(this, e);
+        }
+
+        void OnDigitalInputReceived(DigitalInputReceivedEventArgs e)
+        {
+            DigitalInputReceived?.Invoke(this, e);
+        }
+
+        void OnSysexReceived(SysexReceivedEventArgs e)
+        {
+            SysexReceived?.Invoke(this, e);
+        }
+
+        void serialPort_DataReceived(object sender, SerialDataReceivedEventArgs e)
+        {
+            var bytesToRead = serialPort.BytesToRead;
+            while (serialPort.IsOpen && bytesToRead > 0)
+            {
+                var bytesRead = serialPort.Read(readBuffer, 0, Math.Min(bytesToRead, readBuffer.Length));
+                for (int i = 0; i < bytesRead; i++)
+                {
+                    ProcessInput(readBuffer[i]);
+                }
+                bytesToRead -= bytesRead;
+            }
+        }
+
+        /// <summary>
+        /// Opens a new serial port connection to the Arduino board.
+        /// </summary>
+        public void Open()
+        {
+            serialPort.Open();
+            Thread.Sleep(ConnectionDelay);
+            serialPort.ReadExisting();
+        }
+
+        void ReportInput(ref int[] reportInput, byte command, int index, bool state)
+        {
+            EnsureCapacity(ref reportInput, index);
+            if (!state && reportInput[index] > 0) reportInput[index]--;
+
+            if (reportInput[index] == 0)
+            {
+                commandBuffer[0] = (byte)(command | index);
+                commandBuffer[1] = (byte)(state ? 1 : 0);
+                serialPort.Write(commandBuffer, 0, 2);
+            }
+
+            if (state) reportInput[index]++;
+        }
+
+        /// <summary>
+        /// Enables or disables reporting of analog pin values for
+        /// the specified pin number.
+        /// </summary>
+        /// <param name="pin">The number of the pin to configure.</param>
+        /// <param name="state">
+        /// <see langword="true"/> if analog reporting for the pin should be enabled;
+        /// <see langword="false"/> otherwise.
+        /// </param>
+        public void ReportAnalog(int pin, bool state)
+        {
+            ReportInput(ref reportAnalog, REPORT_ANALOG, pin, state);
+        }
+
+        /// <summary>
+        /// Enables or disables reporting of digital pin changes for
+        /// the specified digital port in the Arduino.
+        /// </summary>
+        /// <param name="port">The digital port to configure.</param>
+        /// <param name="state">
+        /// <see langword="true"/> if reporting of digital pin changes on the
+        /// specified port should be enabled; <see langword="false"/> otherwise.
+        /// </param>
+        public void ReportDigital(int port, bool state)
+        {
+            ReportInput(ref reportDigital, REPORT_DIGITAL, port, state);
+        }
+
+        /// <summary>
+        /// Sets the mode of an individual Arduino pin.
+        /// </summary>
+        /// <param name="pin">The number of the pin to configure.</param>
+        /// <param name="mode">The pin mode.</param>
+        public void PinMode(int pin, PinMode mode)
+        {
+            if (!pinModes.TryGetValue(pin, out PinMode previousMode) || previousMode != mode)
+            {
+                commandBuffer[0] = SET_PIN_MODE;
+                commandBuffer[1] = (byte)pin;
+                commandBuffer[2] = (byte)mode;
+                serialPort.Write(commandBuffer, 0, 3);
+                pinModes[pin] = mode;
+            }
+        }
+
+        /// <summary>
+        /// Reads the current state of the specified digital input pin.
+        /// </summary>
+        /// <param name="pin">The number of the digital pin to read.</param>
+        /// <returns>
+        /// <see langword="true"/> if the pin is HIGH; <see langword="false"/> if the pin is LOW.
+        /// </returns>
+        public bool DigitalRead(int pin)
+        {
+            var port = GetPortNumber(pin);
+            EnsureCapacity(ref digitalInput, port);
+            return ((digitalInput[port] >> (pin & 0x07)) & 0x01) != 0;
+        }
+
+        /// <summary>
+        /// Sets the state of the specified digital output pin.
+        /// </summary>
+        /// <param name="pin">The number of the digital pin to write.</param>
+        /// <param name="value">
+        /// <see langword="true"/> to set the pin HIGH; <see langword="false"/> to set the pin LOW.
+        /// </param>
+        public void DigitalWrite(int pin, bool value)
+        {
+            var port = GetPortNumber(pin);
+            EnsureCapacity(ref digitalOutput, port);
+            if (value) digitalOutput[port] |= (byte)(1 << (pin & 0x07));
+            else digitalOutput[port] &= (byte)~(1 << (pin & 0x07));
+            WritePort(port, digitalOutput[port]);
+        }
+
+        /// <summary>
+        /// Reads the current state of all the digital pins in the specified port.
+        /// </summary>
+        /// <param name="port">The number of the digital port (i.e. collection of 8 pins) to read.</param>
+        /// <returns>
+        /// A <see cref="byte"/> value where each bit represents the state of one pin in the digital port.
+        /// </returns>
+        public byte DigitalPortRead(int port)
+        {
+            EnsureCapacity(ref digitalInput, port);
+            return digitalInput[port];
+        }
+
+        /// <summary>
+        /// Sets the state of all the digital output pins in the specified
+        /// port simultaneously.
+        /// </summary>
+        /// <param name="port">The number of the digital port (i.e. collection of 8 pins) to write.</param>
+        /// <param name="value">
+        /// A <see cref="byte"/> value where each bit will be used to set the state of one pin in the digital port.
+        /// </param>
+        public void DigitalPortWrite(int port, byte value)
+        {
+            EnsureCapacity(ref digitalOutput, port);
+            digitalOutput[port] = value;
+            WritePort(port, digitalOutput[port]);
+        }
+
+        void WritePort(int port, byte value)
+        {
+            commandBuffer[0] = (byte)(DIGITAL_MESSAGE | port);
+            commandBuffer[1] = (byte)(value & 0x7F);
+            commandBuffer[2] = (byte)(value >> 7);
+            serialPort.Write(commandBuffer, 0, 3);
+        }
+
+        /// <summary>
+        /// Returns the current value of the specified analog pin.
+        /// </summary>
+        /// <param name="pin">The number of the analog pin to read.</param>
+        /// <returns>A <see cref="int"/> value representing a digitized analog measurement.</returns>
+        public int AnalogRead(int pin)
+        {
+            EnsureCapacity(ref analogInput, pin);
+            return analogInput[pin];
+        }
+
+        /// <summary>
+        /// Writes an analog value as a PWM wave to the specified digital output pin.
+        /// </summary>
+        /// <param name="pin">The number of the digital pin to write.</param>
+        /// <param name="value">A <see cref="int"/> value used to update the PWM signal.</param>
+        public void AnalogWrite(int pin, int value)
+        {
+            commandBuffer[0] = (byte)(ANALOG_MESSAGE | (pin & 0x0F));
+            commandBuffer[1] = (byte)(value & 0x7F);
+            commandBuffer[2] = (byte)(value >> 7);
+            serialPort.Write(commandBuffer, 0, 3);
+        }
+
+        /// <summary>
+        /// Sets the sampling rate for reporting analog and I2C data in the main firmware loop.
+        /// </summary>
+        /// <param name="milliseconds">
+        /// The sampling interval, in milliseconds, between analog and I2C measurements.
+        /// </param>
+        public void SamplingInterval(int milliseconds)
+        {
+            commandBuffer[0] = START_SYSEX;
+            commandBuffer[1] = SAMPLING_INTERVAL;
+            commandBuffer[2] = (byte)(milliseconds & 0x7F);
+            commandBuffer[3] = (byte)(milliseconds >> 7);
+            commandBuffer[4] = END_SYSEX;
+            serialPort.Write(commandBuffer, 0, 5);
+        }
+
+        /// <summary>
+        /// Sends the specified MIDI SysEx command using the specified arguments.
+        /// </summary>
+        /// <param name="command">A <see cref="byte"/> value indicating the SysEx command ID.</param>
+        /// <param name="args">The optional extended payload sent to configure the SysEx command.</param>
+        public void SendSysex(byte command, params byte[] args)
+        {
+            commandBuffer[0] = START_SYSEX;
+            commandBuffer[1] = command;
+            Array.Copy(args, 0, commandBuffer, 2, args.Length);
+            commandBuffer[args.Length + 2] = END_SYSEX;
+            serialPort.Write(commandBuffer, 0, args.Length + 3);
+        }
+
+        /// <summary>
+        /// Configures I2C settings such as delay time and power pins.
+        /// </summary>
+        /// <param name="args">
+        /// The I2C configuration arguments. The first two bytes are used
+        /// to configure the optional delay time, in microseconds, between
+        /// writing to the I2C register, and reading the data from the device.
+        /// </param>
+        public void I2CConfig(params byte[] args)
+        {
+            SendSysex(I2C_CONFIG, args);
+        }
+
+        /// <summary>
+        /// Writes a data payload to the I2C device with the specified address.
+        /// </summary>
+        /// <param name="address">The address of the slave device in the I2C bus.</param>
+        /// <param name="data">The data payload to write to the device.</param>
+        public void I2CWrite(int address, params byte[] data)
+        {
+            I2CRequest(address, I2CRequestMode.Write, data);
+        }
+
+        /// <summary>
+        /// Sends a request to the I2C device with the specified address.
+        /// </summary>
+        /// <param name="address">The address of the slave device in the I2C bus.</param>
+        /// <param name="mode">The read/write mode of the request.</param>
+        /// <param name="data">The data payload for the I2C request.</param>
+        public void I2CRequest(int address, I2CRequestMode mode, params byte[] data)
+        {
+            const byte ExtendedAddressBit = 0x1 << 5;
+            var extendedMode = address > 127 ? ExtendedAddressBit : 0;
+            commandBuffer[0] = START_SYSEX;
+            commandBuffer[1] = I2C_REQUEST;
+            commandBuffer[2] = (byte)(address & 0x7F);
+            commandBuffer[3] = (byte)((address >> 7) & 0x7 | (byte)mode << 3 | extendedMode);
+            Array.Copy(data, 0, commandBuffer, 4, data.Length);
+            commandBuffer[data.Length + 4] = END_SYSEX;
+            serialPort.Write(commandBuffer, 0, data.Length + 5);
+        }
+
+        static void EnsureCapacity<TElement>(ref TElement[] array, int index)
+        {
+            if (array == null || index >= array.Length)
+            {
+                Array.Resize(ref array, index + 1);
+            }
+        }
+
+        /// <summary>
+        /// Gets the digital port number for the specified pin.
+        /// </summary>
+        /// <param name="pin">The pin number for which to retrieve the digital port.</param>
+        /// <returns>A <see cref="int"/> identifier for the digital port containing the specified pin.</returns>
+        public static int GetPortNumber(int pin)
+        {
+            return (pin >> 3) & 0x0F;
+        }
+
+        void SetDigitalInput(int port, byte data)
+        {
+            EnsureCapacity(ref digitalInput, port);
+            digitalInput[port] = data;
+            OnDigitalInputReceived(new DigitalInputReceivedEventArgs(port, data));
+        }
+
+        void SetAnalogInput(int pin, int value)
+        {
+            EnsureCapacity(ref analogInput, pin);
+            analogInput[pin] = value;
+            OnAnalogInputReceived(new AnalogInputReceivedEventArgs(pin, value));
+        }
+
+        void SetVersion(int majorVersion, int minorVersion)
+        {
+            MajorVersion = majorVersion;
+            MinorVersion = minorVersion;
+        }
+
+        void ProcessInput(byte inputData)
+        {
+            if (parsingSysex)
+            {
+                if (inputData == END_SYSEX)
+                {
+                    parsingSysex = false;
+                    var feature = sysexBuffer[0];
+                    var args = new byte[sysexBytesRead - 1];
+                    Array.Copy(sysexBuffer, 1, args, 0, args.Length);
+                    OnSysexReceived(new SysexReceivedEventArgs(feature, args));
+                }
+                else if (sysexBytesRead < sysexBuffer.Length)
+                {
+                    sysexBuffer[sysexBytesRead++] = inputData;
+                }
+                else parsingSysex = false;
+            }
+            else if (dataToReceive > 0 && inputData < 128)
+            {
+                dataToReceive--;
+                responseBuffer[dataToReceive] = inputData;
+
+                if (multiByteCommand != 0 && dataToReceive == 0)
+                {
+                    switch (multiByteCommand)
+                    {
+                        case DIGITAL_MESSAGE: SetDigitalInput(multiByteChannel, (byte)((responseBuffer[0] << 7) + responseBuffer[1])); break;
+                        case ANALOG_MESSAGE: SetAnalogInput(multiByteChannel, (responseBuffer[0] << 7) + responseBuffer[1]); break;
+                        case REPORT_VERSION: SetVersion(responseBuffer[1], responseBuffer[0]); break;
+                    }
+                }
+            }
+            else
+            {
+                int command;
+                if (inputData < 0xF0)
+                {
+                    command = inputData & 0xF0;
+                    multiByteChannel = inputData & 0x0F;
+                }
+                else command = inputData;
+
+                switch (command)
+                {
+                    case DIGITAL_MESSAGE:
+                    case ANALOG_MESSAGE:
+                    case REPORT_VERSION:
+                        dataToReceive = 2;
+                        multiByteCommand = command;
+                        break;
+                    case START_SYSEX:
+                        parsingSysex = true;
+                        sysexBytesRead = 0;
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Closes the port connection, sets the <see cref="IsOpen"/>
+        /// property to <see langword="false"/> and disposes of the
+        /// internal <see cref="SerialPort"/> object.
+        /// </summary>
+        public void Close()
+        {
+            Dispose(true);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                if (disposing)
+                {
+                    serialPort.Close();
+                    disposed = true;
+                }
+            }
+        }
+
+        void IDisposable.Dispose()
+        {
+            Close();
+        }
+    }
+
+    /// <summary>
+    /// Specifies the mode of an individual Arduino pin.
+    /// </summary>
+    public enum PinMode : byte
+    {
+        /// <summary>
+        /// The digital pin is configured as INPUT.
+        /// </summary>
+        Input = 0x00,
+
+        /// <summary>
+        /// The digital pin is configured as OUTPUT.
+        /// </summary>
+        Output = 0x01,
+
+        /// <summary>
+        /// The analog pin is configured in analog input mode.
+        /// </summary>
+        Analog = 0x02,
+
+        /// <summary>
+        /// The digital pin is configured in PWM output mode.
+        /// </summary>
+        Pwm = 0x03,
+
+        /// <summary>
+        /// The digital pin is configured in Servo output mode.
+        /// </summary>
+        Servo = 0x04,
+
+        /// <summary>
+        /// The pin is configured as a data pin in shiftOut/shiftIn mode.
+        /// </summary>
+        Shift = 0x05,
+
+        /// <summary>
+        /// The pin is configured to access I2C devices.
+        /// </summary>
+        I2C = 0x06,
+
+        /// <summary>
+        /// The pin is configured as a 1-wire bus master.
+        /// </summary>
+        OneWire = 0x07,
+
+        /// <summary>
+        /// The pin is configured for stepper motor control.
+        /// </summary>
+        Stepper = 0x08,
+
+        /// <summary>
+        /// The pin is configured for a rotary encoder.
+        /// </summary>
+        Encoder = 0x09,
+
+        /// <summary>
+        /// The pin is configured for serial communication.
+        /// </summary>
+        Serial = 0x0A,
+
+        /// <summary>
+        /// The digital pin is configured as INPUT_PULLUP.
+        /// </summary>
+        InputPullUp = 0x0B
+    }
+
+    /// <summary>
+    /// Specifies the read/write mode for I2C requests.
+    /// </summary>
+    public enum I2CRequestMode : byte
+    {
+        /// <summary>
+        /// A request to write data to the device.
+        /// </summary>
+        Write = 0x0,
+
+        /// <summary>
+        /// A request to read one data sample from the device.
+        /// </summary>
+        ReadOnce = 0x1,
+
+        /// <summary>
+        /// A request to read and report data continuously from the device.
+        /// </summary>
+        ReadContinuously = 0x2,
+
+        /// <summary>
+        /// A request to stop reading data from the device.
+        /// </summary>
+        StopReading = 0x3
+    }
+}

--- a/Bonsai.Arduino/ArduinoConfiguration.cs
+++ b/Bonsai.Arduino/ArduinoConfiguration.cs
@@ -1,0 +1,42 @@
+﻿using System.ComponentModel;
+using Bonsai.IO;
+
+namespace Bonsai.Arduino
+{
+    /// <summary>
+    /// Represents configuration settings used to initialize a Firmata serial connection.
+    /// </summary>
+    public class ArduinoConfiguration
+    {
+        internal static readonly ArduinoConfiguration Default = new ArduinoConfiguration();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArduinoConfiguration"/> class.
+        /// </summary>
+        public ArduinoConfiguration()
+        {
+            BaudRate = Arduino.DefaultBaudRate;
+            SamplingInterval = Arduino.DefaultSamplingInterval;
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the serial port.
+        /// </summary>
+        [TypeConverter(typeof(SerialPortNameConverter))]
+        [Description("The name of the serial port.")]
+        public string PortName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the serial baud rate.
+        /// </summary>
+        [TypeConverter(typeof(BaudRateConverter))]
+        [Description("The serial baud rate.")]
+        public int BaudRate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sampling interval, in milliseconds, between analog and I2C measurements.
+        /// </summary>
+        [Description("The sampling interval, in milliseconds, between analog and I2C measurements.")]
+        public int SamplingInterval { get; set; }
+    }
+}

--- a/Bonsai.Arduino/ArduinoConfigurationCollection.cs
+++ b/Bonsai.Arduino/ArduinoConfigurationCollection.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Xml.Serialization;
+
+namespace Bonsai.Arduino
+{
+    /// <summary>
+    /// Represents a collection of Firmata configuration settings, indexed by port name.
+    /// </summary>
+    [Obsolete]
+    [XmlRoot("ArduinoConfigurationSettings")]
+    public class ArduinoConfigurationCollection : KeyedCollection<string, ArduinoConfiguration>
+    {
+        /// <inheritdoc/>
+        protected override string GetKeyForItem(ArduinoConfiguration item)
+        {
+            return item.PortName;
+        }
+    }
+}

--- a/Bonsai.Arduino/ArduinoDisposable.cs
+++ b/Bonsai.Arduino/ArduinoDisposable.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading;
+using System.Reactive.Disposables;
+
+namespace Bonsai.Arduino
+{
+    internal sealed class ArduinoDisposable : ICancelable, IDisposable
+    {
+        IDisposable resource;
+
+        public ArduinoDisposable(Arduino arduino, IDisposable disposable)
+        {
+            Arduino = arduino ?? throw new ArgumentNullException(nameof(arduino));
+            resource = disposable ?? throw new ArgumentNullException(nameof(disposable));
+        }
+
+        public Arduino Arduino { get; private set; }
+
+        public bool IsDisposed
+        {
+            get { return resource == null; }
+        }
+
+        public void Dispose()
+        {
+            var disposable = Interlocked.Exchange(ref resource, null);
+            if (disposable != null)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+}

--- a/Bonsai.Arduino/ArduinoDisposable.cs
+++ b/Bonsai.Arduino/ArduinoDisposable.cs
@@ -26,7 +26,10 @@ namespace Bonsai.Arduino
             var disposable = Interlocked.Exchange(ref resource, null);
             if (disposable != null)
             {
-                disposable.Dispose();
+                lock (ArduinoManager.SyncRoot)
+                {
+                    disposable.Dispose();
+                }
             }
         }
     }

--- a/Bonsai.Arduino/ArduinoManager.cs
+++ b/Bonsai.Arduino/ArduinoManager.cs
@@ -6,6 +6,7 @@ using System.Xml;
 using System.IO;
 using System.Reactive.Disposables;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Bonsai.Arduino
 {
@@ -50,12 +51,13 @@ namespace Bonsai.Arduino
                     }
 #pragma warning restore CS0612 // Type or member is obsolete
 
+                    var cancellation = new CancellationTokenSource();
                     var arduino = new Arduino(serialPortName, arduinoConfiguration.BaudRate);
-                    arduino.Open();
+                    arduino.Open(cancellation.Token);
                     arduino.SamplingInterval(arduinoConfiguration.SamplingInterval);
                     var dispose = Disposable.Create(() =>
                     {
-                        arduino.Close();
+                        cancellation.Cancel();
                         openConnections.Remove(portName);
                     });
 

--- a/Bonsai.Arduino/ArduinoManager.cs
+++ b/Bonsai.Arduino/ArduinoManager.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Serialization;
+using System.Xml;
+using System.IO;
+using System.Reactive.Disposables;
+using System.Threading.Tasks;
+
+namespace Bonsai.Arduino
+{
+    internal static class ArduinoManager
+    {
+        public const string DefaultConfigurationFile = "Arduino.config";
+        static readonly Dictionary<string, Tuple<Arduino, RefCountDisposable>> openConnections = new Dictionary<string, Tuple<Arduino, RefCountDisposable>>();
+        static readonly object openConnectionsLock = new object();
+
+        public static ArduinoDisposable ReserveConnection(string portName)
+        {
+            return ReserveConnection(portName, ArduinoConfiguration.Default);
+        }
+
+        public static async Task<ArduinoDisposable> ReserveConnectionAsync(string portName)
+        {
+            return await Task.Run(() => ReserveConnection(portName, ArduinoConfiguration.Default));
+        }
+
+        internal static ArduinoDisposable ReserveConnection(string portName, ArduinoConfiguration arduinoConfiguration)
+        {
+            var connection = default(Tuple<Arduino, RefCountDisposable>);
+            lock (openConnectionsLock)
+            {
+                if (string.IsNullOrEmpty(portName))
+                {
+                    if (!string.IsNullOrEmpty(arduinoConfiguration.PortName)) portName = arduinoConfiguration.PortName;
+                    else if (openConnections.Count == 1) connection = openConnections.Values.Single();
+                    else throw new ArgumentException("An alias or serial port name must be specified.", nameof(portName));
+                }
+
+                if (connection == null && !openConnections.TryGetValue(portName, out connection))
+                {
+                    var serialPortName = arduinoConfiguration.PortName;
+                    if (string.IsNullOrEmpty(serialPortName)) serialPortName = portName;
+
+#pragma warning disable CS0612 // Type or member is obsolete
+                    var configuration = LoadConfiguration();
+                    if (configuration.Contains(serialPortName))
+                    {
+                        arduinoConfiguration = configuration[serialPortName];
+                    }
+#pragma warning restore CS0612 // Type or member is obsolete
+
+                    var arduino = new Arduino(serialPortName, arduinoConfiguration.BaudRate);
+                    arduino.Open();
+                    arduino.SamplingInterval(arduinoConfiguration.SamplingInterval);
+                    var dispose = Disposable.Create(() =>
+                    {
+                        arduino.Close();
+                        openConnections.Remove(portName);
+                    });
+
+                    var refCount = new RefCountDisposable(dispose);
+                    connection = Tuple.Create(arduino, refCount);
+                    openConnections.Add(portName, connection);
+                    return new ArduinoDisposable(arduino, refCount);
+                }
+            }
+
+            return new ArduinoDisposable(connection.Item1, connection.Item2.GetDisposable());
+        }
+
+        [Obsolete]
+        public static ArduinoConfigurationCollection LoadConfiguration()
+        {
+            if (!File.Exists(DefaultConfigurationFile))
+            {
+                return new ArduinoConfigurationCollection();
+            }
+
+            var serializer = new XmlSerializer(typeof(ArduinoConfigurationCollection));
+            using var reader = XmlReader.Create(DefaultConfigurationFile);
+            return (ArduinoConfigurationCollection)serializer.Deserialize(reader);
+        }
+    }
+}

--- a/Bonsai.Arduino/Bonsai.Arduino.csproj
+++ b/Bonsai.Arduino/Bonsai.Arduino.csproj
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Title>Bonsai - Arduino Library</Title>
+    <Description>Bonsai Arduino Library containing communication infrastructure to probe and control the state of Arduino microcontrollers.</Description>
+    <PackageTags>Bonsai Rx Arduino</PackageTags>
+    <TargetFramework>net462</TargetFramework>
+    <VersionPrefix>2.6.0</VersionPrefix>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Bonsai.System\Bonsai.System.csproj" />
+  </ItemGroup>
+</Project>

--- a/Bonsai.Arduino/Bonsai.Arduino.csproj
+++ b/Bonsai.Arduino/Bonsai.Arduino.csproj
@@ -2,10 +2,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Title>Bonsai - Arduino Library</Title>
-    <Description>Bonsai Arduino Library containing communication infrastructure to probe and control the state of Arduino microcontrollers.</Description>
+    <Description>Bonsai Library containing reactive infrastructure to probe and control the state of Arduino microcontrollers.</Description>
     <PackageTags>Bonsai Rx Arduino</PackageTags>
-    <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.6.0</VersionPrefix>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.System\Bonsai.System.csproj" />

--- a/Bonsai.Arduino/CreateArduino.cs
+++ b/Bonsai.Arduino/CreateArduino.cs
@@ -1,0 +1,75 @@
+﻿using Bonsai.IO;
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+
+namespace Bonsai.Arduino
+{
+    /// <summary>
+    /// Represents an operator that creates a connection to an Arduino board
+    /// using the Firmata protocol.
+    /// </summary>
+    [DefaultProperty(nameof(Name))]
+    [Description("Creates a connection to an Arduino board using the Firmata protocol.")]
+    public class CreateArduino : Source<Arduino>, INamedElement
+    {
+        readonly ArduinoConfiguration configuration = new ArduinoConfiguration();
+
+        /// <summary>
+        /// Gets or sets the optional alias for the Arduino board.
+        /// </summary>
+        [Description("The optional alias for the Arduino board.")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the serial port used to communicate with the Arduino.
+        /// </summary>
+        [TypeConverter(typeof(SerialPortNameConverter))]
+        [Description("The name of the serial port used to communicate with the Arduino.")]
+        public string PortName
+        {
+            get { return configuration.PortName; }
+            set { configuration.PortName = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the serial baud rate.
+        /// </summary>
+        [TypeConverter(typeof(BaudRateConverter))]
+        [Description("The serial baud rate.")]
+        public int BaudRate
+        {
+            get { return configuration.BaudRate; }
+            set { configuration.BaudRate = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the sampling interval, in milliseconds, between analog and I2C measurements.
+        /// </summary>
+        [Description("The sampling interval, in milliseconds, between analog and I2C measurements.")]
+        public int SamplingInterval
+        {
+            get { return configuration.SamplingInterval; }
+            set { configuration.SamplingInterval = value; }
+        }
+
+        /// <summary>
+        /// Generates an observable sequence that contains the Firmata connection object.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single instance of the <see cref="Arduino"/> class
+        /// representing the Firmata connection.
+        /// </returns>
+        public override IObservable<Arduino> Generate()
+        {
+            return Observable.Using(
+                () => ArduinoManager.ReserveConnection(Name, configuration),
+                resource =>
+                {
+                    return Observable.Return(resource.Arduino)
+                                     .Concat(Observable.Never(resource.Arduino));
+                });
+        }
+    }
+}

--- a/Bonsai.Arduino/DigitalInput.cs
+++ b/Bonsai.Arduino/DigitalInput.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Bonsai.Arduino
+{
+    /// <summary>
+    /// Represents an operator that generates a sequence of digital state
+    /// transitions from the specified Arduino input pin.
+    /// </summary>
+    [DefaultProperty(nameof(Pin))]
+    [Description("Generates a sequence of digital state transitions from the specified Arduino input pin.")]
+    public class DigitalInput : Source<bool>
+    {
+        /// <summary>
+        /// Gets or sets the name of the serial port used to communicate with the Arduino.
+        /// </summary>
+        [TypeConverter(typeof(PortNameConverter))]
+        [Description("The name of the serial port used to communicate with the Arduino.")]
+        public string PortName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the digital input pin number from which to take readings.
+        /// </summary>
+        [Description("The digital input pin number from which to take readings.")]
+        public int Pin { get; set; }
+
+        /// <summary>
+        /// Configures the digital pin as INPUT and generates an observable
+        /// sequence of all its state transitions.
+        /// </summary>
+        /// <returns>
+        /// A sequence of <see cref="bool"/> values that report the binary state
+        /// transitions of the specified Arduino input pin: <see langword="true"/>
+        /// if the pin is now HIGH; <see langword="false"/> if the pin is now LOW.
+        /// </returns>
+        public override IObservable<bool> Generate()
+        {
+            return ObservableArduino.DigitalInput(PortName, Pin);
+        }
+    }
+}

--- a/Bonsai.Arduino/DigitalInputReceivedEventArgs.cs
+++ b/Bonsai.Arduino/DigitalInputReceivedEventArgs.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace Bonsai.Arduino
+{
+    /// <summary>
+    /// Provides data for the <see cref="Arduino.DigitalInputReceived"/> event.
+    /// </summary>
+    public class DigitalInputReceivedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DigitalInputReceivedEventArgs"/>
+        /// class using the port number and port pin state received in the digital input message.
+        /// </summary>
+        /// <param name="port">
+        /// The number identifying the digital port (i.e. collection of 8 pins) from which
+        /// the state transition event originated.
+        /// </param>
+        /// <param name="state">
+        /// The state of all the digital input pins in the specified port at the time the
+        /// transition occurred.
+        /// </param>
+        public DigitalInputReceivedEventArgs(int port, byte state)
+        {
+            Port = port;
+            State = state;
+        }
+
+        /// <summary>
+        /// Gets the number identifying the digital port from which the event originated.
+        /// </summary>
+        public int Port { get; private set; }
+
+        /// <summary>
+        /// Gets the state of all the digital input pins in the specified port at the time
+        /// the transition occurred.
+        /// </summary>
+        public byte State { get; private set; }
+    }
+}

--- a/Bonsai.Arduino/DigitalOutput.cs
+++ b/Bonsai.Arduino/DigitalOutput.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+
+namespace Bonsai.Arduino
+{
+    /// <summary>
+    /// Represents an operator that writes the sequence of digital state transitions
+    /// to the specified Arduino output pin.
+    /// </summary>
+    [DefaultProperty(nameof(Pin))]
+    [Description("Writes the sequence of digital state transitions to the specified Arduino output pin.")]
+    public class DigitalOutput : Sink<bool>
+    {
+        /// <summary>
+        /// Gets or sets the name of the serial port used to communicate with the Arduino.
+        /// </summary>
+        [TypeConverter(typeof(PortNameConverter))]
+        [Description("The name of the serial port used to communicate with the Arduino.")]
+        public string PortName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the digital output pin number on which to write the state values.
+        /// </summary>
+        [Description("The digital output pin number on which to write the state values.")]
+        public int Pin { get; set; }
+
+        /// <summary>
+        /// Writes a sequence of binary states to the specified Arduino digital output pin.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="bool"/> values used to update the state of the specified
+        /// Arduino output pin. If a value in the sequence is <see langword="true"/>, the pin
+        /// will be set to HIGH; otherwise, the pin will be set to LOW.
+        /// </param>
+        /// <returns>
+        /// A sequence of the <see cref="bool"/> values which have been written into the Arduino
+        /// output pin.
+        /// </returns>
+        /// <remarks>
+        /// This operator only subscribes to the <paramref name="source"/> sequence after
+        /// initializing the connection to the Arduino and configuring the digital pin mode
+        /// to OUTPUT.
+        /// </remarks>
+        public override IObservable<bool> Process(IObservable<bool> source)
+        {
+            return Observable.Using(
+                cancellationToken => ArduinoManager.ReserveConnectionAsync(PortName),
+                (connection, cancellationToken) =>
+                {
+                    var pin = Pin;
+                    connection.Arduino.PinMode(pin, PinMode.Output);
+                    return Task.FromResult(source.Do(value =>
+                    {
+                        lock (connection.Arduino)
+                        {
+                            connection.Arduino.DigitalWrite(pin, value);
+                        }
+                    }));
+                });
+        }
+    }
+}

--- a/Bonsai.Arduino/InputPullUp.cs
+++ b/Bonsai.Arduino/InputPullUp.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Bonsai.Arduino
+{
+    /// <summary>
+    /// Represents an operator that generates a sequence of digital state transitions
+    /// from the specified Arduino input pin in pull-up mode.
+    /// </summary>
+    [DefaultProperty(nameof(Pin))]
+    [Description("Generates a sequence of digital state transitions from the specified Arduino input pin in pull-up mode.")]
+    public class InputPullUp : Source<bool>
+    {
+        /// <summary>
+        /// Gets or sets the name of the serial port used to communicate with the Arduino.
+        /// </summary>
+        [TypeConverter(typeof(PortNameConverter))]
+        [Description("The name of the serial port used to communicate with the Arduino.")]
+        public string PortName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the digital input pin number from which to take readings.
+        /// </summary>
+        [Description("The digital input pin number from which to take readings.")]
+        public int Pin { get; set; }
+
+        /// <summary>
+        /// Configures the digital pin as INPUT_PULLUP and generates an observable
+        /// sequence of all its state transitions.
+        /// </summary>
+        /// <returns>
+        /// A sequence of <see cref="bool"/> values that report the binary state
+        /// transitions of the specified Arduino input pin: <see langword="true"/>
+        /// if the pin is now HIGH; <see langword="false"/> if the pin is now LOW.
+        /// </returns>
+        public override IObservable<bool> Generate()
+        {
+            return ObservableArduino.DigitalInput(PortName, Pin, PinMode.InputPullUp);
+        }
+    }
+}

--- a/Bonsai.Arduino/ObservableArduino.cs
+++ b/Bonsai.Arduino/ObservableArduino.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Reactive.Disposables;
+
+namespace Bonsai.Arduino
+{
+    static class ObservableArduino
+    {
+        public static IObservable<int> AnalogInput(string portName, int pin)
+        {
+            return Observable.Create<int>(async observer =>
+            {
+                var connection = await ArduinoManager.ReserveConnectionAsync(portName);
+                EventHandler<AnalogInputReceivedEventArgs> inputReceived;
+                inputReceived = (sender, e) =>
+                {
+                    if (e.Pin == pin)
+                    {
+                        observer.OnNext(e.Value);
+                    }
+                };
+
+                connection.Arduino.ReportAnalog(pin, true);
+                connection.Arduino.AnalogInputReceived += inputReceived;
+                return Disposable.Create(() =>
+                {
+                    connection.Arduino.AnalogInputReceived -= inputReceived;
+                    connection.Arduino.ReportAnalog(pin, false);
+                    connection.Dispose();
+                });
+            });
+        }
+
+        public static IObservable<bool> DigitalInput(string portName, int pin)
+        {
+            return DigitalInput(portName, pin, PinMode.Input);
+        }
+
+        public static IObservable<bool> DigitalInput(string portName, int pin, PinMode pinMode)
+        {
+            return Observable.Create<bool>(async observer =>
+            {
+                var connection = await ArduinoManager.ReserveConnectionAsync(portName);
+                connection.Arduino.PinMode(pin, pinMode);
+                var port = Arduino.GetPortNumber(pin);
+                EventHandler<DigitalInputReceivedEventArgs> inputReceived;
+                inputReceived = (sender, e) =>
+                {
+                    if (e.Port == port)
+                    {
+                        observer.OnNext(connection.Arduino.DigitalRead(pin));
+                    }
+                };
+
+                connection.Arduino.ReportDigital(port, true);
+                connection.Arduino.DigitalInputReceived += inputReceived;
+                return Disposable.Create(() =>
+                {
+                    connection.Arduino.DigitalInputReceived -= inputReceived;
+                    connection.Arduino.ReportDigital(port, false);
+                    connection.Dispose();
+                });
+            });
+        }
+    }
+}

--- a/Bonsai.Arduino/PortNameConverter.cs
+++ b/Bonsai.Arduino/PortNameConverter.cs
@@ -1,0 +1,37 @@
+﻿using Bonsai.Expressions;
+using System.ComponentModel;
+using System.IO.Ports;
+using System.Linq;
+
+namespace Bonsai.Arduino
+{
+    class PortNameConverter : StringConverter
+    {
+        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+        {
+            return true;
+        }
+
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        {
+            if (context != null)
+            {
+                var workflowBuilder = (WorkflowBuilder)context.GetService(typeof(WorkflowBuilder));
+                if (workflowBuilder != null)
+                {
+                    var portNames = (from builder in workflowBuilder.Workflow.Descendants()
+                                     let createPort = ExpressionBuilder.GetWorkflowElement(builder) as CreateArduino
+                                     where createPort != null && !string.IsNullOrEmpty(createPort.PortName)
+                                     select !string.IsNullOrEmpty(createPort.Name) ? createPort.Name : createPort.PortName)
+                                     .Distinct()
+                                     .ToList();
+
+                    if (portNames.Count > 0) return new StandardValuesCollection(portNames);
+                    else return new StandardValuesCollection(SerialPort.GetPortNames());
+                }
+            }
+
+            return base.GetStandardValues(context);
+        }
+    }
+}

--- a/Bonsai.Arduino/PortNameConverter.cs
+++ b/Bonsai.Arduino/PortNameConverter.cs
@@ -20,18 +20,20 @@ namespace Bonsai.Arduino
                 if (workflowBuilder != null)
                 {
                     var portNames = (from builder in workflowBuilder.Workflow.Descendants()
+                                     where builder is not DisableBuilder
                                      let createPort = ExpressionBuilder.GetWorkflowElement(builder) as CreateArduino
                                      where createPort != null && !string.IsNullOrEmpty(createPort.PortName)
                                      select !string.IsNullOrEmpty(createPort.Name) ? createPort.Name : createPort.PortName)
                                      .Distinct()
                                      .ToList();
-
-                    if (portNames.Count > 0) return new StandardValuesCollection(portNames);
-                    else return new StandardValuesCollection(SerialPort.GetPortNames());
+                    if (portNames.Count > 0)
+                    {
+                        return new StandardValuesCollection(portNames);
+                    }
                 }
             }
 
-            return base.GetStandardValues(context);
+            return new StandardValuesCollection(SerialPort.GetPortNames());
         }
     }
 }

--- a/Bonsai.Arduino/Properties/AssemblyInfo.cs
+++ b/Bonsai.Arduino/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿using Bonsai;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: XmlNamespacePrefix("clr-namespace:Bonsai.Arduino", "ard")]
+[assembly: WorkflowNamespaceIcon("Bonsai:ElementIcon.Daq")]

--- a/Bonsai.Arduino/Properties/launchSettings.json
+++ b/Bonsai.Arduino/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "Bonsai": {
+      "commandName": "Executable",
+      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
+      "commandLineArgs": "--lib:$(TargetDir)."
+    }
+  }
+}

--- a/Bonsai.Arduino/ReceiveSysex.cs
+++ b/Bonsai.Arduino/ReceiveSysex.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+
+namespace Bonsai.Arduino
+{
+    /// <summary>
+    /// Represents an operator that generates a sequence of system exclusive messages
+    /// received from the specified Arduino.
+    /// </summary>
+    [DefaultProperty(nameof(Feature))]
+    [Description("Generates a sequence of system exclusive messages received from the specified Arduino.")]
+    public class ReceiveSysex : Source<byte[]>
+    {
+        /// <summary>
+        /// Gets or sets the name of the serial port used to communicate with the Arduino.
+        /// </summary>
+        [TypeConverter(typeof(PortNameConverter))]
+        [Description("The name of the serial port used to communicate with the Arduino.")]
+        public string PortName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the feature ID used to identify the system exclusive message payload.
+        /// </summary>
+        [Description("The feature ID used to identify the system exclusive message payload.")]
+        public int Feature { get; set; }
+
+        /// <summary>
+        /// Generates an observable sequence of all the system exclusive messages with the
+        /// specified feature ID received from the Arduino.
+        /// </summary>
+        /// <returns>
+        /// A sequence of <see cref="byte"/> arrays containing the payload data which was
+        /// included with each system exclusive message received from the Arduino.
+        /// </returns>
+        public override IObservable<byte[]> Generate()
+        {
+            return Observable.Create<byte[]>(async observer =>
+            {
+                var connection = await ArduinoManager.ReserveConnectionAsync(PortName);
+                EventHandler<SysexReceivedEventArgs> sysexReceived;
+                sysexReceived = (sender, e) =>
+                {
+                    if (e.Feature == Feature)
+                    {
+                        observer.OnNext(e.Args);
+                    }
+                };
+
+                connection.Arduino.SysexReceived += sysexReceived;
+                return Disposable.Create(() =>
+                {
+                    connection.Arduino.SysexReceived -= sysexReceived;
+                    connection.Dispose();
+                });
+            });
+        }
+    }
+}

--- a/Bonsai.Arduino/SendSysex.cs
+++ b/Bonsai.Arduino/SendSysex.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+
+namespace Bonsai.Arduino
+{
+    /// <summary>
+    /// Represents an operator that sends a sequence of system exclusive messages to the specified Arduino.
+    /// </summary>
+    [DefaultProperty(nameof(Feature))]
+    [Description("Sends a sequence of system exclusive messages to the specified Arduino.")]
+    public class SendSysex : Sink<byte[]>
+    {
+        /// <summary>
+        /// Gets or sets the name of the serial port used to communicate with the Arduino.
+        /// </summary>
+        [TypeConverter(typeof(PortNameConverter))]
+        [Description("The name of the serial port used to communicate with the Arduino.")]
+        public string PortName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the feature ID used to identify the system exclusive message payload.
+        /// </summary>
+        [Description("The feature ID used to identify the system exclusive message payload.")]
+        public int Feature { get; set; }
+
+        /// <summary>
+        /// Writes a sequence of system exclusive messages to the specified Arduino.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="byte"/> arrays specifying the payload data to include in each
+        /// of the system exclusive messages sent to the Arduino. The specified feature ID will
+        /// be used to identify each message.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="byte"/> arrays containing the payload data which was
+        /// included with each system exclusive message sent to the Arduino.
+        /// </returns>
+        /// <remarks>
+        /// This operator only subscribes to the <paramref name="source"/> sequence after
+        /// initializing the connection to the Arduino.
+        /// </remarks>
+        public override IObservable<byte[]> Process(IObservable<byte[]> source)
+        {
+            return Observable.Using(
+                cancellationToken => ArduinoManager.ReserveConnectionAsync(PortName),
+                (connection, cancellationToken) => Task.FromResult(source.Do(value =>
+                {
+                    lock (connection.Arduino)
+                    {
+                        connection.Arduino.SendSysex((byte)Feature, value);
+                    }
+                })));
+        }
+    }
+}

--- a/Bonsai.Arduino/ServoOutput.cs
+++ b/Bonsai.Arduino/ServoOutput.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+
+namespace Bonsai.Arduino
+{
+    /// <summary>
+    /// Represents an operator that writes a sequence of angular positions to control
+    /// a servomotor connected to an Arduino output pin.
+    /// </summary>
+    [DefaultProperty(nameof(Pin))]
+    [Description("Writes a sequence of angular positions to control a servomotor connected to an Arduino output pin.")]
+    public class ServoOutput : Sink<int>
+    {
+        /// <summary>
+        /// Gets or sets the name of the serial port used to communicate with the Arduino.
+        /// </summary>
+        [TypeConverter(typeof(PortNameConverter))]
+        [Description("The name of the serial port used to communicate with the Arduino.")]
+        public string PortName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the digital output pin number to which the servo is connected.
+        /// </summary>
+        [Description("The digital output pin number to which the servo is connected.")]
+        public int Pin { get; set; }
+
+        /// <summary>
+        /// Writes a sequence of angular position values to control a servomotor connected to the
+        /// specified Arduino output pin.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="int"/> values specifying angular positions, in degrees from
+        /// 0 to 180, used to control the servomotor connected to the specified Arduino output pin.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="int"/> values containing the angular positions which have been
+        /// used to control the servomotor connected to the specified Arduino output pin.
+        /// </returns>
+        /// <remarks>
+        /// This operator only subscribes to the <paramref name="source"/> sequence after initializing
+        /// the connection to the Arduino and configuring the digital pin as a Servo output.
+        /// </remarks>
+        public override IObservable<int> Process(IObservable<int> source)
+        {
+            return Observable.Using(
+                cancellationToken => ArduinoManager.ReserveConnectionAsync(PortName),
+                (connection, cancellationToken) =>
+                {
+                    var pin = Pin;
+                    connection.Arduino.PinMode(pin, PinMode.Servo);
+                    return Task.FromResult(source.Do(value =>
+                    {
+                        lock (connection.Arduino)
+                        {
+                            connection.Arduino.AnalogWrite(pin, value);
+                        }
+                    }));
+                });
+        }
+    }
+}

--- a/Bonsai.Arduino/SysexReceivedEventArgs.cs
+++ b/Bonsai.Arduino/SysexReceivedEventArgs.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace Bonsai.Arduino
+{
+    /// <summary>
+    /// Provides data for the <see cref="Arduino.SysexReceived"/> event.
+    /// </summary>
+    public class SysexReceivedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SysexReceivedEventArgs"/>
+        /// class using the specified feature ID and optional data payload.
+        /// </summary>
+        /// <param name="feature">
+        /// The identifier of the system exclusive (SysEx) feature received in
+        /// the message event.
+        /// </param>
+        /// <param name="args">
+        /// The data payload received together with the SysEx message.
+        /// </param>
+        public SysexReceivedEventArgs(byte feature, byte[] args)
+        {
+            Feature = feature;
+            Args = args;
+        }
+
+        /// <summary>
+        /// Gets the identifier of the system exclusive (SysEx) feature received in
+        /// the message event.
+        /// </summary>
+        public byte Feature { get; private set; }
+
+        /// <summary>
+        /// Gets the data payload received together with the SysEx message.
+        /// </summary>
+        public byte[] Args { get; private set; }
+    }
+}

--- a/Bonsai.StarterPack/Bonsai.StarterPack.csproj
+++ b/Bonsai.StarterPack/Bonsai.StarterPack.csproj
@@ -7,10 +7,10 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Bonsai.Arduino" Version="2.6.0" />
+    <ProjectReference Include="..\Bonsai.Arduino\Bonsai.Arduino.csproj" />
     <ProjectReference Include="..\Bonsai.Audio\Bonsai.Audio.csproj" />
     <ProjectReference Include="..\Bonsai.Design.Visualizers\Bonsai.Design.Visualizers.csproj" />
     <ProjectReference Include="..\Bonsai.Dsp.Design\Bonsai.Dsp.Design.csproj" />

--- a/Bonsai.sln
+++ b/Bonsai.sln
@@ -18,6 +18,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Vision.Design", "Bon
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.System", "Bonsai.System\Bonsai.System.csproj", "{B783D74F-CB2D-4419-B438-266CD15774FB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Arduino", "Bonsai.Arduino\Bonsai.Arduino.csproj", "{CFED93E8-2AE9-471D-81D6-C89BB0356EF3}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Scripting", "Bonsai.Scripting\Bonsai.Scripting.csproj", "{A341A5A1-45A6-4B35-9AB1-FE42C622F738}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Scripting.Expressions", "Bonsai.Scripting.Expressions\Bonsai.Scripting.Expressions.csproj", "{6DAA7012-22BF-4E0B-A7DB-B7A8B2A95F0A}"
@@ -164,6 +166,16 @@ Global
 		{B783D74F-CB2D-4419-B438-266CD15774FB}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{B783D74F-CB2D-4419-B438-266CD15774FB}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{B783D74F-CB2D-4419-B438-266CD15774FB}.Release|x64.ActiveCfg = Release|Any CPU
+		{CFED93E8-2AE9-471D-81D6-C89BB0356EF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CFED93E8-2AE9-471D-81D6-C89BB0356EF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CFED93E8-2AE9-471D-81D6-C89BB0356EF3}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{CFED93E8-2AE9-471D-81D6-C89BB0356EF3}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{CFED93E8-2AE9-471D-81D6-C89BB0356EF3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CFED93E8-2AE9-471D-81D6-C89BB0356EF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CFED93E8-2AE9-471D-81D6-C89BB0356EF3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CFED93E8-2AE9-471D-81D6-C89BB0356EF3}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{CFED93E8-2AE9-471D-81D6-C89BB0356EF3}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{CFED93E8-2AE9-471D-81D6-C89BB0356EF3}.Release|x64.ActiveCfg = Release|Any CPU
 		{A341A5A1-45A6-4B35-9AB1-FE42C622F738}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A341A5A1-45A6-4B35-9AB1-FE42C622F738}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A341A5A1-45A6-4B35-9AB1-FE42C622F738}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
The Arduino package provided an implementation of the Firmata protocol over serial port using the `DataReceived` event. Similar to https://github.com/bonsai-rx/bonsai/pull/1444 this PR refactors the package implementation to avoid relying on events, both for cross-platform compatibility and for cleaner dispose logic.

For release simplicity, the package was temporarily merged back into the core repository, but the goal remains to split it off into its own separate repo.