### PR TITLE
Fixed uncaught exception when XRefMap is invalid

### DIFF
--- a/Bonsai.Editor/DocumentationException.cs
+++ b/Bonsai.Editor/DocumentationException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Bonsai.Editor
+{
+    internal sealed class DocumentationException : Exception
+    {
+        public DocumentationException()
+            : base()
+        { }
+
+        public DocumentationException(string message)
+            : base(message)
+        { }
+
+        public DocumentationException(string message, Exception innerException)
+            : base(message, innerException)
+        { }
+    }
+}

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2366,12 +2366,12 @@ namespace Bonsai.Editor
                 var message = $"The specified operator {uid} was not found in the documentation for {assemblyName}.";
                 editorSite.ShowError(ex, message);
             }
-            catch (SystemException ex) when (ex is WebException || ex is NotSupportedException)
+            catch (Exception ex) when (ex is WebException or NotSupportedException or DocumentationException)
             {
                 var message = $"The documentation for the module {assemblyName} is not available. {{0}}";
                 editorSite.ShowError(ex, message);
             }
-            catch (SystemException ex)
+            catch (Exception ex)
             {
                 editorSite.ShowError(ex);
             }


### PR DESCRIPTION
The deserialization exceptions were making it to the generic unhandled exception dialog due to the relevant catch clause looking for `SystemException`.

`SystemException` (and its complement `ApplicationException`) is a bit of a failed experiment from .NET Framework 1. It's no longer used for new `System.*` exceptions, and even before .NET Core it was applied very inconsistently. IMO the line between exceptions in the `System` namespace and exceptions outside of it is basically meaningless and very fuzzy regardless.

As such this PR increases the scope to just plain `Exception`.

------------------

This still would have resulted in very vague low-level errors reaching the end user, so I introduced `DocumentationException` to denote specific errors when parsing the XRefMap.

When one XRefMap fails due to a 404 and another fails due to a `DocumentationException`, the `DocumentationException` takes priority.

------------------

Here is the error that occurs when the documentation server responds with something other than an XRefMap:

![image](https://github.com/bonsai-rx/bonsai/assets/278957/12e0de07-3e48-408b-b1f2-d8bc6e9efe3d)

And here's the error that occurs when the documentation server responds with something that claims to be an XRefMap but isn't unusable:

![image](https://github.com/bonsai-rx/bonsai/assets/278957/1d73d2c1-cc6a-4167-819f-145c4e25f3d8)

Fixes https://github.com/bonsai-rx/bonsai/issues/1507