### PR TITLE
Allow filtering which types to include in CollectionEditor

### DIFF
--- a/Bonsai.System.Design/Resources/CollectionEditor.cs
+++ b/Bonsai.System.Design/Resources/CollectionEditor.cs
@@ -95,9 +95,23 @@ namespace Bonsai.Resources.Design
         {
             var itemType = CollectionItemType;
             var newItemTypes = new List<Type>();
-            if (!itemType.IsAbstract) newItemTypes.Add(itemType);
-            newItemTypes.AddRange(itemType.GetCustomAttributes<XmlIncludeAttribute>().Select(attribute => attribute.Type));
+            if (IsValidType(itemType)) newItemTypes.Add(itemType);
+            newItemTypes.AddRange(itemType
+                .GetCustomAttributes<XmlIncludeAttribute>()
+                .Select(attribute => attribute.Type)
+                .Where(IsValidType));
             return newItemTypes.ToArray();
+        }
+
+        static bool IsValidType(Type type)
+        {
+            if (type.IsAbstract || type.IsInterface || type.ContainsGenericParameters)
+            {
+                return false;
+            }
+
+            var designTimeVisibleAttribute = type.GetCustomAttribute<DesignTimeVisibleAttribute>();
+            return designTimeVisibleAttribute == null || designTimeVisibleAttribute.Visible;
         }
 
         /// <summary>


### PR DESCRIPTION
The `CollectionEditor` provides a default automatic way of looking for derived types based on `XmlIncludeAttribute` annotations. This PR makes this automatic search more flexible by allowing types to be filtered by visibility using the [`DesignTimeVisibleAttribute`](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.designtimevisibleattribute). Types marked with the `Visible` property set to `false` will not be included in the list of new item types.