### PR TITLE
Ensure arguments with spaces are surrounded by quotation marks

### DIFF
--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -209,6 +209,7 @@ namespace Bonsai
                     }
 
                     using var pipeServer = new NamedPipeServerStream(pipeName, PipeDirection.In);
+                    editorArgs = editorArgs.ConvertAll(arg => arg.Contains(' ') ? $"\"{arg}\"" : arg);
                     editorArgs.Add(PipeCommand + ":" + pipeName);
 
                     var setupInfo = new ProcessStartInfo();

--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -210,7 +210,7 @@ namespace Bonsai
 
                     using var pipeServer = new NamedPipeServerStream(pipeName, PipeDirection.In);
                     editorArgs = editorArgs.ConvertAll(arg => arg.Contains(' ') ? $"\"{arg}\"" : arg);
-                    editorArgs.Add(PipeCommand + ":" + pipeName);
+                    editorArgs.AddRange(new[] { PipeCommand, pipeName });
 
                     var setupInfo = new ProcessStartInfo();
                     setupInfo.FileName = Assembly.GetEntryAssembly().Location;


### PR DESCRIPTION
When assembling the string assigned to the `Arguments` property of `ProcessStartInfo` we must manually ensure that any arguments with spaces are surrounded by quotation marks (see [Remarks](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.arguments?view=net-7.0#remarks) for more details).

Fixes #1541 