### PR TITLE
Fix race condition within `HandleWorkflowError`

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1407,6 +1407,7 @@ namespace Bonsai.Editor
 
         void HandleWorkflowError(Exception e)
         {
+            var building = this.building; // Ensure the current value of `building` is used when if the handler below is invoked
             Action selectExceptionNode = () =>
             {
                 var workflowException = e as WorkflowException;
@@ -1415,7 +1416,7 @@ namespace Bonsai.Editor
                     workflowError = workflowException;
                     HighlightExceptionBuilderNode(workflowException, building);
                 }
-                else editorSite.ShowError(e.Message, Name);
+                else editorSite.ShowError(e.Message, "Unexpected Exception");
             };
 
             if (InvokeRequired) BeginInvoke(selectExceptionNode);


### PR DESCRIPTION
This was noticed while Gonçalo and I were investigating https://github.com/bonsai-rx/bonsai/issues/1796

Also adds a more sensible caption to the error dialog when non-workflow errors occur.

I considered adding a message to the error encouraging people to report the error since we don't expect bare non-workflow exceptions to escape to this point, but the part of my brain responsible for wording things is already running on fumes as I get all these issues out of my head before the weekend 😅