### PR TITLE
Allow script extensions to declare unsafe blocks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,3 +29,8 @@ charset = utf-8-bom
 [*.{cs}]
 # Organize usings
 dotnet_sort_system_directives_first = true
+
+# Language keyword vs full type name
+# Predefined for members, etc does not create a message because the explicitly sized types are conveient in interop scenarios where the bit size matters.
+dotnet_style_predefined_type_for_locals_parameters_members = true:none
+dotnet_style_predefined_type_for_member_access = true:suggestion

--- a/Bonsai.Configuration/ScriptExtensionsProjectMetadata.cs
+++ b/Bonsai.Configuration/ScriptExtensionsProjectMetadata.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
+using NuGet.Versioning;
 
 namespace Bonsai.Configuration
 {
@@ -12,21 +15,34 @@ namespace Bonsai.Configuration
 
         public bool Exists => projectDocument is not null;
 
-        internal const string ItemGroupElement = "ItemGroup";
-        internal const string PackageReferenceElement = "PackageReference";
-        internal const string PackageIncludeAttribute = "Include";
-        internal const string PackageVersionAttribute = "Version";
-        internal const string UseWindowsFormsElement = "UseWindowsForms";
-        internal const string AllowUnsafeBlocksElement = "AllowUnsafeBlocks";
+        const string OuterIndent = "  ";
+        const string InnerIndent = "    ";
+        const string ItemGroupElement = "ItemGroup";
+        const string PackageReferenceElement = "PackageReference";
+        const string PackageIncludeAttribute = "Include";
+        const string PackageVersionAttribute = "Version";
+        const string UseWindowsFormsElement = "UseWindowsForms";
+        const string AllowUnsafeBlocksElement = "AllowUnsafeBlocks";
+
+        const string ProjectFileTemplate = @"<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+</Project>";
 
         internal ScriptExtensionsProjectMetadata(XDocument projectDocument)
-            => this.projectDocument = projectDocument;
+        {
+            Debug.Assert(projectDocument is null || projectDocument.Root is not null);
+            this.projectDocument = projectDocument;
+        }
 
         private XElement GetProperty(string key)
             => projectDocument?.XPathSelectElement($"/Project/PropertyGroup/{key}");
 
         private bool GetBoolProperty(string key)
-            => String.Equals(GetProperty(key)?.Value, "true", StringComparison.InvariantCultureIgnoreCase);
+            => string.Equals(GetProperty(key)?.Value, "true", StringComparison.InvariantCultureIgnoreCase);
 
         public bool AllowUnsafeBlocks => GetBoolProperty(AllowUnsafeBlocksElement);
 
@@ -57,5 +73,60 @@ namespace Bonsai.Configuration
                    where id != null
                    select id.Value;
         }
+
+        public ScriptExtensionsProjectMetadata AddPackageReferences(IEnumerable<PackageReference> packageReferences)
+        {
+            var root = projectDocument?.Root;
+            root ??= XElement.Parse(ProjectFileTemplate, LoadOptions.PreserveWhitespace);
+
+            var projectReferences = root.Descendants(PackageReferenceElement).ToArray();
+            var lastReference = projectReferences.LastOrDefault();
+
+            foreach (var reference in packageReferences)
+            {
+                var includeAttribute = new XAttribute(PackageIncludeAttribute, reference.Id);
+                var versionAttribute = new XAttribute(PackageVersionAttribute, reference.Version);
+                var existingReference = (from element in projectReferences
+                                         let id = element.Attribute(PackageIncludeAttribute)
+                                         where id != null && id.Value == reference.Id
+                                         select element).FirstOrDefault();
+                if (existingReference != null)
+                {
+                    var version = existingReference.Attribute(PackageVersionAttribute);
+                    if (version == null)
+                        existingReference.Add(versionAttribute);
+                    else if (NuGetVersion.Parse(version.Value) < NuGetVersion.Parse(reference.Version))
+                        version.SetValue(reference.Version);
+
+                    continue;
+                }
+
+                var referenceElement = new XElement(PackageReferenceElement, includeAttribute, versionAttribute);
+                if (lastReference == null)
+                {
+                    var itemGroup = new XElement(ItemGroupElement);
+                    itemGroup.Add(Environment.NewLine + InnerIndent);
+                    itemGroup.Add(referenceElement);
+                    itemGroup.Add(Environment.NewLine + OuterIndent);
+
+                    root.Add(OuterIndent);
+                    root.Add(itemGroup);
+                    root.Add(Environment.NewLine);
+                    root.Add(Environment.NewLine);
+                }
+                else
+                {
+                    lastReference.AddAfterSelf(referenceElement);
+                    if (lastReference.PreviousNode != null && lastReference.PreviousNode.NodeType >= XmlNodeType.Text)
+                        lastReference.AddAfterSelf(lastReference.PreviousNode);
+                }
+                lastReference = referenceElement;
+            }
+
+            return new ScriptExtensionsProjectMetadata(new XDocument(root));
+        }
+
+        public string GetProjectXml()
+            => Exists ? projectDocument.Root.ToString(SaveOptions.DisableFormatting) : ProjectFileTemplate;
     }
 }

--- a/Bonsai.Configuration/ScriptExtensionsProjectMetadata.cs
+++ b/Bonsai.Configuration/ScriptExtensionsProjectMetadata.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+namespace Bonsai.Configuration
+{
+    public readonly struct ScriptExtensionsProjectMetadata
+    {
+        private readonly XDocument projectDocument;
+
+        public bool Exists => projectDocument is not null;
+
+        internal const string ItemGroupElement = "ItemGroup";
+        internal const string PackageReferenceElement = "PackageReference";
+        internal const string PackageIncludeAttribute = "Include";
+        internal const string PackageVersionAttribute = "Version";
+        internal const string UseWindowsFormsElement = "UseWindowsForms";
+        internal const string AllowUnsafeBlocksElement = "AllowUnsafeBlocks";
+
+        internal ScriptExtensionsProjectMetadata(XDocument projectDocument)
+            => this.projectDocument = projectDocument;
+
+        private XElement GetProperty(string key)
+            => projectDocument?.XPathSelectElement($"/Project/PropertyGroup/{key}");
+
+        private bool GetBoolProperty(string key)
+            => String.Equals(GetProperty(key)?.Value, "true", StringComparison.InvariantCultureIgnoreCase);
+
+        public bool AllowUnsafeBlocks => GetBoolProperty(AllowUnsafeBlocksElement);
+
+        public IEnumerable<string> GetAssemblyReferences()
+        {
+            yield return "System.dll";
+            yield return "System.Core.dll";
+            yield return "System.Drawing.dll";
+            yield return "System.Numerics.dll";
+            yield return "System.Reactive.Linq.dll";
+            yield return "System.Runtime.Serialization.dll";
+            yield return "System.Xml.dll";
+            yield return "Bonsai.Core.dll";
+            yield return "Microsoft.CSharp.dll";
+            yield return "netstandard.dll";
+
+            if (GetBoolProperty(UseWindowsFormsElement))
+                yield return "System.Windows.Forms.dll";
+        }
+
+        public IEnumerable<string> GetPackageReferences()
+        {
+            if (!Exists)
+                return Enumerable.Empty<string>();
+
+            return from element in projectDocument.Descendants(XName.Get(PackageReferenceElement))
+                   let id = element.Attribute(PackageIncludeAttribute)
+                   where id != null
+                   select id.Value;
+        }
+    }
+}

--- a/Bonsai.Configuration/ScriptExtensionsProvider.cs
+++ b/Bonsai.Configuration/ScriptExtensionsProvider.cs
@@ -143,14 +143,25 @@ namespace Bonsai.Configuration
                 return fileName;
             }
 
-            var compilerParameters = new CompilerParameters(assemblyReferences, assemblyFile);
-            compilerParameters.GenerateExecutable = false;
-            compilerParameters.GenerateInMemory = false;
-            compilerParameters.IncludeDebugInformation = includeDebugInformation;
+            var compilerParameters = new CompilerParameters(assemblyReferences, assemblyFile)
+            {
+                GenerateExecutable = false,
+                GenerateInMemory = false,
+                IncludeDebugInformation = includeDebugInformation,
+                CompilerOptions = "",
+            };
+
+            if (scriptEnvironment.GetAllowUnsafeBlocks())
+            {
+                compilerParameters.CompilerOptions += " /unsafe";
+            }
+            
             if (!includeDebugInformation)
             {
-                compilerParameters.CompilerOptions = "/optimize";
+                compilerParameters.CompilerOptions += " /optimize";
             }
+
+            compilerParameters.CompilerOptions = compilerParameters.CompilerOptions.TrimStart();
 
             using (var codeProvider = new CSharpCodeProvider())
             {

--- a/Bonsai.Configuration/ScriptExtensionsProvider.cs
+++ b/Bonsai.Configuration/ScriptExtensionsProvider.cs
@@ -97,13 +97,14 @@ namespace Bonsai.Configuration
             var assemblyNames = new HashSet<string>();
             var assemblyDirectory = Path.GetTempPath() + OutputAssemblyName + "." + Guid.NewGuid().ToString();
             var scriptEnvironment = new ScriptExtensions(configuration, assemblyDirectory);
+            var scriptProjectMetadata = scriptEnvironment.LoadProjectMetadata();
             var packageSource = new PackageSource(editorRepositoryPath);
             var packageRepository = new SourceRepository(packageSource, Repository.Provider.GetCoreV3());
             var dependencyResource = packageRepository.GetResource<DependencyInfoResource>();
             var localPackageResource = packageRepository.GetResource<FindLocalPackagesResource>();
             using (var cacheContext = new SourceCacheContext())
             {
-                var projectReferences = from id in scriptEnvironment.GetPackageReferences()
+                var projectReferences = from id in scriptProjectMetadata.GetPackageReferences()
                                         from assemblyReference in FindAssemblyReferences(
                                             projectFramework,
                                             dependencyResource,
@@ -111,7 +112,7 @@ namespace Bonsai.Configuration
                                             cacheContext,
                                             packageId: id)
                                         select assemblyReference;
-                assemblyNames.AddRange(scriptEnvironment.GetAssemblyReferences());
+                assemblyNames.AddRange(scriptProjectMetadata.GetAssemblyReferences());
                 assemblyNames.AddRange(projectReferences);
             }
 
@@ -143,25 +144,23 @@ namespace Bonsai.Configuration
                 return fileName;
             }
 
+
+            var compilerOptions = new List<string>();
+            {
+                if (scriptProjectMetadata.AllowUnsafeBlocks)
+                    compilerOptions.Add("/unsafe");
+
+                if (!includeDebugInformation)
+                    compilerOptions.Add("/optimize");
+            }
+
             var compilerParameters = new CompilerParameters(assemblyReferences, assemblyFile)
             {
                 GenerateExecutable = false,
                 GenerateInMemory = false,
                 IncludeDebugInformation = includeDebugInformation,
-                CompilerOptions = "",
+                CompilerOptions = string.Join(" ", compilerOptions),
             };
-
-            if (scriptEnvironment.GetAllowUnsafeBlocks())
-            {
-                compilerParameters.CompilerOptions += " /unsafe";
-            }
-            
-            if (!includeDebugInformation)
-            {
-                compilerParameters.CompilerOptions += " /optimize";
-            }
-
-            compilerParameters.CompilerOptions = compilerParameters.CompilerOptions.TrimStart();
 
             using (var codeProvider = new CSharpCodeProvider())
             {

--- a/Bonsai/DependencyInspector.cs
+++ b/Bonsai/DependencyInspector.cs
@@ -112,10 +112,12 @@ namespace Bonsai
             var dependencies = assemblies.Select(assembly =>
                 configuration.GetAssemblyPackageReference(assembly.GetName().Name, packageMap))
                 .Where(package => package != null);
-            if (File.Exists(scriptEnvironment.ProjectFileName))
+
+            var scriptProjectMetadata = scriptEnvironment.LoadProjectMetadata();
+            if (scriptProjectMetadata.Exists)
             {
                 dependencies = dependencies.Concat(
-                    from id in scriptEnvironment.GetPackageReferences()
+                    from id in scriptProjectMetadata.GetPackageReferences()
                     where configuration.Packages.Contains(id)
                     select configuration.Packages[id]);
             }


### PR DESCRIPTION
The setting can be toggled by modifying `Extensions.csproj`, same as any other C# project.

This change also improves the robustness of the `UseWindowsForms` check since I modified it to use the helper I added for this change.

In particular it now only checks in appropriate locations within the project file, and perhaps more importantly it disregards the case of `true` vs `True`. At some point\* Visual Studio started using the latter when these settings are changed via the UI, so anyone using it would've had `True` treated as false.

<sub>(\*I assume so at least, I typically just modify my `csproj` by hand and I don't have an old version of Visual Studio to check at the moment–I would guess it changed when they redid the project configuration tool.)</sub>

Opening the whole project file to check a single value makes me slightly itchy, but it's consistent with similar logic in `ScriptExtensions` and I didn't want to get lost in the weeds refactoring.

Fixes https://github.com/bonsai-rx/bonsai/issues/1727