### PR TITLE
Allow starting editor session on a specified folder

### DIFF
--- a/Bonsai.Design/FolderBrowserDialog.cs
+++ b/Bonsai.Design/FolderBrowserDialog.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
 using System.Windows.Forms;
 
 namespace Bonsai.Design
@@ -48,6 +49,14 @@ namespace Bonsai.Design
             dialog.GetOptions(out uint options);
             options |= FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM;
             dialog.SetOptions(options);
+            if (!string.IsNullOrEmpty(SelectedPath) &&
+                SHCreateItemFromParsingName(
+                    SelectedPath, pbc: null,
+                    typeof(IShellItem).GUID,
+                    out IShellItem selectedShellItem) == S_OK)
+            {
+                dialog.SetFolder(selectedShellItem);
+            }
 
             if (dialog.Show(hwndOwner) == S_OK &&
                 dialog.GetResult(out IShellItem shellItem) == S_OK &&
@@ -174,6 +183,13 @@ namespace Bonsai.Design
             [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
             uint Compare([In, MarshalAs(UnmanagedType.Interface)] IShellItem psi, [In] uint hint, out int piOrder);
         }
+
+        [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+        static extern uint SHCreateItemFromParsingName(
+            [MarshalAs(UnmanagedType.LPWStr)] string pszPath,
+            IBindCtx pbc,
+            [MarshalAs(UnmanagedType.LPStruct)] Guid riid,
+            [MarshalAs(UnmanagedType.Interface)] out IShellItem ppv);
 
         #endregion
     }

--- a/Bonsai.Editor/StartScreen.Designer.cs
+++ b/Bonsai.Editor/StartScreen.Designer.cs
@@ -39,8 +39,9 @@
             this.getStartedTreeView = new System.Windows.Forms.TreeView();
             this.recentLayoutPanel = new Bonsai.Editor.TableLayoutPanel();
             this.recentLabel = new Bonsai.Editor.Label();
-            this.openWorkflowDialog = new System.Windows.Forms.OpenFileDialog();
             this.recentFileView = new Bonsai.Editor.RecentlyUsedFileView();
+            this.openWorkflowDialog = new System.Windows.Forms.OpenFileDialog();
+            this.openFolderDialog = new Bonsai.Design.FolderBrowserDialog();
             this.tableLayoutPanel.SuspendLayout();
             this.startLayoutPanel.SuspendLayout();
             this.recentLayoutPanel.SuspendLayout();
@@ -245,6 +246,7 @@
         private Bonsai.Editor.RecentlyUsedFileView recentFileView;
         private Bonsai.Editor.TableLayoutPanel recentLayoutPanel;
         private System.Windows.Forms.ImageList iconList;
+        private Bonsai.Design.FolderBrowserDialog openFolderDialog;
     }
 }
 

--- a/Bonsai.Editor/StartScreen.cs
+++ b/Bonsai.Editor/StartScreen.cs
@@ -29,7 +29,10 @@ namespace Bonsai.Editor
             getStartedTreeView.Nodes.Add(forumNode);
             openTreeView.Nodes.Add(newFileNode);
             openTreeView.Nodes.Add(openFileNode);
-            openTreeView.Nodes.Add(openFolderNode);
+            if (!EditorSettings.IsRunningOnMono)
+            {
+                openTreeView.Nodes.Add(openFolderNode);
+            }
             openTreeView.Nodes.Add(galleryNode);
             openTreeView.Nodes.Add(packageManagerNode);
             FileName = string.Empty;

--- a/Bonsai.Editor/StartScreen.cs
+++ b/Bonsai.Editor/StartScreen.cs
@@ -14,10 +14,11 @@ namespace Bonsai.Editor
         bool tabSelect;
         readonly List<Image> customImages = new List<Image>();
         readonly ComponentResourceManager resources = new ComponentResourceManager(typeof(StartScreen));
-        readonly TreeNode newProjectNode = new TreeNode("New Project", 0, 0);
-        readonly TreeNode openProjectNode = new TreeNode("Open Project", 1, 1);
-        readonly TreeNode galleryNode = new TreeNode("Bonsai Gallery", 2, 2);
-        readonly TreeNode packageManagerNode = new TreeNode("Manage Packages", 3, 3);
+        readonly TreeNode newFileNode = new TreeNode("New File", 0, 0);
+        readonly TreeNode openFileNode = new TreeNode("Open File", 1, 1);
+        readonly TreeNode openFolderNode = new TreeNode("Open Folder", 2, 2);
+        readonly TreeNode galleryNode = new TreeNode("Bonsai Gallery", 3, 3);
+        readonly TreeNode packageManagerNode = new TreeNode("Manage Packages", 4, 4);
         readonly TreeNode documentationNode = new TreeNode("Documentation");
         readonly TreeNode forumNode = new TreeNode("Forums");
 
@@ -26,28 +27,29 @@ namespace Bonsai.Editor
             InitializeComponent();
             getStartedTreeView.Nodes.Add(documentationNode);
             getStartedTreeView.Nodes.Add(forumNode);
-            openTreeView.Nodes.Add(newProjectNode);
-            openTreeView.Nodes.Add(openProjectNode);
+            openTreeView.Nodes.Add(newFileNode);
+            openTreeView.Nodes.Add(openFileNode);
+            openTreeView.Nodes.Add(openFolderNode);
             openTreeView.Nodes.Add(galleryNode);
             openTreeView.Nodes.Add(packageManagerNode);
+            FileName = string.Empty;
         }
 
         public EditorResult EditorResult { get; private set; }
 
-        public string FileName
-        {
-            get { return openWorkflowDialog.FileName; }
-        }
+        public string FileName { get; private set; }
 
         private void ActivateNode(TreeNode node)
         {
             if (node == documentationNode) EditorDialog.ShowDocs();
             if (node == forumNode) EditorDialog.ShowForum();
-            if (node == newProjectNode) EditorResult = EditorResult.ReloadEditor;
+            if (node == newFileNode) EditorResult = EditorResult.ReloadEditor;
             if (node == galleryNode) EditorResult = EditorResult.OpenGallery;
             if (node == packageManagerNode) EditorResult = EditorResult.ManagePackages;
-            if (node == openProjectNode && openWorkflowDialog.ShowDialog() == DialogResult.OK)
+            if (node == openFileNode && openWorkflowDialog.ShowDialog() == DialogResult.OK ||
+                node == openFolderNode && openFolderDialog.ShowDialog() == DialogResult.OK)
             {
+                FileName = node == openFileNode ? openWorkflowDialog.FileName : openFolderDialog.SelectedPath;
                 EditorResult = EditorResult.ReloadEditor;
             }
 
@@ -87,6 +89,12 @@ namespace Bonsai.Editor
             foreach (var file in recentlyUsedFiles)
             {
                 recentFileView.Nodes.Add(Path.GetFileName(file.FileName), file.FileName);
+                if (string.IsNullOrEmpty(openWorkflowDialog.InitialDirectory))
+                {
+                    var initialDirectory = Path.GetDirectoryName(file.FileName);
+                    openWorkflowDialog.InitialDirectory = initialDirectory;
+                    openFolderDialog.SelectedPath = initialDirectory;
+                }
             }
 
             openTreeView.Select();
@@ -110,8 +118,9 @@ namespace Bonsai.Editor
                 Math.Min(MaxImageSize, (int)(16 * factor.Height)),
                 Math.Min(MaxImageSize, (int)(16 * factor.Height)));
 
-            var newItemImage = (Image)(resources.GetObject("newToolStripMenuItem.Image"));
-            var openItemImage = (Image)(resources.GetObject("openToolStripMenuItem.Image"));
+            var newFileImage = (Image)resources.GetObject("newToolStripMenuItem.Image");
+            var openFileImage = (Image)resources.GetObject("openFileToolStripMenuItem.Image");
+            var openFolderImage = (Image)resources.GetObject("openToolStripMenuItem.Image");
             var galleryItemImage = (Image)(resources.GetObject("galleryToolStripMenuItem.Image"));
             var packageManagerItemImage = (Image)(resources.GetObject("packageManagerToolStripMenuItem.Image"));
             var editorTheme = EditorSettings.Instance.EditorTheme;
@@ -129,14 +138,16 @@ namespace Bonsai.Editor
                 recentFileView.BackColor = ThemeHelper.Invert(systemMenuColor);
                 recentFileView.ForeColor = ThemeHelper.Invert(recentFileView.ForeColor);
                 recentFileView.LineColor = ThemeHelper.Invert(recentFileView.LineColor);
-                customImages.Add(newItemImage = ThemeHelper.InvertScale(newItemImage, iconList.ImageSize));
-                customImages.Add(openItemImage = ThemeHelper.InvertScale(openItemImage, iconList.ImageSize));
+                customImages.Add(newFileImage = ThemeHelper.InvertScale(newFileImage, iconList.ImageSize));
+                customImages.Add(openFileImage = ThemeHelper.InvertScale(openFileImage, iconList.ImageSize));
+                customImages.Add(openFolderImage = ThemeHelper.InvertScale(openFolderImage, iconList.ImageSize));
                 customImages.Add(galleryItemImage = ThemeHelper.InvertScale(galleryItemImage, iconList.ImageSize));
                 customImages.Add(packageManagerItemImage = ThemeHelper.InvertScale(packageManagerItemImage, iconList.ImageSize));
             }
 
-            iconList.Images.Add(newItemImage);
-            iconList.Images.Add(openItemImage);
+            iconList.Images.Add(newFileImage);
+            iconList.Images.Add(openFileImage);
+            iconList.Images.Add(openFolderImage);
             iconList.Images.Add(galleryItemImage);
             iconList.Images.Add(packageManagerItemImage);
             base.ScaleControl(factor, specified);

--- a/Bonsai.Editor/StartScreen.resx
+++ b/Bonsai.Editor/StartScreen.resx
@@ -124,31 +124,43 @@
   <data name="openWorkflowDialog.TrayLocation" type="System.Drawing.Point, System.Drawing">
     <value>17, 17</value>
   </data>
+  <data name="openFolderDialog.TrayLocation" type="System.Drawing.Point, System.Drawing">
+    <value>277, 17</value>
+  </data>
   <data name="galleryToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAACYAAAAmAfhOc6sAAAAZdEVYdFNvZnR3YXJlAHd3dy5pbmtzY2FwZS5vcmeb7jwa
-        AAABNklEQVQ4T52Sy0rDQBSGs/JBRBDduFUQFyq1SgVBFAq68C3EC4IgCCKulOrGy9LLQlofJa0P0XRS
-        nMxMiJlfz3SCRk3T+MFPmDPn/OfMIc4P8A+lQBEov1f2hb0aDMo3RUWVYM/prlpIqOc6RO3KfHUg7E2P
-        vgZRswU2W0JwfILu5hbaw6PoTM0gcl2b0ceAOlOxuLiEVgqIY/hrVfiVFbC5BWgpTV6mAY3rjU9APTxB
-        h6GJGbRGt7oBVW+YY6YBdQ5OzxB7HsLGC9T9I8R5DXxn3zyF7olMA5qAlZbQHhmDv7oOeXNnChPlTkDb
-        poV1JqfBD4+gOYe8vjUxNl/O3wERuU2wxWXwvQNT/La9C1au4L31ajNyDAjqROPSf0C7SDon2KLv+hUY
-        RCk+A0MF9KdBYVkc5wMNv1IGxf8/cAAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAA
+        JAAAACQBh7CwIgAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAE2SURBVDhPnZLL
+        SsNAFIaz8kFEEN24VRAXKrVKBUEUCrrwLcQLgiAIIq6U6sbL0stCWh8lrQ/RdFKczEyImV/PdIJGTdP4
+        wU+YM+f858whzg/wD6VAESi/V/aFvRoMyjdFRZVgz+muWkio5zpE7cp8dSDsTY++BlGzBTZbQnB8gu7m
+        FtrDo+hMzSByXZvRx4A6U7G4uIRWCohj+GtV+JUVsLkFaClNXqYBjeuNT0A9PEGHoYkZtEa3ugFVb5hj
+        pgF1Dk7PEHsewsYL1P0jxHkNfGffPIXuiUwDmoCVltAeGYO/ug55c2cKE+VOQNumhXUmp8EPj6A5h7y+
+        NTE2X87fARG5TbDFZfC9A1P8tr0LVq7gvfVqM3IMCOpE49J/QLtIOifYou/6FRhEKT4DQwX0p0FhWRzn
+        Aw2/UgbF/z9wAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="newToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAMRJREFUOE/NkjsOAiEYhDmCtSew9AycyAtYyjVsPImJhRWHsLESjUCLDv4T2V1Y
+        wQAADsEBuJFr7QAAAMRJREFUOE/NkjsOAiEYhDmCtSew9AycyAtYyjVsPImJhRWHsLESjUCLDv4T2V1Y
         X42TTDbAzLf/PlSpEMLCOTeJMSYaa+xLpK17aC0li+t2OSUkr3Eu0aFwB4R2q1k67De5SADW2BdIfRIZ
         2zJ8PR1zAdcCapGTSlcI0yw37Lz3c6k9hUOMXDx30loPbIypQ1iCOQEKZ3fpuAnpv4MxQAmRev0r1AA0
         zpCR+kP9/+BjAIRJ+Cd+BaD+BzDml4B3LPFfpNQN8wIwvWiZlr0AAAAASUVORK5CYII=
 </value>
   </data>
+  <data name="openFileToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wAAADsABataJCQAAAMRJREFUOE9jgIHv37////btGwr+8ePHf6g0ceDLly//9YrW/mcInvM/ZsI+sCE/
+        f/4kbAhIEczW528+YBiCjlEMBXFWHr71nz92EVgTOu5afx6sycnJCYzb2trA/F+/fkEMAXFAmkG2XX/0
+        GiwJYoM0g1wCctGH9x/BGN0QuAEgxTvPPsDQfPvhU7hmZANQDAER6C6AYWTN6AaAMNgAUBiAbIeFAUgQ
+        JImuGR3DDQAB5FggywBkMGoAFQ0gBuM0gHj87T8Ac76PyhFBSacAAAAASUVORK5CYII=
+</value>
+  </data>
   <data name="openToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAARxJREFUOE+VkrGqwjAUhvsG9z6J3Ee49BVcWlBw6F7wCZw6qrMIF1TodB9Ah+6d
+        wQAADsEBuJFr7QAAARxJREFUOE+VkrGqwjAUhvsG9z6J3Ee49BVcWlBw6F7wCZw6qrMIF1TodB9Ah+6d
         XAqiLsVBB4X0atqO5+aENiRNoxj4SM/J//9Nm1j1oJR+FUVBGCBBsF9JXg8Uny8Z6Qx/werOoTeNeEiF
         HCyorJbFikndvNwykEPiOAbbtjVEAJpn6wQ++gtuaoJr9/sDMvInaAZwM75td7pqO6APKkyIElCW5Td/
         YOJn5iZPd4A1YjIjIqAWy/8A6zaTjBKAhed5EEURpGnKF7DXRlvA1vd9TWhis96oAXmej8Iw1IQmxuOJ

--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -195,8 +195,16 @@ namespace Bonsai
                         else editorArgs.Add(SuppressBootstrapCommand);
                         if (!string.IsNullOrEmpty(initialFileName))
                         {
-                            editorArgs.Add(initialFileName);
-                            workingDirectory = Path.GetDirectoryName(initialFileName);
+                            if (Directory.Exists(initialFileName))
+                            {
+                                workingDirectory = initialFileName;
+                                initialFileName = string.Empty;
+                            }
+                            else
+                            {
+                                editorArgs.Add(initialFileName);
+                                workingDirectory = Path.GetDirectoryName(initialFileName);
+                            }
                         }
                     }
 


### PR DESCRIPTION
This PR adds support for opening the IDE on a specific folder, which can be passed either as an argument to the command-line or selected in the start screen. The main use for this functionality is to allow starting a new workflow using extensions available on an existing project folder, without requiring opening an existing workflow.

To make it easier to use existing local environments, the open dialogs also now use the path to the most recent file as a starting location.