### PR TITLE
Remove XML serialization properties from public API

### DIFF
--- a/Bonsai.Core/Expressions/ExternalizedDateTimeOffset.cs
+++ b/Bonsai.Core/Expressions/ExternalizedDateTimeOffset.cs
@@ -33,6 +33,7 @@ namespace Bonsai.Expressions
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Value))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string ValueXml
         {
             get { return property.ValueXml; }

--- a/Bonsai.Core/Expressions/ExternalizedTimeSpan.cs
+++ b/Bonsai.Core/Expressions/ExternalizedTimeSpan.cs
@@ -33,6 +33,7 @@ namespace Bonsai.Expressions
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Value))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string ValueXml
         {
             get { return property.ValueXml; }

--- a/Bonsai.Core/Expressions/Properties/DateTimeOffsetProperty.cs
+++ b/Bonsai.Core/Expressions/Properties/DateTimeOffsetProperty.cs
@@ -43,6 +43,7 @@ namespace Bonsai.Expressions
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Value))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string ValueXml
         {
             get { return Value.ToString("o"); }

--- a/Bonsai.Core/Expressions/Properties/TimeSpanProperty.cs
+++ b/Bonsai.Core/Expressions/Properties/TimeSpanProperty.cs
@@ -44,6 +44,7 @@ namespace Bonsai.Expressions
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Value))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string ValueXml
         {
             get { return XmlConvert.ToString(Value); }

--- a/Bonsai.Core/Expressions/ReplaySubjectBuilder.cs
+++ b/Bonsai.Core/Expressions/ReplaySubjectBuilder.cs
@@ -35,6 +35,7 @@ namespace Bonsai.Expressions
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Window))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string WindowXml
         {
             get
@@ -113,6 +114,7 @@ namespace Bonsai.Expressions
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Window))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string WindowXml
         {
             get

--- a/Bonsai.Core/Reactive/BufferTime.cs
+++ b/Bonsai.Core/Reactive/BufferTime.cs
@@ -40,6 +40,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(TimeSpan))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string TimeSpanXml
         {
             get { return XmlConvert.ToString(TimeSpan); }
@@ -51,6 +52,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(TimeShift))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string TimeShiftXml
         {
             get

--- a/Bonsai.Core/Reactive/BufferTrigger.cs
+++ b/Bonsai.Core/Reactive/BufferTrigger.cs
@@ -45,6 +45,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(TimeSpan))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string TimeSpanXml
         {
             get

--- a/Bonsai.Core/Reactive/Concurrency/SchedulerMapping.cs
+++ b/Bonsai.Core/Reactive/Concurrency/SchedulerMapping.cs
@@ -38,6 +38,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [XmlText]
         [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string InstanceXml
         {
             get

--- a/Bonsai.Core/Reactive/Delay.cs
+++ b/Bonsai.Core/Reactive/Delay.cs
@@ -27,6 +27,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(DueTime))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string DueTimeXml
         {
             get { return XmlConvert.ToString(DueTime); }

--- a/Bonsai.Core/Reactive/DelaySubscription.cs
+++ b/Bonsai.Core/Reactive/DelaySubscription.cs
@@ -27,6 +27,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(DueTime))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string DueTimeXml
         {
             get { return XmlConvert.ToString(DueTime); }

--- a/Bonsai.Core/Reactive/Gate.cs
+++ b/Bonsai.Core/Reactive/Gate.cs
@@ -32,6 +32,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(DueTime))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string DueTimeXml
         {
             get

--- a/Bonsai.Core/Reactive/GateInterval.cs
+++ b/Bonsai.Core/Reactive/GateInterval.cs
@@ -28,6 +28,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Interval))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string IntervalXml
         {
             get { return XmlConvert.ToString(Interval); }
@@ -52,6 +53,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(DueTime))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string DueTimeXml
         {
             get

--- a/Bonsai.Core/Reactive/Replay.cs
+++ b/Bonsai.Core/Reactive/Replay.cs
@@ -59,6 +59,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Window))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string WindowXml
         {
             get

--- a/Bonsai.Core/Reactive/SampleInterval.cs
+++ b/Bonsai.Core/Reactive/SampleInterval.cs
@@ -28,6 +28,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Interval))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string IntervalXml
         {
             get { return XmlConvert.ToString(Interval); }

--- a/Bonsai.Core/Reactive/Subjects/ReplaySubject.cs
+++ b/Bonsai.Core/Reactive/Subjects/ReplaySubject.cs
@@ -36,6 +36,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Window))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string WindowXml
         {
             get
@@ -104,6 +105,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Window))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string WindowXml
         {
             get

--- a/Bonsai.Core/Reactive/Throttle.cs
+++ b/Bonsai.Core/Reactive/Throttle.cs
@@ -27,6 +27,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(DueTime))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string DueTimeXml
         {
             get { return XmlConvert.ToString(DueTime); }

--- a/Bonsai.Core/Reactive/TimedGate.cs
+++ b/Bonsai.Core/Reactive/TimedGate.cs
@@ -28,6 +28,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(TimeSpan))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string TimeSpanXml
         {
             get { return XmlConvert.ToString(TimeSpan); }

--- a/Bonsai.Core/Reactive/Timeout.cs
+++ b/Bonsai.Core/Reactive/Timeout.cs
@@ -27,6 +27,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(DueTime))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string DueTimeXml
         {
             get { return XmlConvert.ToString(DueTime); }

--- a/Bonsai.Core/Reactive/Timer.cs
+++ b/Bonsai.Core/Reactive/Timer.cs
@@ -38,6 +38,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(DueTime))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string DueTimeXml
         {
             get { return XmlConvert.ToString(DueTime); }
@@ -49,6 +50,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Period))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string PeriodXml
         {
             get { return XmlConvert.ToString(Period); }

--- a/Bonsai.Core/Reactive/WindowTime.cs
+++ b/Bonsai.Core/Reactive/WindowTime.cs
@@ -38,6 +38,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(TimeSpan))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string TimeSpanXml
         {
             get { return XmlConvert.ToString(TimeSpan); }
@@ -49,6 +50,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(TimeShift))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string TimeShiftXml
         {
             get

--- a/Bonsai.Core/Reactive/WindowTrigger.cs
+++ b/Bonsai.Core/Reactive/WindowTrigger.cs
@@ -44,6 +44,7 @@ namespace Bonsai.Reactive
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(TimeSpan))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string TimeSpanXml
         {
             get

--- a/Bonsai.Dsp/FirFilter.cs
+++ b/Bonsai.Dsp/FirFilter.cs
@@ -36,6 +36,7 @@ namespace Bonsai.Dsp
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Kernel))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string KernelXml
         {
             get { return ArrayConvert.ToString(Kernel, CultureInfo.InvariantCulture); }

--- a/Bonsai.Dsp/IirFilter.cs
+++ b/Bonsai.Dsp/IirFilter.cs
@@ -38,6 +38,7 @@ namespace Bonsai.Dsp
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(FeedforwardCoefficients))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string FeedforwardCoefficientsXml
         {
             get { return ArrayConvert.ToString(FeedforwardCoefficients, CultureInfo.InvariantCulture); }
@@ -49,6 +50,7 @@ namespace Bonsai.Dsp
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(FeedbackCoefficients))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string FeedbackCoefficientsXml
         {
             get { return ArrayConvert.ToString(FeedbackCoefficients, CultureInfo.InvariantCulture); }

--- a/Bonsai.Shaders/Delay.cs
+++ b/Bonsai.Shaders/Delay.cs
@@ -28,6 +28,7 @@ namespace Bonsai.Shaders
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(DueTime))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string DueTimeXml
         {
             get { return XmlConvert.ToString(DueTime); }

--- a/Bonsai.Shaders/DelaySubscription.cs
+++ b/Bonsai.Shaders/DelaySubscription.cs
@@ -29,6 +29,7 @@ namespace Bonsai.Shaders
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(DueTime))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string DueTimeXml
         {
             get { return XmlConvert.ToString(DueTime); }

--- a/Bonsai.Shaders/Timer.cs
+++ b/Bonsai.Shaders/Timer.cs
@@ -40,6 +40,7 @@ namespace Bonsai.Shaders
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(DueTime))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string DueTimeXml
         {
             get { return XmlConvert.ToString(DueTime); }
@@ -51,6 +52,7 @@ namespace Bonsai.Shaders
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Period))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string PeriodXml
         {
             get { return Period.HasValue ? XmlConvert.ToString(Period.Value) : null; }

--- a/Bonsai.Vision/Drawing/AddTextBase.cs
+++ b/Bonsai.Vision/Drawing/AddTextBase.cs
@@ -74,6 +74,7 @@ namespace Bonsai.Vision.Drawing
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Font))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string FontXml
         {
             get

--- a/Bonsai.Vision/Drawing/CreateFont.cs
+++ b/Bonsai.Vision/Drawing/CreateFont.cs
@@ -45,6 +45,7 @@ namespace Bonsai.Vision.Drawing
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Font))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string FontXml
         {
             get

--- a/Bonsai.Vision/Filter2D.cs
+++ b/Bonsai.Vision/Filter2D.cs
@@ -35,6 +35,7 @@ namespace Bonsai.Vision
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Kernel))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string KernelXml
         {
             get { return ArrayConvert.ToString(Kernel, CultureInfo.InvariantCulture); }

--- a/Bonsai.Vision/WarpAffine.cs
+++ b/Bonsai.Vision/WarpAffine.cs
@@ -29,11 +29,12 @@ namespace Bonsai.Vision
         /// </summary>
         [Browsable(false)]
         [XmlElement(nameof(Transform))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string TransformXml
         {
             get
             {
-                var transform = (Mat)Transform;
+                var transform = Transform;
                 if (transform == null) return null;
 
                 var array = new float[transform.Rows, transform.Cols];


### PR DESCRIPTION
This PR hides all XML serialization properties from the public API. These properties are an implementation detail of how XML serialization currently works and might change at any point so we want to make it clear that they shouldn't be relied upon.

Fixes #1205 