### PR TITLE
Add missing circle constructor

### DIFF
--- a/Bonsai.Vision/Bonsai.Vision.csproj
+++ b/Bonsai.Vision/Bonsai.Vision.csproj
@@ -5,7 +5,7 @@
     <Description>Bonsai Vision Library containing reactive algorithms for computer vision and image processing.</Description>
     <PackageTags>Bonsai Rx Image Processing Computer Vision</PackageTags>
     <TargetFramework>net462</TargetFramework>
-    <VersionPrefix>2.8.0</VersionPrefix>
+    <VersionPrefix>2.8.1</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />

--- a/Bonsai.Vision/Circle.cs
+++ b/Bonsai.Vision/Circle.cs
@@ -20,6 +20,18 @@ namespace Bonsai.Vision
         public float Radius;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Circle"/> structure with
+        /// the specified parameters.
+        /// </summary>
+        /// <param name="center">The center of the circle.</param>
+        /// <param name="radius">The radius of the circle.</param>
+        public Circle(Point2f center, float radius)
+        {
+            Center = center;
+            Radius = radius;
+        }
+
+        /// <summary>
         /// Creates a <see cref="string"/> representation of this
         /// <see cref="Circle"/> structure.
         /// </summary>


### PR DESCRIPTION
This PR adds the missing constructor that allows creating dynamic values of type `Circle` without the need for custom scripting modules.

Fixes #1622 