### PR TITLE
Clarify use of cross-correlation for FIR filters

### DIFF
--- a/Bonsai.Dsp/FirFilter.cs
+++ b/Bonsai.Dsp/FirFilter.cs
@@ -13,6 +13,11 @@ namespace Bonsai.Dsp
     /// Represents an operator that convolves the input signal with a finite-impulse
     /// response filter kernel.
     /// </summary>
+    /// <remarks>
+    /// This operator is implemented using cross-correlation. If kernels are symmetric,
+    /// there is no difference between correlation and convolution. When using asymmetric
+    /// kernels, note the kernel needs to be flipped to obtain a true convolution.
+    /// </remarks>
     [Description("Convolves the input signal with a finite-impulse response filter kernel.")]
     public class FirFilter : Transform<Mat, Mat>
     {


### PR DESCRIPTION
The underlying implementation of the `FirFilter` operator uses the [`filter2D`](https://docs.opencv.org/4.x/d4/d86/group__imgproc__filter.html#ga27c049795ce870216ddfb366086b5a04) function from OpenCV to efficiently apply the filter.

Although the documentation of `filter2D` itself states that it "convolves an image with a kernel", in fact the implementation actually computes the cross-correlation. This is a surprisingly common, if misleading, assumption in the computer vision and image processing field, likely coming from the use of either symmetric kernels (in which case correlation is equal to convolution), or learned kernels (in which case the learning process can easily deal with reversed kernel weights).

Nevertheless, the current reference documentation of the operator can be misleading if one is attempting to use `FirFilter` with externally computed asymmetric kernels for temporal convolution. This PR adds a new remarks section clarifying the relationship between correlation and convolution, and how the kernel must be processed to obtain the correct result in case of an asymmetric kernel.

Fixes #1761 