### PR TITLE
Refactor text visualizer to use buffered updates

### DIFF
--- a/Bonsai.Design/BufferedVisualizer.cs
+++ b/Bonsai.Design/BufferedVisualizer.cs
@@ -12,11 +12,10 @@ namespace Bonsai.Design
     /// </summary>
     public abstract class BufferedVisualizer : DialogTypeVisualizer
     {
-        const int TargetInterval = 1000 / 50;
-
-        internal BufferedVisualizer()
-        {
-        }
+        /// <summary>
+        /// Gets or sets the target interval, in milliseconds, between visualizer updates.
+        /// </summary>
+        protected virtual int TargetInterval => 1000 / 50;
 
         /// <inheritdoc/>
         public override IObservable<object> Visualize(IObservable<IObservable<object>> source, IServiceProvider provider)

--- a/Bonsai.Design/BufferedVisualizer.cs
+++ b/Bonsai.Design/BufferedVisualizer.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Reactive;
 using System.Reactive.Linq;
 using System.Windows.Forms;
 
@@ -39,15 +41,24 @@ namespace Bonsai.Design
                     return mergedSource
                         .Timestamp(HighResolutionScheduler.Default)
                         .Buffer(() => timerTick)
-                        .Do(buffer =>
-                        {
-                            foreach (var timestamped in buffer)
-                            {
-                                var time = timestamped.Timestamp.LocalDateTime;
-                                Show(time, timestamped.Value);
-                            }
-                        }).Finally(timer.Stop);
+                        .Do(ShowBuffer).Finally(timer.Stop);
                 });
+        }
+
+        /// <summary>
+        /// Updates the type visualizer with a new buffer of timestamped values.
+        /// </summary>
+        /// <param name="values">
+        /// A buffer of timestamped values where each timestamp indicates the
+        /// time at which the value was received.
+        /// </param>
+        protected virtual void ShowBuffer(IList<Timestamped<object>> values)
+        {
+            foreach (var timestamped in values)
+            {
+                var time = timestamped.Timestamp.LocalDateTime;
+                Show(time, timestamped.Value);
+            }
         }
 
         /// <summary>

--- a/Bonsai.Design/BufferedVisualizer.cs
+++ b/Bonsai.Design/BufferedVisualizer.cs
@@ -2,7 +2,7 @@
 using System.Reactive.Linq;
 using System.Windows.Forms;
 
-namespace Bonsai.Design.Visualizers
+namespace Bonsai.Design
 {
     /// <summary>
     /// Provides an abstract base class for type visualizers with an update

--- a/Bonsai.Design/ObjectTextVisualizer.cs
+++ b/Bonsai.Design/ObjectTextVisualizer.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using Bonsai;
 using Bonsai.Design;
 using System.Drawing;
+using System.Reactive;
 
 [assembly: TypeVisualizer(typeof(ObjectTextVisualizer), Target = typeof(object))]
 
@@ -12,7 +13,7 @@ namespace Bonsai.Design
     /// <summary>
     /// Provides a type visualizer for displaying any object type as text.
     /// </summary>
-    public class ObjectTextVisualizer : DialogTypeVisualizer
+    public class ObjectTextVisualizer : BufferedVisualizer
     {
         const int AutoScaleHeight = 13;
         const float DefaultDpi = 96f;
@@ -23,6 +24,20 @@ namespace Bonsai.Design
         int bufferSize;
 
         /// <inheritdoc/>
+        protected override int TargetInterval => 1000 / 30;
+
+        /// <inheritdoc/>
+        protected override void ShowBuffer(IList<Timestamped<object>> values)
+        {
+            if (values.Count > 0)
+            {
+                base.ShowBuffer(values);
+                textBox.Text = string.Join(Environment.NewLine, buffer);
+                textPanel.Invalidate();
+            }
+        }
+
+        /// <inheritdoc/>
         public override void Show(object value)
         {
             value = value ?? string.Empty;
@@ -31,7 +46,6 @@ namespace Bonsai.Design
             {
                 buffer.Dequeue();
             }
-            textBox.Text = string.Join(Environment.NewLine, buffer);
         }
 
         /// <inheritdoc/>

--- a/Bonsai.Design/ObjectTextVisualizer.cs
+++ b/Bonsai.Design/ObjectTextVisualizer.cs
@@ -18,7 +18,7 @@ namespace Bonsai.Design
         const int AutoScaleHeight = 13;
         const float DefaultDpi = 96f;
 
-        TextBox textBox;
+        RichTextBox textBox;
         UserControl textPanel;
         Queue<string> buffer;
         int bufferSize;
@@ -52,11 +52,11 @@ namespace Bonsai.Design
         public override void Load(IServiceProvider provider)
         {
             buffer = new Queue<string>();
-            textBox = new TextBox { Dock = DockStyle.Fill };
+            textBox = new RichTextBox { Dock = DockStyle.Fill };
             textBox.ReadOnly = true;
             textBox.Multiline = true;
             textBox.WordWrap = false;
-            textBox.TextChanged += (sender, e) => textPanel.Invalidate();
+            textBox.ScrollBars = RichTextBoxScrollBars.Horizontal;
 
             textPanel = new UserControl();
             textPanel.SuspendLayout();
@@ -80,9 +80,8 @@ namespace Bonsai.Design
             var lineHeight = AutoScaleHeight * e.Graphics.DpiY / DefaultDpi;
             bufferSize = (int)((textBox.ClientSize.Height - 2) / lineHeight);
             var textSize = TextRenderer.MeasureText(textBox.Text, textBox.Font);
-            if (textBox.ScrollBars == ScrollBars.None && textBox.ClientSize.Width < textSize.Width)
+            if (textBox.ClientSize.Width < textSize.Width)
             {
-                textBox.ScrollBars = ScrollBars.Horizontal;
                 var offset = 2 * lineHeight + SystemInformation.HorizontalScrollBarHeight - textPanel.Height;
                 if (offset > 0)
                 {


### PR DESCRIPTION
Since the default text visualizer has the broadest compatibility with all data types, it is increasingly used to inspect all kinds of data including high-throughput event streams. Unfortunately, this can place a high load on visualizers and cause stalls by refreshing complex text boxes at a high frequency.

This PR refactors the default text visualizer to use buffered updates. It also extends the default buffered visualizer interface to allow having a single control refresh per buffer and configurable target update interval.