### PR TITLE
Add tie-break for method overloads in derived classes

### DIFF
--- a/Bonsai.Core/Expressions/ExpressionBuilder.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilder.cs
@@ -819,7 +819,9 @@ namespace Bonsai.Expressions
                     return new CallCandidate
                     {
                         method = method,
-                        declaringType = method.DeclaringType,
+                        declaringType = method.IsVirtual
+                            ? ((MethodInfo)method).GetBaseDefinition().DeclaringType
+                            : method.DeclaringType,
                         arguments = callArguments,
                         generic = method.IsGenericMethod,
                         expansion = ParamExpansionRequired(parameters, argumentTypes),

--- a/Bonsai.Core/Expressions/ExpressionBuilder.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilder.cs
@@ -765,6 +765,7 @@ namespace Bonsai.Expressions
             internal static readonly CallCandidate Ambiguous = new CallCandidate();
             internal static readonly CallCandidate None = new CallCandidate();
             internal MethodBase method;
+            internal Type declaringType;
             internal Expression[] arguments;
             internal bool generic;
             internal bool expansion;
@@ -818,6 +819,7 @@ namespace Bonsai.Expressions
                     return new CallCandidate
                     {
                         method = method,
+                        declaringType = method.DeclaringType,
                         arguments = callArguments,
                         generic = method.IsGenericMethod,
                         expansion = ParamExpansionRequired(parameters, argumentTypes),
@@ -852,6 +854,15 @@ namespace Bonsai.Expressions
                 {
                     // skip self-test
                     if (i == j) continue;
+
+                    // exclude self if declaring type is base type of other; and vice-versa
+                    if (candidates[i].declaringType != candidates[j].declaringType)
+                    {
+                        if (candidates[i].declaringType.IsAssignableFrom(candidates[j].declaringType))
+                            candidates[i].excluded = true;
+                        else candidates[j].excluded = true;
+                        continue;
+                    }
 
                     // compare implicit type conversion
                     var comparison = CompareFunctionMember(


### PR DESCRIPTION
This PR implements an additional tie-break for ambiguous overload resolution where, all else being equal, applicable overloads provided by a derived class are preferred to overloads provided by the base class.

According to the [C# specs for signature scoping](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/basic-concepts#7722-hiding-through-nesting), for the purposes of this tie-break we should consider the declaring type of a virtual method to be the base definition, ignoring any overrides.

Fixes #1054 