### PR TITLE
Prevent empty category nodes from being dragged into the workflow

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1541,7 +1541,9 @@ namespace Bonsai.Editor
 
         private void toolboxTreeView_ItemDrag(object sender, ItemDragEventArgs e)
         {
-            if (e.Item is TreeNode selectedNode && selectedNode.GetNodeCount(false) == 0)
+            if (e.Item is TreeNode selectedNode &&
+                selectedNode.Tag is not null &&
+                selectedNode.GetNodeCount(false) == 0)
             {
                 toolboxTreeView.DoDragDrop(selectedNode, DragDropEffects.Copy);
             }


### PR DESCRIPTION
The current check for deciding whether a toolbox node can be dragged into the workflow was based on testing for number of children, i.e. operator nodes are always leaf nodes either in hierarchical or search mode.

However, category nodes can also be leaf nodes if there are no operators of that category. This can easily happen for the `Workflow` and `Subject` categories. An additional restriction to prevent this is to check whether the node actually has a non-null content `Tag`.

Fixes #1759 