### PR TITLE
Ensure restored bounds are at least in one screen

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -247,7 +247,8 @@ namespace Bonsai.Editor
         void RestoreEditorSettings()
         {
             var desktopBounds = ScaleBounds(EditorSettings.Instance.DesktopBounds, scaleFactor);
-            if (desktopBounds.Width > 0)
+            if (desktopBounds.Width > 0 &&
+                Array.Exists(Screen.AllScreens, screen => screen.WorkingArea.IntersectsWith(desktopBounds)))
             {
                 Bounds = desktopBounds;
             }


### PR DESCRIPTION
This PR ensures that editor bounds restored from user settings can be visible at least in one of the connected screens. The approach chosen is to test whether the bounds intersect at least one of the available screens. This was preferred to a strict "contains" test to avoid resetting the settings when only a few pixels are outside the working area.

Fixes #1281 