### PR TITLE
Add source item template for dotnet new

### DIFF
--- a/Bonsai.Audio/Bonsai.Audio.csproj
+++ b/Bonsai.Audio/Bonsai.Audio.csproj
@@ -5,7 +5,7 @@
     <Description>Bonsai Audio Library containing modules for sound capture and playback.</Description>
     <PackageTags>Bonsai Rx Audio</PackageTags>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="openal.redist" Version="2.0.7" />

--- a/Bonsai.Scripting/Bonsai.Scripting.csproj
+++ b/Bonsai.Scripting/Bonsai.Scripting.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Scripting</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.System\Bonsai.System.csproj" />

--- a/Bonsai.System.Design/Bonsai.System.Design.csproj
+++ b/Bonsai.System.Design/Bonsai.System.Design.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Reactive Extensions IO Resources Design</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.Design\Bonsai.Design.csproj" />

--- a/Bonsai.System.Tests/Bonsai.System.Tests.csproj
+++ b/Bonsai.System.Tests/Bonsai.System.Tests.csproj
@@ -3,7 +3,7 @@
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/Bonsai.Templates/Bonsai.SourceTemplate/.template.config/template.json
+++ b/Bonsai.Templates/Bonsai.SourceTemplate/.template.config/template.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "Bonsai",
+    "classifications": [ "Bonsai", "Source" ],
+    "description": "A class used to create a simple Bonsai observable source",
+    "identity": "Bonsai.SourceTemplate",
+    "name": "Bonsai Source",
+    "tags": {
+        "language": "C#",
+        "type": "item"
+    },
+    "sources": [
+        {
+            "modifiers": [
+                {
+                    "exclude": [
+                        "**/[Bb]in/**",
+                        "**/[Oo]bj/**",
+                        "**/[Pp]roperties/**",
+                        "**/*.ico",
+                        "**/*.vstemplate",
+                        "Bonsai.SourceTemplate.csproj"
+                    ]
+                }
+            ]
+        }
+    ],
+    "symbols": {
+        "itemName": {
+            "type": "derived",
+            "valueSource": "name",
+            "valueTransform": "safe_name",
+            "replaces": "$safeitemname$",
+            "fileRename": "SourceTemplate"
+        },
+        "namespace": {
+            "type": "bind",
+            "binding": "msbuild:RootNamespace",
+            "replaces": "$rootnamespace$"
+        }
+    },
+    "constraints": {
+        "csharp-only": {
+            "type": "project-capability",
+            "args": "CSharp"
+        }  
+    },
+    "shortName": "bonsaisource",
+    "defaultName": "Source1",
+    "preferDefaultName": true
+}

--- a/Bonsai.Templates/Bonsai.Templates.csproj
+++ b/Bonsai.Templates/Bonsai.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>2.7.0</PackageVersion>
+    <PackageVersion>2.8.0</PackageVersion>
     <PackageId>Bonsai.Templates</PackageId>
     <Title>Bonsai Templates</Title>
     <Authors>Bonsai</Authors>
@@ -17,6 +17,7 @@
   <ItemGroup>
     <Content Include="Bonsai.EnvironmentTemplate\**\*" />
     <Content Include="Bonsai.PackageTemplate\**\*" Exclude="**\**\bin\**;**\**\obj\**;**\**\Properties\**;**\*.ico;**\*.user;**\*.vstemplate;**\Bonsai.PackageTemplate.csproj" />
+    <Content Include="Bonsai.SourceTemplate\**\*" Exclude="**\**\bin\**;**\**\obj\**;**\**\Properties\**;**\*.ico;**\*.user;**\*.vstemplate;**\*.csproj" />
     <Compile Remove="**\*" />
   </ItemGroup>
 

--- a/Bonsai.Vision.Design/Bonsai.Vision.Design.csproj
+++ b/Bonsai.Vision.Design/Bonsai.Vision.Design.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Vision Visualizers</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />


### PR DESCRIPTION
This PR adds a new item template for sources using `dotnet new`. It leverages the new binding support introduced in .NET 7.0 SDK to extract the current project root namespace.

Example usage: `dotnet new bonsaisource -n MySource`