### PR TITLE
Clear text visualizer on right double-click

### DIFF
--- a/Bonsai.Design/ObjectTextVisualizer.cs
+++ b/Bonsai.Design/ObjectTextVisualizer.cs
@@ -59,6 +59,15 @@ namespace Bonsai.Design
             textBox.Multiline = true;
             textBox.WordWrap = false;
             textBox.ScrollBars = RichTextBoxScrollBars.Horizontal;
+            textBox.MouseDoubleClick += (sender, e) =>
+            {
+                if (e.Button == MouseButtons.Right)
+                {
+                    buffer.Clear();
+                    textBox.Text = string.Empty;
+                    textPanel.Invalidate();
+                }
+            };
 
             textPanel = new UserControl();
             textPanel.SuspendLayout();

--- a/Bonsai.Design/RichTextLabel.cs
+++ b/Bonsai.Design/RichTextLabel.cs
@@ -4,12 +4,46 @@ namespace Bonsai.Design
 {
     internal class RichTextLabel : RichTextBox
     {
+        const int WM_RBUTTONDOWN = 0x204;
+        const int WM_RBUTTONUP = 0x205;
+        const int WM_RBUTTONDBLCLK = 0x206;
+
         public RichTextLabel()
         {
             ReadOnly = true;
             TabStop = false;
             SetStyle(ControlStyles.Selectable, false);
             SetStyle(ControlStyles.UserMouse, true);
+        }
+
+        static MouseEventArgs CreateMouseEventArgs(MouseButtons button, int clicks = 1)
+        {
+            var mousePosition = MousePosition;
+            return new MouseEventArgs(
+                button,
+                clicks,
+                mousePosition.X,
+                mousePosition.Y,
+                delta: 0);
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            switch (m.Msg)
+            {
+                case WM_RBUTTONDOWN:
+                    OnMouseDown(CreateMouseEventArgs(MouseButtons.Right));
+                    break;
+                case WM_RBUTTONUP:
+                    OnMouseUp(CreateMouseEventArgs(MouseButtons.Right));
+                    break;
+                case WM_RBUTTONDBLCLK:
+                    OnMouseDoubleClick(CreateMouseEventArgs(MouseButtons.Right, clicks: 2));
+                    break;
+                default:
+                    base.WndProc(ref m);
+                    break;
+            }
         }
     }
 }


### PR DESCRIPTION
The default text visualizer is commonly used to inspect the running state of arbitrary sequences throughout the workflow. When a running stream may output several identical values, it can be hard to distinguish whether the sequence has stopped or is emitting constantly identical values.

This PR makes this easier by providing a new action (mouse button right double-click) that clears the text visualizer.