### PR TITLE
Ensure single row display for text visualizer

### DIFF
--- a/Bonsai.Design/ObjectTextVisualizer.cs
+++ b/Bonsai.Design/ObjectTextVisualizer.cs
@@ -5,6 +5,7 @@ using Bonsai;
 using Bonsai.Design;
 using System.Drawing;
 using System.Reactive;
+using System.Text.RegularExpressions;
 
 [assembly: TypeVisualizer(typeof(ObjectTextVisualizer), Target = typeof(object))]
 
@@ -40,8 +41,10 @@ namespace Bonsai.Design
         /// <inheritdoc/>
         public override void Show(object value)
         {
-            value = value ?? string.Empty;
-            buffer.Enqueue(value.ToString());
+            value ??= string.Empty;
+            var text = value.ToString();
+            text = Regex.Replace(text, @"\r|\n", string.Empty);
+            buffer.Enqueue(text);
             while (buffer.Count > bufferSize)
             {
                 buffer.Dequeue();


### PR DESCRIPTION
This PR ensures the default text visualizer always displays a single row for every element in a sequence, even if the string representation of the object includes line break characters. This is important to ensure the correctness of the visualizer behavior: expanding the height of the visualizer window directly controls how many values are buffered on the display by using multiples of the rendered line height.

If arbitrary multi-line text is left to render unfiltered, this calculation has the potential to be thrown off in a very misleading way, as expanding the control to see all the lines will have the effect of expanding the buffer. Since in this case a single value would already fill up multiple lines, and new values are shown at the bottom, this would mean that the value at the top would be a value in the past, rather than the most recent.

As it currently stands, it is best to assume that no line breaks are allowed. Future versions of the text visualizer, or other visualizers, may introduce other options for multi-line text but for now we want to ensure predictability over flexibility.