### PR TITLE
Disable caret selection from text visualizer

### DIFF
--- a/Bonsai.Design/ObjectTextVisualizer.cs
+++ b/Bonsai.Design/ObjectTextVisualizer.cs
@@ -55,8 +55,7 @@ namespace Bonsai.Design
         public override void Load(IServiceProvider provider)
         {
             buffer = new Queue<string>();
-            textBox = new RichTextBox { Dock = DockStyle.Fill };
-            textBox.ReadOnly = true;
+            textBox = new RichTextLabel { Dock = DockStyle.Fill };
             textBox.Multiline = true;
             textBox.WordWrap = false;
             textBox.ScrollBars = RichTextBoxScrollBars.Horizontal;

--- a/Bonsai.Design/RichTextLabel.cs
+++ b/Bonsai.Design/RichTextLabel.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows.Forms;
+
+namespace Bonsai.Design
+{
+    internal class RichTextLabel : RichTextBox
+    {
+        public RichTextLabel()
+        {
+            ReadOnly = true;
+            TabStop = false;
+            SetStyle(ControlStyles.Selectable, false);
+            SetStyle(ControlStyles.UserMouse, true);
+        }
+    }
+}


### PR DESCRIPTION
During high-frequency text visualizer updates on Mono, the caret is redrawn at the update frequency of the text box control. This PR disables caret selection entirely for a more streamlined and performant visualization experience.

The only disadvantage is that the possibility of copy / pasting text from the control is also disabled, but this is a feature which is very hard to use for scrolling streams anyway as the selection is constantly invalidated by new updates.