### PR TITLE
Add ReadTextFile and WriteTextFile operators

### DIFF
--- a/Bonsai.System/IO/ReadTextFile.cs
+++ b/Bonsai.System/IO/ReadTextFile.cs
@@ -11,7 +11,7 @@ namespace Bonsai.IO
     /// </summary>
     [DefaultProperty(nameof(Path))]
     [Description("Opens a text file, returns a single string with all lines in the file, and then closes the file.")]
-    public class ReadAllText : Source<string>
+    public class ReadTextFile : Source<string>
     {
         /// <summary>
         /// Gets or sets the relative or absolute path of the file to open for reading.

--- a/Bonsai.System/IO/WriteTextFile.cs
+++ b/Bonsai.System/IO/WriteTextFile.cs
@@ -11,7 +11,7 @@ namespace Bonsai.IO
     /// </summary>
     [DefaultProperty(nameof(Path))]
     [Description("Creates a new file, writes the source string to the file, and then closes the file.")]
-    public class WriteAllText : Sink<string>
+    public class WriteTextFile : Sink<string>
     {
         /// <summary>
         /// Gets or sets the relative or absolute path of the file to open for writing.


### PR DESCRIPTION
This PR adds new `ReadTextFile` and `WriteTextFile` operators, to mirror the .NET framework equivalent helpers [`File.ReadAllText`](https://learn.microsoft.com/en-us/dotnet/api/system.io.file.readalltext?view=net-7.0) and [`File.WriteAllText`](https://learn.microsoft.com/en-us/dotnet/api/system.io.file.writealltext?view=net-7.0). The goal is to provide quick interfacing to reading and writing entire contents of text files, e.g. for serialization/deserialization purposes.

In the future we will want to generalize the IO streaming interface, but in the meantime these can provide a flexible compromise, for example for small config files.