### PR TITLE
Improve information contrast for obsolete operators

### DIFF
--- a/Bonsai.Editor/GraphModel/GraphNode.cs
+++ b/Bonsai.Editor/GraphModel/GraphNode.cs
@@ -115,8 +115,8 @@ namespace Bonsai.Editor.GraphModel
         {
             get
             {
-                if ((Flags & NodeFlags.Disabled) != 0) return DisabledBrush;
-                else if ((Flags & NodeFlags.Obsolete) != 0) return ObsoleteBrush;
+                if ((Flags & NodeFlags.Obsolete) != 0) return ObsoleteBrush;
+                else if ((Flags & NodeFlags.Disabled) != 0) return DisabledBrush;
                 else return null;
             }
         }

--- a/Bonsai.Editor/GraphModel/GraphNode.cs
+++ b/Bonsai.Editor/GraphModel/GraphNode.cs
@@ -135,6 +135,8 @@ namespace Bonsai.Editor.GraphModel
 
         public ElementIcon Icon { get; private set; }
 
+        public bool IsDisabled => (Flags & NodeFlags.Disabled) != 0;
+
         public bool IsBuildDependency => (Flags & NodeFlags.BuildDependency) != 0;
 
         public bool IsAnnotation => (Flags & NodeFlags.Annotation) != 0;

--- a/Bonsai.Editor/GraphView/GraphViewControl.cs
+++ b/Bonsai.Editor/GraphView/GraphViewControl.cs
@@ -1082,7 +1082,7 @@ namespace Bonsai.Editor.GraphView
             iconRendererState.Stroke = stroke;
             iconRendererState.CurrentColor = currentColor;
             iconRendererState.Translation = nodeRectangle.Location;
-            if (layout.Node.ModifierBrush != null)
+            if (layout.Node.IsDisabled)
             {
                 graphics.FillEllipse(Brushes.DarkGray, nodeRectangle);
             }


### PR DESCRIPTION
Currently the editor visual annotation for obsolete operators is competing with that for disabled operators. Both drop the category color associated with the original node. This PR improves the amount of visual information provided for obsolete operators by preserving the original category color.

It also makes it possible to distinguish between disabled obsolete operators and disabled normal operators, since disabled obsolete operators will now visibly change from colored to gray, but keep the distinctive foreground hatch pattern.

<img src="https://github.com/bonsai-rx/bonsai/assets/5315880/3305c476-32de-4a03-a60f-a89b0588cda6" height="150px"/>
