### PR TITLE
Enable support for compressed XRefMap from documentation server

### DIFF
--- a/Bonsai.Editor/DocumentationHelper.cs
+++ b/Bonsai.Editor/DocumentationHelper.cs
@@ -57,6 +57,7 @@ namespace Bonsai.Editor
             var request = WebRequest.CreateHttp(requestUrl);
             request.ReadWriteTimeout = ReadWriteTimeout;
             request.CachePolicy = new RequestCachePolicy(RequestCacheLevel.Revalidate);
+            request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate; //TODO: Use DecompressionMethods.All upon .NET modernization
             using var response = await request.GetResponseAsync();
             var stream = response.GetResponseStream();
             using var reader = new StreamReader(stream);


### PR DESCRIPTION
With today's Bonsai documentation, the GZip-compressed XRefMap is only 200 KB. That's down from 2.74 MB uncompressed 🎉

The TODO is so we hopefully remember to switch to `DecompressionMethods.All` when we upgrade to modern .NET so that we can take advantage of Brotli and any other future compression methods supported in the future.

(Gonçalo and I considered manually using [`~DecompressionMethods.None`](https://github.com/dotnet/runtime/blob/56d7e5d80ed6dd5e80ca8225ab689a60cae3cfc7/src/libraries/System.Net.Primitives/src/System/Net/DecompressionMethods.cs#L13) since it works downlevel, but decided this might be confusing.)