### PR TITLE
Fix GateInterval not working after the first tick

### DIFF
--- a/Bonsai.Core/ObservableCombinators.cs
+++ b/Bonsai.Core/ObservableCombinators.cs
@@ -90,7 +90,7 @@ namespace Bonsai
         /// </returns>
         public static IObservable<TSource> Gate<TSource>(this IObservable<TSource> source, TimeSpan interval, IScheduler scheduler)
         {
-            return Gate(source, Observable.Timer(interval, scheduler));
+            return Gate(source, Observable.Interval(interval, scheduler));
         }
 
         /// <summary>

--- a/Bonsai.Core/Reactive/GateInterval.cs
+++ b/Bonsai.Core/Reactive/GateInterval.cs
@@ -86,7 +86,7 @@ namespace Bonsai.Reactive
         {
             var dueTime = DueTime;
             var scheduler = HighResolutionScheduler.Default;
-            var interval = Observable.Timer(Interval, scheduler);
+            var interval = Observable.Interval(Interval, scheduler);
             return dueTime.HasValue
                 ? source.Gate(interval, dueTime.Value, scheduler)
                 : source.Gate(interval);


### PR DESCRIPTION
This was caused by a change from the `Observable.Window(Func<IObservable<>> windowClosingSelector)` overload to the `Observable.Window(IObservable<> windowBoundaries)` overload done in https://github.com/bonsai-rx/bonsai/commit/606d6feed4932876df231b867c150db072a1c828 for https://github.com/bonsai-rx/bonsai/pull/1315

These two overloads don't actually act quite the same way:
* The former calls the function to retrieve an observable and subscribes to it every time a window opens. The window will close once it emits an element.
* The latter subscribes once and the timing of elements emitted by the sequence determines when the window will close then re-open again.

The observable returned by [`Observable.Timer`](https://reactivex.io/documentation/operators/timer.html) implicitly resets when it is re-subscribed, meaning it works fine with the former but only trigger once with the latter. (Essentially there was one window of the interval length followed by another which never closed.)

[`Observable.Interval`](https://reactivex.io/documentation/operators/interval.html) on the other hand continuously emits new values on the interval, which means it works as expected with this overload and probably makes it better suited to this task regardless.

Fixes https://github.com/bonsai-rx/bonsai/issues/1628