### PR TITLE
Improve detection of word boundaries in node names

### DIFF
--- a/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
+++ b/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
@@ -3,7 +3,7 @@
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>2.8.0</VersionPrefix>
+    <VersionPrefix>2.8.1</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.bonsai" />

--- a/Bonsai.Editor.Tests/WordSeparationTests.cs
+++ b/Bonsai.Editor.Tests/WordSeparationTests.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Editor.Tests
+{
+    [TestClass]
+    public class WordSeparationTests
+    {
+        [DataTestMethod]
+        [DataRow("UpdateVRState", "Update", "VR", "State")]
+        [DataRow("Get-DisplayLED", "Get-", "Display", "LED")]
+        [DataRow("A_LARGE_NAME", "A_", "LARGE_", "NAME")]
+        [DataRow("Get-LatestI2CReading", "Get-", "Latest", "I2C", "Reading")]
+        [DataRow("ObserveOnTaskPool", "Observe", "On", "Task", "Pool")]
+        public void SplitOnWordBoundaries_ExpectedWordSequence(string text, params string[] expectedWords)
+        {
+            var words = text.SplitOnWordBoundaries();
+            CollectionAssert.AreEqual(expectedWords, words);
+        }
+    }
+}

--- a/Bonsai.Editor.Tests/WordSeparationTests.cs
+++ b/Bonsai.Editor.Tests/WordSeparationTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Bonsai.Editor.Tests
 {
@@ -6,6 +7,8 @@ namespace Bonsai.Editor.Tests
     public class WordSeparationTests
     {
         [DataTestMethod]
+        [DataRow("")]
+        [DataRow("State Space", "State ", "Space")]
         [DataRow("UpdateVRState", "Update", "VR", "State")]
         [DataRow("Get-DisplayLED", "Get-", "Display", "LED")]
         [DataRow("A_LARGE_NAME", "A_", "LARGE_", "NAME")]
@@ -15,6 +18,13 @@ namespace Bonsai.Editor.Tests
         {
             var words = text.SplitOnWordBoundaries();
             CollectionAssert.AreEqual(expectedWords, words);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void SplitOnWordBoundaries_NullString_ThrowsArgumentNullException()
+        {
+            StringExtensions.SplitOnWordBoundaries(null);
         }
     }
 }

--- a/Bonsai.Editor.Tests/WordSeparationTests.cs
+++ b/Bonsai.Editor.Tests/WordSeparationTests.cs
@@ -8,7 +8,9 @@ namespace Bonsai.Editor.Tests
     {
         [DataTestMethod]
         [DataRow("")]
+        [DataRow("Point.X", "Point.", "X")]
         [DataRow("State Space", "State ", "Space")]
+        [DataRow("TimeStep.ElapsedTime", "Time", "Step.", "Elapsed", "Time")]
         [DataRow("UpdateVRState", "Update", "VR", "State")]
         [DataRow("Get-DisplayLED", "Get-", "Display", "LED")]
         [DataRow("A_LARGE_NAME", "A_", "LARGE_", "NAME")]

--- a/Bonsai.Editor.Tests/WordSeparationTests.cs
+++ b/Bonsai.Editor.Tests/WordSeparationTests.cs
@@ -9,6 +9,8 @@ namespace Bonsai.Editor.Tests
         [DataTestMethod]
         [DataRow("")]
         [DataRow("Point.X", "Point.", "X")]
+        [DataRow("Source/1", "Source/", "1")]
+        [DataRow("Source/Path", "Source/", "Path")]
         [DataRow("State Space", "State ", "Space")]
         [DataRow("TimeStep.ElapsedTime", "Time", "Step.", "Elapsed", "Time")]
         [DataRow("UpdateVRState", "Update", "VR", "State")]

--- a/Bonsai.Editor/Bonsai.Editor.csproj
+++ b/Bonsai.Editor/Bonsai.Editor.csproj
@@ -7,7 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>2.8.0</VersionPrefix>
+    <VersionPrefix>2.8.1</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.svg" />

--- a/Bonsai.Editor/GraphView/GraphViewControl.cs
+++ b/Bonsai.Editor/GraphView/GraphViewControl.cs
@@ -988,31 +988,10 @@ namespace Bonsai.Editor.GraphView
             EnsureVisible(CursorNode);
         }
 
-        private static string[] GetWords(string text)
-        {
-            var wordCount = 0;
-            var words = new string[text.Length];
-            var builder = new StringBuilder(text.Length);
-            foreach (var c in text)
-            {
-                if (builder.Length > 0 && (Char.IsUpper(c) || Char.IsWhiteSpace(c)))
-                {
-                    words[wordCount++] = builder.ToString();
-                    builder.Clear();
-                }
-
-                builder.Append(c);
-            }
-
-            if (builder.Length > 0) words[wordCount++] = builder.ToString();
-            Array.Resize(ref words, wordCount);
-            return words;
-        }
-
         private static IEnumerable<string> WordWrap(Graphics graphics, string text, Font font, float lineWidth)
         {
             var trimStart = true;
-            var words = GetWords(text);
+            var words = text.SplitOnWordBoundaries();
             var lineBreak = words.Length <= 1 ? 0 : 2;
             var result = new StringBuilder(text.Length);
             foreach (var word in words)

--- a/Bonsai.Editor/StringExtensions.cs
+++ b/Bonsai.Editor/StringExtensions.cs
@@ -17,11 +17,7 @@ namespace Bonsai.Editor
 
         static bool IsWordSeparator(char c)
         {
-            return char.IsWhiteSpace(c) || c switch
-            {
-                '_' or '-' or '.' => true,
-                _ => false
-            };
+            return char.IsSeparator(c) || char.IsPunctuation(c);
         }
 
         static bool IsWordBreak(string text, int index, char current)

--- a/Bonsai.Editor/StringExtensions.cs
+++ b/Bonsai.Editor/StringExtensions.cs
@@ -19,7 +19,7 @@ namespace Bonsai.Editor
         {
             return char.IsWhiteSpace(c) || c switch
             {
-                '_' or '-' => true,
+                '_' or '-' or '.' => true,
                 _ => false
             };
         }

--- a/Bonsai.Editor/StringExtensions.cs
+++ b/Bonsai.Editor/StringExtensions.cs
@@ -20,7 +20,7 @@ namespace Bonsai.Editor
             return char.IsSeparator(c) || char.IsPunctuation(c);
         }
 
-        static bool IsWordBreak(string text, int index, char current)
+        static bool IsWordBoundary(string text, int index, char current)
         {
             var previous = text[index - 1];
             return IsLowerToUpperCase(previous, current)
@@ -41,7 +41,7 @@ namespace Bonsai.Editor
             for (int i = 0; i < text.Length; i++)
             {
                 var c = text[i];
-                if (i > 0 && IsWordBreak(text, i, c))
+                if (i > 0 && IsWordBoundary(text, i, c))
                 {
                     words[wordCount++] = builder.ToString();
                     builder.Clear();

--- a/Bonsai.Editor/StringExtensions.cs
+++ b/Bonsai.Editor/StringExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Text;
+
+namespace Bonsai.Editor
+{
+    internal static class StringExtensions
+    {
+        public static string[] SplitOnWordBoundaries(this string text)
+        {
+            var wordCount = 0;
+            var words = new string[text.Length];
+            var builder = new StringBuilder(text.Length);
+            foreach (var c in text)
+            {
+                if (builder.Length > 0 && (Char.IsUpper(c) || Char.IsWhiteSpace(c)))
+                {
+                    words[wordCount++] = builder.ToString();
+                    builder.Clear();
+                }
+
+                builder.Append(c);
+            }
+
+            if (builder.Length > 0) words[wordCount++] = builder.ToString();
+            Array.Resize(ref words, wordCount);
+            return words;
+        }
+    }
+}

--- a/Bonsai.Editor/StringExtensions.cs
+++ b/Bonsai.Editor/StringExtensions.cs
@@ -34,6 +34,11 @@ namespace Bonsai.Editor
 
         public static string[] SplitOnWordBoundaries(this string text)
         {
+            if (text == null)
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+
             var wordCount = 0;
             var words = new string[text.Length];
             var builder = new StringBuilder(text.Length);

--- a/Bonsai.Editor/StringExtensions.cs
+++ b/Bonsai.Editor/StringExtensions.cs
@@ -5,14 +5,42 @@ namespace Bonsai.Editor
 {
     internal static class StringExtensions
     {
+        static bool IsLowerToUpperCase(char a, char b)
+        {
+            return char.IsLower(a) && char.IsUpper(b);
+        }
+
+        static bool IsUpperToLowerCase(char a, char b)
+        {
+            return char.IsUpper(a) && char.IsLower(b);
+        }
+
+        static bool IsWordSeparator(char c)
+        {
+            return char.IsWhiteSpace(c) || c switch
+            {
+                '_' or '-' => true,
+                _ => false
+            };
+        }
+
+        static bool IsWordBreak(string text, int index, char current)
+        {
+            var previous = text[index - 1];
+            return IsLowerToUpperCase(previous, current)
+                || IsWordSeparator(previous)
+                || index < text.Length - 1 && IsUpperToLowerCase(current, text[index + 1]);
+        }
+
         public static string[] SplitOnWordBoundaries(this string text)
         {
             var wordCount = 0;
             var words = new string[text.Length];
             var builder = new StringBuilder(text.Length);
-            foreach (var c in text)
+            for (int i = 0; i < text.Length; i++)
             {
-                if (builder.Length > 0 && (Char.IsUpper(c) || Char.IsWhiteSpace(c)))
+                var c = text[i];
+                if (i > 0 && IsWordBreak(text, i, c))
                 {
                     words[wordCount++] = builder.ToString();
                     builder.Clear();


### PR DESCRIPTION
This PR updates word separation rules for the editor graph view to improve the rendering of typical casing rules which might be used in operator names. In general all previous rules were preserved, and a few new ones added:

- Separators and punctuation marks are now explicit word separators
- Changes in casing either lower to upper, or upper to lower, are used to delimit word tokens. Non-letter characters are ignored and only the immediately preceding and subsequent characters are inspected. 

Fixes #1692 