### PR TITLE
Ensure external browser docs are shown on modifier

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2337,10 +2337,10 @@ namespace Bonsai.Editor
 
             try
             {
+                var showExternal = ModifierKeys.HasFlag(Keys.Control);
                 var editorControl = selectionModel.SelectedView.EditorControl;
                 var url = await documentationProvider.GetDocumentationAsync(assemblyName, uid);
-                if (!ModifierKeys.HasFlag(Keys.Control) &&
-                    editorControl.AnnotationPanel.HasWebView)
+                if (!showExternal && editorControl.AnnotationPanel.HasWebView)
                 {
                     editorControl.AnnotationPanel.Navigate(url.AbsoluteUri);
                     var nameSeparator = uid.LastIndexOf(ExpressionHelper.MemberSeparator);


### PR DESCRIPTION
This PR caches the modifier key before initiating asynchronous calls to fetch documentation map. Apparently the async call can reset the modifier state even if the key is held. The second time it worked because HTTP call is cached.

Fixes #1653 