### PR TITLE
Avoid cancellation exception on task completion

### DIFF
--- a/Bonsai.Configuration/Bonsai.Configuration.csproj
+++ b/Bonsai.Configuration/Bonsai.Configuration.csproj
@@ -4,7 +4,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>2.8.1</VersionPrefix>
+    <VersionPrefix>2.8.2</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.NuGet\Bonsai.NuGet.csproj" />

--- a/Bonsai.Configuration/ConsoleBootstrapper.cs
+++ b/Bonsai.Configuration/ConsoleBootstrapper.cs
@@ -15,17 +15,19 @@ namespace Bonsai.Configuration
 
         protected override async Task RunPackageOperationAsync(Func<Task> operationFactory)
         {
-            await operationFactory().ContinueWith(task =>
+            try { await operationFactory(); }
+            catch (Exception ex)
             {
-                if (task.Exception is AggregateException ex)
+                if (ex is AggregateException aex)
                 {
-                    foreach (var error in ex.InnerExceptions)
+                    foreach (var error in aex.InnerExceptions)
                     {
                         PackageManager.Logger.LogError(error.Message);
                     }
                 }
-                else PackageManager.Logger.LogError(task.Exception.Message);
-            }, TaskContinuationOptions.OnlyOnFaulted);
+                else PackageManager.Logger.LogError(ex.Message);
+                throw;
+            }
         }
     }
 }

--- a/Bonsai.Player/Bonsai.Player.csproj
+++ b/Bonsai.Player/Bonsai.Player.csproj
@@ -12,7 +12,7 @@
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageIconUrl></PackageIconUrl>
-    <VersionPrefix>2.8.1</VersionPrefix>
+    <VersionPrefix>2.8.2</VersionPrefix>
     <PackAsTool>true</PackAsTool>
   </PropertyGroup>
   <ItemGroup>

--- a/Bonsai/Bonsai.csproj
+++ b/Bonsai/Bonsai.csproj
@@ -7,7 +7,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <UseWindowsForms>true</UseWindowsForms>
     <TargetFramework>net48</TargetFramework>
-    <VersionPrefix>2.8.1</VersionPrefix>
+    <VersionPrefix>2.8.2</VersionPrefix>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>
     <ApplicationIcon>..\Bonsai.Editor\Bonsai.ico</ApplicationIcon>

--- a/Bonsai32/Bonsai32.csproj
+++ b/Bonsai32/Bonsai32.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <TargetFramework>net48</TargetFramework>
     <PlatformTarget>x86</PlatformTarget>
-    <VersionPrefix>2.8.1</VersionPrefix>
+    <VersionPrefix>2.8.2</VersionPrefix>
     <OutputType>Exe</OutputType>
     <OutputPath>..\Bonsai\bin\$(Configuration)\</OutputPath>
     <ApplicationIcon>..\Bonsai.Editor\Bonsai.ico</ApplicationIcon>


### PR DESCRIPTION
This PR updates the implementation of `RunPackageOperationAsync` in the console bootstrapper class to avoid explicit scheduling of exception continuations. Instead, a standard try-catch block on top of the async-await pattern is used to ensure task completion in case of successful termination.

Fixes #1687 