### PR TITLE
Add support for streaming binary serial read buffers

### DIFF
--- a/Bonsai.System/IO/Ports/SerialRead.cs
+++ b/Bonsai.System/IO/Ports/SerialRead.cs
@@ -38,7 +38,7 @@ namespace Bonsai.IO.Ports
         /// </returns>
         public override IObservable<byte[]> Generate()
         {
-            return Generate(Observable.Return(Unit.Default));
+            return ObservableSerialPort.Read(PortName, Count);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds support for continuous streaming of fixed size buffers from the low-level `SerialRead` operator. This makes `SerialRead` work symmetrically with the `SerialReadLine` operator. Furthermore we adapted the triggered interface to use the `Read` methods from serial port for parity with `SerialReadLine` usage and to allow for interleaving binary and text operators.

Care should be taken to ensure that the binary stream is correctly aligned. Cancellation of blocking operations is supported but the serial port will not be closed until the corresponding subscription to `CreateSerialPort` is cancelled, or all operators accessing the serial port are cancelled.