### PR TITLE
Allow filtering package updates

### DIFF
--- a/Bonsai.NuGet.Design/Bonsai.NuGet.Design.csproj
+++ b/Bonsai.NuGet.Design/Bonsai.NuGet.Design.csproj
@@ -5,7 +5,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>2.8.0</VersionPrefix>
+    <VersionPrefix>2.8.1</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.Design\Bonsai.Design.csproj" />

--- a/Bonsai.NuGet.Design/PackageViewController.cs
+++ b/Bonsai.NuGet.Design/PackageViewController.cs
@@ -1,4 +1,4 @@
-using Bonsai.Design;
+﻿using Bonsai.Design;
 using Bonsai.NuGet.Design.Properties;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -209,12 +209,9 @@ namespace Bonsai.NuGet.Design
 
         QueryContinuation<IEnumerable<IPackageSearchMetadata>> GetPackageQuery(SourceRepository repository, string searchTerm, int pageSize, bool includePrerelease, bool updateFeed)
         {
-            if (updateFeed)
-            {
-                var localPackages = PackageManager.LocalRepository.GetLocalPackages();
-                return new UpdateQuery(repository, localPackages, includePrerelease);
-            }
-            else return new SearchQuery(repository, searchTerm, pageSize, includePrerelease, packageTypes);
+            return updateFeed
+                ? new UpdateQuery(repository, PackageManager.LocalRepository, searchTerm, includePrerelease, packageTypes)
+                : new SearchQuery(repository, searchTerm, pageSize, includePrerelease, packageTypes);
         }
 
         static Bitmap ResizeImage(Image image, Size newSize)

--- a/Bonsai.NuGet/Bonsai.NuGet.csproj
+++ b/Bonsai.NuGet/Bonsai.NuGet.csproj
@@ -4,7 +4,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>2.8.0</VersionPrefix>
+    <VersionPrefix>2.8.1</VersionPrefix>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="Rx-Main" Version="2.2.5" />

--- a/Bonsai.NuGet/QueryHelper.cs
+++ b/Bonsai.NuGet/QueryHelper.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using NuGet.Protocol.Core.Types;
+
+namespace Bonsai.NuGet
+{
+    static class QueryHelper
+    {
+        public static SearchFilter CreateSearchFilter(bool includePrerelease, IEnumerable<string> packageTypes)
+        {
+            var searchFilterType = includePrerelease ? SearchFilterType.IsAbsoluteLatestVersion : SearchFilterType.IsLatestVersion;
+            return new SearchFilter(includePrerelease, searchFilterType)
+            {
+                PackageTypes = packageTypes
+            };
+        }
+    }
+}

--- a/Bonsai.NuGet/SearchQuery.cs
+++ b/Bonsai.NuGet/SearchQuery.cs
@@ -10,12 +10,23 @@ namespace Bonsai.NuGet
 {
     public class SearchQuery : QueryContinuation<IEnumerable<IPackageSearchMetadata>>
     {
-        public SearchQuery(SourceRepository repository, string searchTerm, int pageSize, bool includePrerelease, IEnumerable<string> packageTypes = default)
+        public SearchQuery(
+            SourceRepository repository,
+            string searchTerm,
+            int pageSize,
+            bool includePrerelease,
+            IEnumerable<string> packageTypes = default)
             : this(repository, searchTerm, 0, pageSize, includePrerelease, packageTypes)
         {
         }
 
-        private SearchQuery(SourceRepository repository, string searchTerm, int pageIndex, int pageSize, bool includePrerelease, IEnumerable<string> packageTypes)
+        private SearchQuery(
+            SourceRepository repository,
+            string searchTerm,
+            int pageIndex,
+            int pageSize,
+            bool includePrerelease,
+            IEnumerable<string> packageTypes)
         {
             Repository = repository;
             SearchTerm = searchTerm;
@@ -25,23 +36,21 @@ namespace Bonsai.NuGet
             PackageTypes = packageTypes;
         }
 
-        public SourceRepository Repository { get; private set; }
+        public SourceRepository Repository { get; }
 
-        public string SearchTerm { get; private set; }
+        public string SearchTerm { get; }
 
-        public int PageIndex { get; private set; }
+        public int PageIndex { get; }
 
-        public int PageSize { get; private set; }
+        public int PageSize { get; }
 
-        public bool IncludePrerelease { get; private set; }
+        public bool IncludePrerelease { get; }
 
-        public IEnumerable<string> PackageTypes { get; private set; }
+        public IEnumerable<string> PackageTypes { get; }
 
         public override async Task<QueryResult<IEnumerable<IPackageSearchMetadata>>> GetResultAsync(CancellationToken token = default)
         {
-            var searchFilterType = IncludePrerelease ? SearchFilterType.IsAbsoluteLatestVersion : SearchFilterType.IsLatestVersion;
-            var searchFilter = new SearchFilter(IncludePrerelease, searchFilterType);
-            searchFilter.PackageTypes = PackageTypes;
+            var searchFilter = QueryHelper.CreateSearchFilter(IncludePrerelease, PackageTypes);
             try
             {
                 var result = (await Repository.SearchAsync(SearchTerm, searchFilter, PageIndex * PageSize, PageSize + 1, token)).ToList();


### PR DESCRIPTION
This PR enables filtering the local package repository prior to querying for package updates. It also runs all update queries in parallel, resulting in significant performance improvements for nuget.org update queries.

Fixes #1524 