### PR TITLE
Log full exception trace for console bootstrap

### DIFF
--- a/Bonsai.Configuration/ConsoleBootstrapper.cs
+++ b/Bonsai.Configuration/ConsoleBootstrapper.cs
@@ -18,14 +18,7 @@ namespace Bonsai.Configuration
             try { await operationFactory(); }
             catch (Exception ex)
             {
-                if (ex is AggregateException aex)
-                {
-                    foreach (var error in aex.InnerExceptions)
-                    {
-                        PackageManager.Logger.LogError(error.Message);
-                    }
-                }
-                else PackageManager.Logger.LogError(ex.Message);
+                PackageManager.Logger.LogError(ex.ToString());
                 throw;
             }
         }


### PR DESCRIPTION
This PR modifies the console bootstrapper behavior to ensure the full exception stack trace is dumped to the logger in the event of an error. The motivation is to improve the debugging experience in terminal-only environments where visualization and exploring of networking and authentication issues may be complicated.

The original bug report suggested throwing at the top-level application, but this may have knock-on effects on the inter-process communication underlying the bootstrapper logic and when calling the Bonsai process from other applications, so it is avoided by having a more verbose log behavior at the level of the specific bootstrapper.

Fixes #1804 