### PR TITLE
Fix build metadata in workflow version causing semver parsing to fail

### DIFF
--- a/Bonsai.Editor/SemanticVersion.cs
+++ b/Bonsai.Editor/SemanticVersion.cs
@@ -107,6 +107,11 @@ namespace Bonsai.Editor
                 return false;
             }
 
+            // Drop build metadata if present (it's not considered for version precedence or equivalence)
+            var plus = version.IndexOf('+');
+            if (plus >= 0)
+                version = version.Substring(0, plus);
+
             string specialVersion;
             var hyphen = version.IndexOf('-');
             if (hyphen >= 0)


### PR DESCRIPTION
Not important for 2.8.3. The official release builds don't have build meadata so this doesn't affect them.

----------

Bonsai has randomly been telling me that it has "upgraded" workflows I literally just saved. I finally got annoyed enough to poke around to figure out why it thought my workflow was upgraded.

Turns out it was "upgrading" them because the `version` was null here, causing the check to always succeed:

https://github.com/bonsai-rx/bonsai/blob/88a2412f25c467a1ef3505477413900484518e49/Bonsai.Editor/GraphModel/UpgradeHelper.cs#L229-L231

It was null because the parsing in `SemanticVersion` was not handling the build metadata. This change properly ignores it per the semver spec.

I considered adding a `BuildMetadata` property to `SemanticVersion`, but I felt it wasn't super valuable as this type is internal and is built around handling comparisons for the semver spec and the build metadata is completely ignored for those purposes.

This type currently has symmetry between equality operators and `Equals`/`GetHashCode` as well as comparison operators and `CompareTo`, but introducing this member properly should probably involve refactoring everything to break that symmetry. (Similar to how `float.Equals` is bitwise equality but `float.operator==` is IEEE-754 equality.)