### PR TITLE
Add ReadAllText and WriteAllText operators

### DIFF
--- a/Bonsai.System/IO/ReadAllText.cs
+++ b/Bonsai.System/IO/ReadAllText.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.ComponentModel;
+using System.IO;
+using System.Reactive.Linq;
+
+namespace Bonsai.IO
+{
+    /// <summary>
+    /// Represents an operator that opens a text file, returns a single string with all
+    /// lines in the file, and then closes the file.
+    /// </summary>
+    [DefaultProperty(nameof(Path))]
+    [Description("Opens a text file, returns a single string with all lines in the file, and then closes the file.")]
+    public class ReadAllText : Source<string>
+    {
+        /// <summary>
+        /// Gets or sets the relative or absolute path of the file to open for reading.
+        /// </summary>
+        [Description("The relative or absolute path of the file to open for reading.")]
+        [Editor("Bonsai.Design.OpenFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Generates an observable sequence that opens the text file, returns a single string
+        /// with all lines in the file, and then closes the file.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single string with all lines in the file.
+        /// </returns>
+        public override IObservable<string> Generate()
+        {
+            var path = Path;
+            return Observable.Defer(() => Observable.Return(File.ReadAllText(path)));
+        }
+    }
+}

--- a/Bonsai.System/IO/WriteAllText.cs
+++ b/Bonsai.System/IO/WriteAllText.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.ComponentModel;
+using System.IO;
+using System.Reactive.Linq;
+
+namespace Bonsai.IO
+{
+    /// <summary>
+    /// Represents an operator that opens a text file, writes the source string to
+    /// the file, and then closes the file.
+    /// </summary>
+    [DefaultProperty(nameof(Path))]
+    [Description("Creates a new file, writes the source string to the file, and then closes the file.")]
+    public class WriteAllText : Sink<string>
+    {
+        /// <summary>
+        /// Gets or sets the relative or absolute path of the file to open for writing.
+        /// </summary>
+        [Description("The relative or absolute path of the file to open for writing. If the specified file already exists, it is overwritten.")]
+        [Editor("Bonsai.Design.SaveFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Creates a new file, writes the string in the observable sequence to the file,
+        /// and then closes the file.
+        /// </summary>
+        /// <param name="source">
+        /// The sequence containing the string to write to the file.
+        /// </param>
+        /// <returns>
+        /// An observable sequence that is identical to the <paramref name="source"/> sequence
+        /// but where there is an additional side effect of writing the string to the file.
+        /// </returns>
+        public override IObservable<string> Process(IObservable<string> source)
+        {
+            var path = Path;
+            return source.Do(contents =>
+            {
+                using var writer = new StreamWriter(path, append: false);
+                writer.Write(contents);
+            });
+        }
+    }
+}

--- a/Bonsai.System/IO/WriteAllText.cs
+++ b/Bonsai.System/IO/WriteAllText.cs
@@ -16,9 +16,21 @@ namespace Bonsai.IO
         /// <summary>
         /// Gets or sets the relative or absolute path of the file to open for writing.
         /// </summary>
-        [Description("The relative or absolute path of the file to open for writing. If the specified file already exists, it is overwritten.")]
+        [Description("The relative or absolute path of the file to open for writing.")]
         [Editor("Bonsai.Design.SaveFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         public string Path { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the output file should be overwritten if it already exists.
+        /// </summary>
+        [Description("Indicates whether the output file should be overwritten if it already exists.")]
+        public bool Overwrite { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether text should be appended to the output file if it already exists.
+        /// </summary>
+        [Description("Indicates whether text should be appended to the output file if it already exists.")]
+        public bool Append { get; set; }
 
         /// <summary>
         /// Creates a new file, writes the string in the observable sequence to the file,
@@ -34,9 +46,17 @@ namespace Bonsai.IO
         public override IObservable<string> Process(IObservable<string> source)
         {
             var path = Path;
+            var overwrite = Overwrite;
+            var append = Append;
             return source.Do(contents =>
             {
-                using var writer = new StreamWriter(path, append: false);
+                PathHelper.EnsureDirectory(path);
+                if (File.Exists(path) && !overwrite && !append)
+                {
+                    throw new IOException($"The file '{path}' already exists.");
+                }
+
+                using var writer = new StreamWriter(path, append);
                 writer.Write(contents);
             });
         }


### PR DESCRIPTION
This PR adds support for `ReadAllText` and `WriteAllText` operators, mirroring the .NET framework equivalent helpers with the same name. The goal is to provide quick interfacing to reading and writing entire contents of text files, e.g. for serialization/deserialization purposes.

In the future we will want to generalize the IO streaming interface, but in the meantime these can provide a flexible compromise, for example for small config files.