### PR TITLE
Avoid rebuilding combinator reset delegate

### DIFF
--- a/Bonsai.Core/Expressions/CombinatorBuilder.cs
+++ b/Bonsai.Core/Expressions/CombinatorBuilder.cs
@@ -58,7 +58,7 @@ namespace Bonsai.Expressions
             else
             {
                 var combinatorType = combinator.GetType();
-                resetCombinator = BuildResetCombinator(combinatorType);
+                resetCombinator = GetResetCombinatorAction(combinatorType);
                 var processMethodParameters = GetProcessMethods(combinatorType).Select(m => m.GetParameters()).ToArray();
                 var paramArray = processMethodParameters.Any(p =>
                     p.Length >= 1 &&
@@ -75,39 +75,62 @@ namespace Bonsai.Expressions
             }
         }
 
-        static Delegate BuildResetCombinator(Type combinatorType)
+        static Delegate GetResetCombinatorAction(Type combinatorType)
         {
             if (!combinatorType.IsDefined(typeof(ResetCombinatorAttribute)))
             {
                 return null;
             }
 
-            List<PropertyInfo> resetProperties = null;
-            var combinatorProperties = combinatorType.GetProperties();
-            for (int i = 0; i < combinatorProperties.Length; i++)
-            {
-                var property = combinatorProperties[i];
-                if (!property.CanWrite || !Attribute.IsDefined(property, typeof(XmlIgnoreAttribute))) continue;
+            var resetCombinatorType = typeof(ResetCombinator<>).MakeGenericType(combinatorType);
+            return ((ResetCombinator)Activator.CreateInstance(resetCombinatorType)).Action;
+        }
 
-                var proxyProperty = Array.Find(combinatorProperties, p =>
+        abstract class ResetCombinator
+        {
+            public abstract Delegate Action { get; }
+        }
+
+        class ResetCombinator<T> : ResetCombinator
+        {
+            static readonly Delegate Instance = BuildResetCombinator(typeof(T));
+
+            public override Delegate Action => Instance;
+
+            static Delegate BuildResetCombinator(Type combinatorType)
+            {
+                if (!combinatorType.IsDefined(typeof(ResetCombinatorAttribute)))
                 {
-                    var xmlElement = p.GetCustomAttribute<XmlElementAttribute>();
-                    return xmlElement != null && xmlElement.ElementName == property.Name;
-                });
-                if (proxyProperty == null)
-                {
-                    if (resetProperties == null) resetProperties = new List<PropertyInfo>();
-                    resetProperties.Add(property);
+                    return null;
                 }
-            }
 
-            if (resetProperties == null) return null;
-            var combinator = Expression.Parameter(combinatorType);
-            return Expression.Lambda(Expression.Block(resetProperties.Select(property =>
-            {
-                var propertyExpression = Expression.Property(combinator, property);
-                return Expression.Assign(propertyExpression, Expression.Default(property.PropertyType));
-            })), combinator).Compile();
+                List<PropertyInfo> resetProperties = null;
+                var combinatorProperties = combinatorType.GetProperties();
+                for (int i = 0; i < combinatorProperties.Length; i++)
+                {
+                    var property = combinatorProperties[i];
+                    if (!property.CanWrite || !Attribute.IsDefined(property, typeof(XmlIgnoreAttribute))) continue;
+
+                    var proxyProperty = Array.Find(combinatorProperties, p =>
+                    {
+                        var xmlElement = p.GetCustomAttribute<XmlElementAttribute>();
+                        return xmlElement != null && xmlElement.ElementName == property.Name;
+                    });
+                    if (proxyProperty == null)
+                    {
+                        resetProperties ??= new List<PropertyInfo>();
+                        resetProperties.Add(property);
+                    }
+                }
+
+                if (resetProperties == null) return null;
+                var combinator = Expression.Parameter(combinatorType);
+                return Expression.Lambda(Expression.Block(resetProperties.Select(property =>
+                {
+                    var propertyExpression = Expression.Property(combinator, property);
+                    return Expression.Assign(propertyExpression, Expression.Default(property.PropertyType));
+                })), combinator).Compile();
+            }
         }
 
         static IEnumerable<MethodInfo> GetProcessMethods(Type combinatorType)
@@ -150,7 +173,7 @@ namespace Bonsai.Expressions
         {
             var combinatorExpression = Expression.Constant(combinator);
             var processMethods = GetProcessMethods(combinatorExpression.Type);
-            if (resetCombinator != null) resetCombinator.DynamicInvoke(combinator);
+            resetCombinator?.DynamicInvoke(combinator);
             return BuildCall(combinatorExpression, processMethods, arguments.Take(maxArgumentCount).ToArray());
         }
     }

--- a/Bonsai.Core/Expressions/CombinatorBuilder.cs
+++ b/Bonsai.Core/Expressions/CombinatorBuilder.cs
@@ -99,11 +99,6 @@ namespace Bonsai.Expressions
 
             static Delegate BuildResetCombinator(Type combinatorType)
             {
-                if (!combinatorType.IsDefined(typeof(ResetCombinatorAttribute)))
-                {
-                    return null;
-                }
-
                 List<PropertyInfo> resetProperties = null;
                 var combinatorProperties = combinatorType.GetProperties();
                 for (int i = 0; i < combinatorProperties.Length; i++)


### PR DESCRIPTION
Operator properties can sometimes represent shared state which is meant to be assigned and used only at runtime, and which needs to be explicitly invalidated in between workflow execution (see #1083).

Such operators can use the `ResetCombinatorAttribute` to indicate they want any non-serializable properties (i.e. properties marked with the `XmlIgnoreAttribute`) to be reset to their default values on every build. Currently this is implemented as a delegate which is emitted at build time for every resettable operator. However, since the delegate logic depends only on the combinator type, it would be possible to cache the emitted delegates to avoid re-emitting delegates for multiple uses of the same operator.

This PR introduces a nested generic type to serve as the cache, which should speed up build times in workflows with large numbers of resettable operators.