### PR TITLE
Improve cursor selection when clicking in editor empty space

### DIFF
--- a/Bonsai.Editor/GraphView/GraphViewControl.cs
+++ b/Bonsai.Editor/GraphView/GraphViewControl.cs
@@ -692,6 +692,7 @@ namespace Bonsai.Editor.GraphView
                 point.X = Math.Min(point.X, (int)rightMost.Location.X);
             }
 
+            var bottomY = 0f;
             foreach (var layout in layoutNodes)
             {
                 if (layout.Node.Value == null) continue;
@@ -699,13 +700,14 @@ namespace Bonsai.Editor.GraphView
                 var boundingRectangle = new RectangleF(
                     layout.BoundingRectangle.Location,
                     new SizeF(NodeAirspace, NodeAirspace));
+                bottomY = Math.Max(bottomY, boundingRectangle.Bottom);
                 if (boundingRectangle.Contains(point))
                 {
                     return layout.Node;
                 }
             }
 
-            return null;
+            return point.Y >= bottomY ? GetLastNode() : null;
         }
 
         public GraphNode GetNodeAt(Point point)

--- a/Bonsai.Editor/GraphView/GraphViewControl.cs
+++ b/Bonsai.Editor/GraphView/GraphViewControl.cs
@@ -686,6 +686,12 @@ namespace Bonsai.Editor.GraphView
             point.X += canvas.HorizontalScroll.Value;
             point.Y += canvas.VerticalScroll.Value;
 
+            if (layoutNodes.Count > 0)
+            {
+                var rightMost = layoutNodes[0];
+                point.X = Math.Min(point.X, (int)rightMost.Location.X);
+            }
+
             foreach (var layout in layoutNodes)
             {
                 if (layout.Node.Value == null) continue;
@@ -699,7 +705,7 @@ namespace Bonsai.Editor.GraphView
                 }
             }
 
-            return GetLastNode();
+            return null;
         }
 
         public GraphNode GetNodeAt(Point point)


### PR DESCRIPTION
Similar to multi-line text editors, this PR updates the editor to move the cursor to the end of the line when clicking in the empty space to the right of the last node. It also moves the cursor to the last node when clicking in the empty space below the last line.