### PR TITLE
Add library folders to DLL search path on windows

### DIFF
--- a/Bonsai.Configuration/Bonsai.Configuration.csproj
+++ b/Bonsai.Configuration/Bonsai.Configuration.csproj
@@ -4,7 +4,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>2.8.0</VersionPrefix>
+    <VersionPrefix>2.8.1</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.NuGet\Bonsai.NuGet.csproj" />

--- a/Bonsai.Configuration/ConfigurationHelper.cs
+++ b/Bonsai.Configuration/ConfigurationHelper.cs
@@ -37,6 +37,11 @@ namespace Bonsai.Configuration
                 currentPath = string.Join(new string(Path.PathSeparator, 1), path, currentPath);
                 Environment.SetEnvironmentVariable(PathEnvironmentVariable, currentPath);
             }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                NativeMethods.AddDllDirectory(path);
+            }
         }
 
         public static string GetConfigurationRoot(PackageConfiguration configuration = null)

--- a/Bonsai.Configuration/NativeMethods.cs
+++ b/Bonsai.Configuration/NativeMethods.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Bonsai.Configuration
+{
+    static class NativeMethods
+    {
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal static extern int AddDllDirectory(string NewDirectory);
+    }
+}

--- a/Bonsai.Player/Bonsai.Player.csproj
+++ b/Bonsai.Player/Bonsai.Player.csproj
@@ -12,7 +12,7 @@
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageIconUrl></PackageIconUrl>
-    <VersionPrefix>2.8.0</VersionPrefix>
+    <VersionPrefix>2.8.1</VersionPrefix>
     <PackAsTool>true</PackAsTool>
   </PropertyGroup>
   <ItemGroup>

--- a/Bonsai/Bonsai.csproj
+++ b/Bonsai/Bonsai.csproj
@@ -7,7 +7,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <UseWindowsForms>true</UseWindowsForms>
     <TargetFramework>net48</TargetFramework>
-    <VersionPrefix>2.8.0</VersionPrefix>
+    <VersionPrefix>2.8.1</VersionPrefix>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>
     <ApplicationIcon>..\Bonsai.Editor\Bonsai.ico</ApplicationIcon>


### PR DESCRIPTION
Starting from Windows 8 and Windows 7 SP1 KB2533623, [Microsoft introduced new API enhancements for securely loading external native libraries](https://support.microsoft.com/en-us/topic/microsoft-security-advisory-insecure-library-loading-could-allow-remote-code-execution-486ea436-2d47-27e5-6cb9-26ab7230c704).

The new API defines a process wide DLL search path which is modified only by direct calls to OS-specific functions. Modern .NET libraries that declare the [`DefaultDllImportSearchPath`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.defaultdllimportsearchpathsattribute?view=netframework-4.7.2) attribute set to [`DllImportSearchPath.SafeDirectories`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.dllimportsearchpath?view=netframework-4.7.2) will use only this DLL search path to find native libraries and ignore the directories in the `PATH` environment variable set by the bootstrapper, which would ultimately lead to binding failures of native dependencies.

To workaround this, the bootstrapper now calls [`AddDllDirectory`](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-adddlldirectory) on Windows for each active native library folder when bootstrapping the environment.

Adding the same folders to the `PATH` environment variable is still required for compatibility with libraries relying on the default legacy p/invoke DLL import.

Fixes #1549 