### PR TITLE
Fix circle picker rescaling and size conversion issues

### DIFF
--- a/Bonsai.Vision.Design/Bonsai.Vision.Design.csproj
+++ b/Bonsai.Vision.Design/Bonsai.Vision.Design.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Vision Visualizers</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.8.0</VersionPrefix>
+    <VersionPrefix>2.8.1</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />

--- a/Bonsai.Vision.Design/ImageEllipsePicker.cs
+++ b/Bonsai.Vision.Design/ImageEllipsePicker.cs
@@ -63,7 +63,7 @@ namespace Bonsai.Vision.Design
                                 select (from moveEvt in mouseMove.TakeUntil(mouseUp)
                                         let target = NormalizedLocation(moveEvt.X, moveEvt.Y)
                                         let modifiedRegion = downEvt.Button == MouseButtons.Right
-                                            ? ScaleRegion(region, target, ModifierKeys.HasFlag(Keys.Control))
+                                            ? ScaleRegion(region, target, IsCirclePicker || ModifierKeys.HasFlag(Keys.Control))
                                             : MoveRegion(region, target - location)
                                         let modifiedRectangle = RegionRectangle(modifiedRegion)
                                         where modifiedRectangle.Width > 0 && modifiedRectangle.Height > 0 &&

--- a/Bonsai.Vision.Design/IplImageCircleEditor.cs
+++ b/Bonsai.Vision.Design/IplImageCircleEditor.cs
@@ -126,7 +126,7 @@ namespace Bonsai.Vision.Design
             RotatedRect ellipse;
             ellipse.Angle = 0;
             ellipse.Center = circle.Center;
-            ellipse.Size = new Size2f(circle.Radius, circle.Radius);
+            ellipse.Size = new Size2f(circle.Radius * 2, circle.Radius * 2);
             return ellipse;
         }
 
@@ -134,7 +134,7 @@ namespace Bonsai.Vision.Design
         {
             Circle circle;
             circle.Center = ellipse.Center;
-            circle.Radius = ellipse.Size.Width;
+            circle.Radius = ellipse.Size.Width / 2;
             return circle;
         }
 


### PR DESCRIPTION
This PR ensures that circle radius is correctly converted to ellipse width, and vice-versa, when setting up the graphical circle picker. We also fixed a minor issue where the circle was being edited as an ellipse during the resize operation.

Fixes #1620 