### PR TITLE
Require user defined conversion when multicasting to subject with non-matching type

### DIFF
--- a/Bonsai.Core.Tests/CombinatorBuilderTests.cs
+++ b/Bonsai.Core.Tests/CombinatorBuilderTests.cs
@@ -22,8 +22,10 @@ namespace Bonsai.Core.Tests
 
         IObservable<TSource> TestCombinatorBuilder<TSource>(object combinator, params Expression[] arguments)
         {
+            Expression buildResult;
             var builder = new CombinatorBuilder { Combinator = combinator };
-            var buildResult = builder.Build(arguments);
+            try { buildResult = builder.Build(arguments); }
+            catch (Exception ex) { throw new WorkflowBuildException(ex.Message, builder, ex); }
             var lambda = Expression.Lambda<Func<IObservable<TSource>>>(buildResult);
             var resultFactory = lambda.Compile();
             var result = resultFactory();

--- a/Bonsai.Core.Tests/OverloadedCombinatorBuilderTests.cs
+++ b/Bonsai.Core.Tests/OverloadedCombinatorBuilderTests.cs
@@ -188,8 +188,8 @@ namespace Bonsai.Core.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(InvalidOperationException))]
-        public void Build_AmbiguousOverloadedMethodCalledWithIntTuple_ThrowsInvalidOperationException()
+        [ExpectedException(typeof(WorkflowBuildException))]
+        public void Build_AmbiguousOverloadedMethodCalledWithIntTuple_ThrowsWorkflowBuildException()
         {
             var value = 5;
             var combinator = new AmbiguousOverloadedCombinatorMock();

--- a/Bonsai.Core.Tests/TypeConversionTests.cs
+++ b/Bonsai.Core.Tests/TypeConversionTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Reactive.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Core.Tests
+{
+    public partial class CombinatorBuilderTests
+    {
+        [Combinator]
+        class TypeCombinatorMock<T> : Combinator<T, T>
+        {
+            public override IObservable<T> Process(IObservable<T> source)
+            {
+                return source;
+            }
+        }
+
+        private void BuildConvertCast<TSource, TResult>(TSource value, out TResult result)
+        {
+            var combinator = new TypeCombinatorMock<TResult>();
+            var source = CreateObservableExpression(Observable.Return(value));
+            var resultProvider = TestCombinatorBuilder<TResult>(combinator, source);
+            result = Last(resultProvider).Result;
+        }
+
+        [TestMethod]
+        public void Build_ConvertDoubleToInt_ReturnsTruncatedValue()
+        {
+            var value = 5.5;
+            BuildConvertCast(value, out int result);
+            Assert.AreEqual((int)value, result);
+        }
+
+        [TestMethod]
+        public void Build_ConvertObjectToImplementedInterface_ReturnsValidObject()
+        {
+            BuildConvertCast(5.5, out IComparable result);
+            Assert.IsNotNull(result);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(WorkflowBuildException))]
+        public void Build_ConvertObjectToNotImplementedInterface_ThrowsBuildException()
+        {
+            BuildConvertCast(5.5, out IDisposable result);
+            Assert.IsNotNull(result);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(WorkflowBuildException))]
+        public void Build_ConvertInterfaceToDifferentInterface_ThrowsBuildException()
+        {
+            BuildConvertCast(5.5, out IComparable result);
+            BuildConvertCast(result, out IDisposable disposable);
+            Assert.AreSame((IDisposable)result, disposable);
+        }
+    }
+}

--- a/Bonsai.Core/Expressions/MulticastSubject.cs
+++ b/Bonsai.Core/Expressions/MulticastSubject.cs
@@ -60,6 +60,13 @@ namespace Bonsai.Expressions
             var subjectType = subjectExpression.Type.GetGenericArguments()[0];
             if (observableType != subjectType)
             {
+                if (!HasConversion(observableType, subjectType))
+                {
+                    throw new InvalidOperationException(
+                        $"No coercion operator is defined between types '{observableType}' and '{subjectType}'."
+                    );
+                }
+
                 source = CoerceMethodArgument(typeof(IObservable<>).MakeGenericType(subjectType), source);
                 observableType = subjectType;
             }


### PR DESCRIPTION
The implementation of `MulticastSubject` performed a coercion of the source sequence when the type of values in the sequence did not directly match the type of the subject. This PR makes this behavior more strict: conversions are still allowed, but they have to be supported on type upcasting, interface implementation, or a user-defined explicit conversion between the two types.

This eliminates cases where the type of the source sequence is an interface being multicast to a subject type declared with a different interface.

Fixes #1458 