### PR TITLE
Ensure VideoWriter frame size is cached per subscription

### DIFF
--- a/Bonsai.Vision/VideoWriterDisposable.cs
+++ b/Bonsai.Vision/VideoWriterDisposable.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reactive.Disposables;
 using System.Threading;
+using OpenCV.Net;
 
 namespace Bonsai.Vision
 {
@@ -11,16 +12,22 @@ namespace Bonsai.Vision
     {
         IDisposable resource;
 
-        internal VideoWriterDisposable(OpenCV.Net.VideoWriter writer, IDisposable disposable)
+        internal VideoWriterDisposable(OpenCV.Net.VideoWriter writer, Size frameSize, IDisposable disposable)
         {
             Writer = writer ?? throw new ArgumentNullException(nameof(writer));
+            FrameSize = frameSize;
             resource = disposable;
         }
 
         /// <summary>
         /// Gets the reference to the disposable video writer instance.
         /// </summary>
-        public OpenCV.Net.VideoWriter Writer { get; private set; }
+        public OpenCV.Net.VideoWriter Writer { get; }
+
+        /// <summary>
+        /// Gets the size of individual video frames.
+        /// </summary>
+        public Size FrameSize { get; }
 
         /// <summary>
         /// Gets a value indicating whether the video writer has been disposed.


### PR DESCRIPTION
This PR resolves a subtle issue with `VideoWriter` parallelism where the frame size of the writer was cached at the class level. The cache has now been moved to the per-subscription disposable instance, ensuring that multiple subscriptions can be safely created over the same operator.

Fixes #1467 