### PR TITLE
Update package dependencies

### DIFF
--- a/Bonsai.Audio/Bonsai.Audio.csproj
+++ b/Bonsai.Audio/Bonsai.Audio.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="openal.redist" Version="2.0.7" />
-    <PackageReference Include="OpenCV.Net" Version="3.4.1" />
+    <PackageReference Include="OpenCV.Net" Version="3.4.2" />
     <PackageReference Include="OpenTK" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Bonsai.Core.Tests/Bonsai.Core.Tests.csproj
+++ b/Bonsai.Core.Tests/Bonsai.Core.Tests.csproj
@@ -9,10 +9,10 @@
     <EmbeddedResource Include="**\*.bonsai" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Bonsai.Core/Bonsai.Core.csproj
+++ b/Bonsai.Core/Bonsai.Core.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Rx-PlatformServices" Version="2.2.5" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
     <PackageReference Include="System.CodeDom" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/Bonsai.Dsp/Bonsai.Dsp.csproj
+++ b/Bonsai.Dsp/Bonsai.Dsp.csproj
@@ -9,7 +9,7 @@
     <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenCV.Net" Version="3.4.1" />
+    <PackageReference Include="OpenCV.Net" Version="3.4.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.System\Bonsai.System.csproj" />

--- a/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
+++ b/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
@@ -9,10 +9,10 @@
     <EmbeddedResource Include="**\*.bonsai" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Bonsai.Editor/Bonsai.Editor.csproj
+++ b/Bonsai.Editor/Bonsai.Editor.csproj
@@ -14,10 +14,10 @@
     <EmbeddedResource Include="**\*.css" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SvgNet" Version="3.2.0" />
-    <PackageReference Include="YamlDotNet" Version="12.0.2" />
+    <PackageReference Include="SvgNet" Version="3.3.3" />
+    <PackageReference Include="YamlDotNet" Version="13.1.1" />
     <PackageReference Include="Markdig" Version="0.18.1" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1587.40" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1823.32" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.Design\Bonsai.Design.csproj" />

--- a/Bonsai.NuGet/Bonsai.NuGet.csproj
+++ b/Bonsai.NuGet/Bonsai.NuGet.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Rx-Main" Version="2.2.5" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Protocol" Version="6.6.1" />

--- a/Bonsai.Shaders/Bonsai.Shaders.csproj
+++ b/Bonsai.Shaders/Bonsai.Shaders.csproj
@@ -8,7 +8,7 @@
     <VersionPrefix>0.27.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenCV.Net" Version="3.4.1" />
+    <PackageReference Include="OpenCV.Net" Version="3.4.2" />
     <PackageReference Include="OpenTK" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Bonsai.System.Tests/Bonsai.System.Tests.csproj
+++ b/Bonsai.System.Tests/Bonsai.System.Tests.csproj
@@ -6,10 +6,10 @@
     <VersionPrefix>2.7.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Bonsai.Vision/Bonsai.Vision.csproj
+++ b/Bonsai.Vision/Bonsai.Vision.csproj
@@ -8,7 +8,7 @@
     <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenCV.Net" Version="3.4.1" />
+    <PackageReference Include="OpenCV.Net" Version="3.4.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.Dsp\Bonsai.Dsp.csproj" />

--- a/Bonsai32/Properties/launchSettings.json
+++ b/Bonsai32/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Bonsai32": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}


### PR DESCRIPTION
This PR updates all common package dependencies to their latest versions:
- Editor dependencies
- Unit test dependencies
- Rx (updated to latest v6.0 for lightweight .NET 6.0 support)
- OpenCV.NET (now includes mono DLL map config file for cross-platform runtimes)