### PR TITLE
Allow TypeMapping extension types

### DIFF
--- a/Bonsai.Core/Expressions/InputMappingBuilder.cs
+++ b/Bonsai.Core/Expressions/InputMappingBuilder.cs
@@ -33,7 +33,6 @@ namespace Bonsai.Expressions
         /// will be projected into.
         /// </summary>
         [Externalizable(false)]
-        [TypeConverter(typeof(TypeMappingConverter))]
         [Description("Specifies an optional output type into which the selected properties will be mapped.")]
         [Editor("Bonsai.Design.TypeMappingEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         public TypeMapping TypeMapping

--- a/Bonsai.Core/Expressions/MemberSelectorBuilder.cs
+++ b/Bonsai.Core/Expressions/MemberSelectorBuilder.cs
@@ -29,7 +29,6 @@ namespace Bonsai.Expressions
         /// will be projected into.
         /// </summary>
         [Externalizable(false)]
-        [TypeConverter(typeof(TypeMappingConverter))]
         [Description("Specifies an optional output type into which the selected properties will be mapped.")]
         [Editor("Bonsai.Design.TypeMappingEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         public TypeMapping TypeMapping { get; set; }

--- a/Bonsai.Core/Expressions/TypeMapping.cs
+++ b/Bonsai.Core/Expressions/TypeMapping.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Xml.Serialization;
 
 namespace Bonsai.Expressions
@@ -9,6 +10,7 @@ namespace Bonsai.Expressions
     /// to specify output and visualizer types.
     /// </summary>
     [XmlType(Namespace = Constants.XmlNamespace)]
+    [TypeConverter(typeof(TypeMappingConverter))]
     public abstract class TypeMapping
     {
         internal abstract Type TargetType { get; }

--- a/Bonsai.Core/Expressions/TypeMappingConverter.cs
+++ b/Bonsai.Core/Expressions/TypeMappingConverter.cs
@@ -1,26 +1,116 @@
 ﻿using Microsoft.CSharp;
 using System;
 using System.CodeDom;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Serialization;
 
 namespace Bonsai.Expressions
 {
     class TypeMappingConverter : TypeConverter
     {
+        static bool HasExtensionTypes(ITypeDescriptorContext context)
+        {
+            if (context == null) return false;
+            var builderType = context.Instance?.GetType() ?? context.PropertyDescriptor.ComponentType;
+            if (Attribute.IsDefined(builderType, typeof(XmlIncludeAttribute))) return true;
+
+            var propertyInfo = builderType.GetProperty(context.PropertyDescriptor.Name);
+            return propertyInfo != null &&
+                (Attribute.IsDefined(propertyInfo, typeof(XmlElementAttribute)) ||
+                 Attribute.IsDefined(propertyInfo.PropertyType, typeof(XmlIncludeAttribute)));
+        }
+
+        static IEnumerable<Type> GetInstanceTypes(ITypeDescriptorContext context)
+        {
+            var builderType = context.Instance?.GetType() ?? context.PropertyDescriptor.ComponentType;
+            var includeAttributes = (XmlIncludeAttribute[])builderType.GetCustomAttributes(typeof(XmlIncludeAttribute), inherit: true);
+            if (includeAttributes.Length > 0)
+            {
+                return includeAttributes.Select(attribute => attribute.Type);
+            }
+
+            var propertyInfo = builderType.GetProperty(context.PropertyDescriptor.Name);
+            if (propertyInfo == null) return Enumerable.Empty<Type>();
+
+            var elementAttributes = (XmlElementAttribute[])propertyInfo.GetCustomAttributes(typeof(XmlElementAttribute), inherit: true);
+            if (elementAttributes.Length > 0)
+            {
+                return elementAttributes.Select(attribute => attribute.Type);
+            }
+
+            return propertyInfo.PropertyType.GetCustomAttributes<XmlIncludeAttribute>().Select(attribute => attribute.Type);
+        }
+
+        static string GetDisplayName(Type type)
+        {
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(TypeMapping<>))
+            {
+                return GetDisplayName(type.GetGenericArguments()[0]);
+            }
+
+            var displayNameAttribute = (DisplayNameAttribute)type.GetCustomAttribute(typeof(DisplayNameAttribute));
+            if (!string.IsNullOrEmpty(displayNameAttribute?.DisplayName))
+            {
+                return displayNameAttribute.DisplayName;
+            }
+
+            return type.Name;
+        }
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) && HasExtensionTypes(context);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string typeName)
+            {
+                var targetType = GetInstanceTypes(context).FirstOrDefault(
+                    type => string.Equals(GetDisplayName(type), typeName, StringComparison.OrdinalIgnoreCase));
+                return Activator.CreateInstance(targetType);
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
-            var mapping = value as TypeMapping;
-            if (mapping != null && mapping.TargetType != null && destinationType == typeof(string))
+            if (value is TypeMapping mapping && mapping.TargetType != null && destinationType == typeof(string))
             {
-                using (var provider = new CSharpCodeProvider())
+                if (HasExtensionTypes(context))
                 {
+                    return GetDisplayName(mapping.TargetType);
+                }
+                else
+                {
+                    using var provider = new CSharpCodeProvider();
                     var typeRef = new CodeTypeReference(mapping.TargetType);
                     return provider.GetTypeOutput(typeRef);
                 }
             }
 
             return base.ConvertTo(context, culture, value, destinationType);
+        }
+
+        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+        {
+            return HasExtensionTypes(context);
+        }
+
+        public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+        {
+            return true;
+        }
+
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        {
+            var includeTypes = GetInstanceTypes(context).Select(Activator.CreateInstance).ToArray();
+            return new StandardValuesCollection(includeTypes);
         }
     }
 }

--- a/Bonsai.Core/Expressions/VisualizerMappingBuilder.cs
+++ b/Bonsai.Core/Expressions/VisualizerMappingBuilder.cs
@@ -22,7 +22,6 @@ namespace Bonsai.Expressions
         /// observable sequence with a mashup visualizer.
         /// </summary>
         [Externalizable(false)]
-        [TypeConverter(typeof(TypeMappingConverter))]
         [Description("Specifies the visualizer type used to combine the observable sequence with a mashup visualizer.")]
         public TypeMapping VisualizerType { get; set; }
 


### PR DESCRIPTION
Allow properties exposing an abstract `TypeMapping` type to provide standard values in the type converter when the hosting context declares allowable extension types with the [`XmlIncludeAttribute`](https://learn.microsoft.com/en-us/dotnet/api/system.xml.serialization.xmlincludeattribute). This makes it easier to generate builder operators requiring type hinting, such as deserializers of data contracts, schemas, etc.