### PR TITLE
Refactor matrix and spike visualizers to use buffered updates

### DIFF
--- a/Bonsai.Dsp.Design/SpikeWaveformCollectionVisualizer.cs
+++ b/Bonsai.Dsp.Design/SpikeWaveformCollectionVisualizer.cs
@@ -54,8 +54,6 @@ namespace Bonsai.Dsp.Design
 
                 Graph.UpdateWaveform(spike.ChannelIndex, samples, bufferSize.Height, samples.Length);
             }
-
-            InvalidateGraph();
         }
     }
 }


### PR DESCRIPTION
High-sampling rate visualizers were some of the first visualizers in the language to be buffered. This PR unifies this buffering strategy using the new `BufferedVisualizer` abstract base class. The main difference is the built-in protection against overloading the window message loop in case of high-frequency notifications (e.g. small buffers emitted at high-frequency).