### PR TITLE
Prevent infinite recursion when visualizer mappings of the same node are combined together

### DIFF
--- a/Bonsai.Editor/Layout/LayoutHelper.cs
+++ b/Bonsai.Editor/Layout/LayoutHelper.cs
@@ -193,6 +193,10 @@ namespace Bonsai.Design
             if (visualizerMappings.Count == 0) return Array.Empty<VisualizerFactory>();
             return visualizerMappings.Select(mapping =>
             {
+                // stack overflow happens if a visualizer ends up being mapped to itself
+                if (mapping.Source == builder)
+                    throw new WorkflowBuildException("Combining together visualizer mappings from the same node is not currently supported.", builder);
+
                 var nestedSources = GetMashupArguments(mapping.Source, typeVisualizerMap);
                 var visualizerType = mapping.VisualizerType ?? typeVisualizerMap.GetTypeVisualizers(mapping.Source).FirstOrDefault();
                 return new VisualizerFactory(mapping.Source, visualizerType, nestedSources);


### PR DESCRIPTION
This is potentially not the most elegant solution possible here, but Gonçalo asked me to take a quick look and see if we could squeeze a fix in for 2.8.3.

Maybe this is good enough to just prevent the crash since we don't expect anyone to actually intentionally make graphs like this and this code only runs on startup. If not we could leave https://github.com/bonsai-rx/bonsai/issues/1769 open and do a more thorough investigation later.

I'm not attached to the wording of the message if anyone has a better suggestion. (Might be more accurate to say the same node appears multiple times in the mashup? Not sure if people would actually consider `VisualizerMapping` associations to be mashups though, that feels like internal nomenclature leaking to the surface.)

For some reason the error dialog shows up twice, but I think that's actually an unrelated bug. (The exception is only actually thrown once, at first I thought it was getting thrown for each `VisualizerMapping` node but I verified that's not the case.)

Fixes https://github.com/bonsai-rx/bonsai/issues/1769