### PR TITLE
Add community code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+This project has adopted the Contributor Covenant code of conduct to clarify expected behavior in our community.
+
+For more information, see the [Bonsai Foundation Code of Conduct](https://bonsai-rx.org/code-of-conduct).


### PR DESCRIPTION
As our community grows and diversifies we acknowledge the need to make our various open discussion spaces inclusive of a variety of different backgrounds and experiences.

Similar to several other open-source projects, we have adopted the [Contributor Covenant](https://www.contributor-covenant.org/) as the basis of our efforts to clarify several common expectations for public participation in development and community discussions.

Fixes #1190 