### PR TITLE
Ensure retrieval of closest subject definition

### DIFF
--- a/Bonsai.Configuration/NativeMethods.cs
+++ b/Bonsai.Configuration/NativeMethods.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace Bonsai.Configuration
 {

--- a/Bonsai.Configuration/ScriptExtensions.cs
+++ b/Bonsai.Configuration/ScriptExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using NuGet.Configuration;
-using NuGet.Packaging;
 using NuGet.Versioning;
 using System;
 using System.Collections.Generic;

--- a/Bonsai.Editor.Tests/EditorHelper.cs
+++ b/Bonsai.Editor.Tests/EditorHelper.cs
@@ -25,6 +25,14 @@ namespace Bonsai.Editor.Tests
             return graph.ToInspectableGraph();
         }
 
+        internal static TBuilder FindExpressionBuilder<TBuilder>(this ExpressionBuilderGraph workflow) where TBuilder : class
+        {
+            return (from node in workflow
+                    let builder = node.Value as TBuilder
+                    where builder != null
+                    select builder).FirstOrDefault();
+        }
+
         internal static GraphNode FindNode(this WorkflowEditor editor, string name)
         {
             var node = editor.Workflow.First(n => ExpressionBuilder.GetElementDisplayName(n.Value) == name);

--- a/Bonsai.Editor.Tests/NestedSubscribeSubjectWithClosestRedefinition.bonsai
+++ b/Bonsai.Editor.Tests/NestedSubscribeSubjectWithClosestRedefinition.bonsai
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.1"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="IntProperty">
+          <Value>8</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="rx:PublishSubject">
+        <Name>Values</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Values</Name>
+      </Expression>
+      <Expression xsi:type="rx:Defer">
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="Multiply">
+              <Operand xsi:type="IntProperty">
+                <Value>2</Value>
+              </Operand>
+            </Expression>
+            <Expression xsi:type="rx:PublishSubject">
+              <Name>Values</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Timer">
+                <rx:DueTime>PT0S</rx:DueTime>
+                <rx:Period>PT0S</rx:Period>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:SelectMany">
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="WorkflowInput">
+                    <Name>Source1</Name>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>Values</Name>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="1" To="2" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="3" To="4" Label="Source1" />
+            <Edge From="4" To="5" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="2" To="3" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/Bonsai.Editor.Tests/WorkflowEditorDefinitionTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorDefinitionTests.cs
@@ -1,0 +1,22 @@
+﻿using Bonsai.Editor.GraphModel;
+using Bonsai.Reactive;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Editor.Tests
+{
+    public partial class WorkflowEditorTests
+    {
+        [TestMethod]
+        public void GetSubjectDefinition_NestedSubscribeSubject_ReturnsClosestDefinition()
+        {
+            var workflowBuilder = LoadEmbeddedWorkflow("NestedSubscribeSubjectWithClosestRedefinition.bonsai");
+            var deferBuilder = workflowBuilder.Workflow.FindExpressionBuilder<Defer>();
+            Assert.IsNotNull(deferBuilder);
+            var selectManyBuilder = deferBuilder.Workflow.FindExpressionBuilder<SelectMany>();
+            Assert.IsNotNull(selectManyBuilder);
+            var definition = workflowBuilder.GetSubjectDefinition(selectManyBuilder.Workflow, "Values");
+            Assert.IsNotNull(definition);
+            Assert.AreSame(deferBuilder.Workflow, definition.Root.Key);
+        }
+    }
+}

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel.Design;
 using System.IO;
 using System.Linq;
 using System.Xml;
 using Bonsai.Dag;
-using Bonsai.Design;
 using Bonsai.Editor.GraphModel;
 using Bonsai.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Bonsai.Editor.Tests
 {
     [TestClass]
-    public class WorkflowEditorTests
+    public partial class WorkflowEditorTests
     {
         static Stream LoadEmbeddedResource(string name)
         {

--- a/Bonsai.Editor/ExportHelper.cs
+++ b/Bonsai.Editor/ExportHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System.Drawing;
-using System.Linq;
 using System.Windows.Forms;
 using Bonsai.Editor.GraphModel;
 using Bonsai.Editor.GraphView;

--- a/Bonsai.Editor/GraphModel/WorkflowBuilderExtensions.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowBuilderExtensions.cs
@@ -51,7 +51,7 @@ namespace Bonsai.Editor.GraphModel
                         let subjectBuilder = element.Builder as SubjectExpressionBuilder
                         where subjectBuilder != null && subjectBuilder.Name == name
                         select new SubjectDefinition(level, subjectBuilder, element.IsReadOnly))
-                        .LastOrDefault();
+                        .FirstOrDefault();
             }
 
             return null;

--- a/Bonsai/ScriptExtensionsEnvironment.cs
+++ b/Bonsai/ScriptExtensionsEnvironment.cs
@@ -1,6 +1,5 @@
 ﻿using Bonsai.Configuration;
 using Bonsai.Editor;
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 


### PR DESCRIPTION
This PR fixes the search command for retrieving subject definitions in the case of subject redefinition. In this case subject definitions with the same name will appear in multiple locations along the call context stack. Previously we were looking for the last definition, however because the search data structure is a LIFO the closest definition is actually the first definition at the top of the stack.

Fixes #1586 