### PR TITLE
Ensure base path is not modified on resubscription

### DIFF
--- a/Bonsai.System/Bonsai.System.csproj
+++ b/Bonsai.System/Bonsai.System.csproj
@@ -5,7 +5,7 @@
     <Description>Bonsai System Library containing reactive infrastructure to interface with the underlying operating system.</Description>
     <PackageTags>Bonsai Rx Reactive Extensions IO Serial Port Resources</PackageTags>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>2.8.0</VersionPrefix>
+    <VersionPrefix>2.8.1</VersionPrefix>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.IO.Ports" Version="6.0.0" />

--- a/Bonsai.System/IO/FileSink.cs
+++ b/Bonsai.System/IO/FileSink.cs
@@ -135,10 +135,10 @@ namespace Bonsai.IO
             return Observable.Create<TElement>(observer =>
             {
                 PathHelper.EnsureDirectory(fileName);
-                fileName = PathHelper.AppendSuffix(fileName, Suffix);
-                if (File.Exists(fileName) && !Overwrite)
+                var filePath = PathHelper.AppendSuffix(fileName, Suffix);
+                if (File.Exists(filePath) && !Overwrite)
                 {
-                    throw new IOException(string.Format("The file '{0}' already exists.", fileName));
+                    throw new IOException(string.Format("The file '{0}' already exists.", filePath));
                 }
 
                 var disposable = new WriterDisposable<TWriter>(Buffered);
@@ -152,7 +152,7 @@ namespace Bonsai.IO
                             var runningWriter = disposable.Writer;
                             if (runningWriter == null)
                             {
-                                runningWriter = disposable.Writer = CreateWriter(fileName, input);
+                                runningWriter = disposable.Writer = CreateWriter(filePath, input);
                             }
 
                             Write(runningWriter, input);

--- a/Bonsai.System/IO/StreamSink.cs
+++ b/Bonsai.System/IO/StreamSink.cs
@@ -162,8 +162,8 @@ namespace Bonsai.IO
                     try
                     {
                         if (!path.StartsWith(@"\\")) PathHelper.EnsureDirectory(path);
-                        path = PathHelper.AppendSuffix(path, Suffix);
-                        stream = CreateStream(path, Overwrite, cancellationSource.Token);
+                        var streamPath = PathHelper.AppendSuffix(path, Suffix);
+                        stream = CreateStream(streamPath, Overwrite, cancellationSource.Token);
                         disposable.Writer = CreateWriter(stream);
                     }
                     catch (Exception ex)


### PR DESCRIPTION
This PR ensures that the base path provided in `StreamSink` and `FileSink` base process method remains immutable to subscription side-effects. This will prevent erroneous suffixes from being generated on repeated subscriptions to the same observable sequence.

Fixes #1551 