### PR TITLE
Add net6.0 build target to player project

### DIFF
--- a/Bonsai.Configuration/Bonsai.Configuration.csproj
+++ b/Bonsai.Configuration/Bonsai.Configuration.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>

--- a/Bonsai.Configuration/ConfigurationHelper.cs
+++ b/Bonsai.Configuration/ConfigurationHelper.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Xml;
 using System.Xml.Serialization;
 
@@ -19,7 +20,7 @@ namespace Bonsai.Configuration
 
         static string GetEnvironmentPlatform()
         {
-            return Environment.Is64BitProcess ? "x64" : "x86";
+            return RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
         }
 
         static string GetDefaultConfigurationFilePath()

--- a/Bonsai.Configuration/ConfigurationHelper.cs
+++ b/Bonsai.Configuration/ConfigurationHelper.cs
@@ -40,9 +40,9 @@ namespace Bonsai.Configuration
 
         public static string GetConfigurationRoot(PackageConfiguration configuration = null)
         {
-            return configuration == null || string.IsNullOrWhiteSpace(configuration.ConfigurationFile)
-                ? Path.GetDirectoryName(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile)
-                : Path.GetDirectoryName(configuration.ConfigurationFile);
+            return !string.IsNullOrWhiteSpace(configuration?.ConfigurationFile)
+                ? Path.GetDirectoryName(configuration.ConfigurationFile)
+                : AppDomain.CurrentDomain.BaseDirectory;
         }
 
         public static string GetAssemblyLocation(this PackageConfiguration configuration, string assemblyName)

--- a/Bonsai.Configuration/ScriptExtensionsProvider.cs
+++ b/Bonsai.Configuration/ScriptExtensionsProvider.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CSharp;
+﻿#if NET472_OR_GREATER
+using Microsoft.CSharp;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -179,3 +180,4 @@ namespace Bonsai.Configuration
         }
     }
 }
+#endif

--- a/Bonsai.NuGet/Bonsai.NuGet.csproj
+++ b/Bonsai.NuGet/Bonsai.NuGet.csproj
@@ -3,11 +3,16 @@
   <PropertyGroup>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="Rx-Main" Version="2.2.5" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="NuGet.Protocol" Version="6.6.1" />
     <PackageReference Include="NuGet.Resolver" Version="6.6.1" />
   </ItemGroup>

--- a/Bonsai.Player/Bonsai.Player.csproj
+++ b/Bonsai.Player/Bonsai.Player.csproj
@@ -6,10 +6,10 @@
     <Description>A command line player for Bonsai workflows.</Description>
     <PackageTags>Bonsai Player Rx Reactive Extensions</PackageTags>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -19,7 +19,7 @@
     <ProjectReference Include="..\Bonsai.Core\Bonsai.Core.csproj" />
     <ProjectReference Include="..\Bonsai.Configuration\Bonsai.Configuration.csproj" PrivateAssets="all" />
   </ItemGroup>
-  <Target Name="ILRepack" AfterTargets="Build">
+  <Target Name="ILRepack" AfterTargets="Build" Condition="'$(TargetFramework)' == 'net472'">
     <PropertyGroup>
       <WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\$(TargetFramework)</WorkingDirectory>
     </PropertyGroup>


### PR DESCRIPTION
This PR allows the player project to run as a command-line application on .NET 6.0 platforms. Extension scripts are not currently supported in .NET 6 as this would require porting over the Roslyn infrastructure. We will address this in a future release when we extend Roslyn support to all scripts.