### PR TITLE
Show visualizer if checked menu item is selected but visualizer is hidden

### DIFF
--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1719,6 +1719,15 @@ namespace Bonsai.Editor.GraphView
                     }
                     UpdateSelection(forceUpdate: true);
                 }
+                else if (menuItem.Checked)
+                {
+                    var visualizerLauncher = visualizerMapping[inspectBuilder];
+                    var visualizerVisible = visualizerLauncher.Visible;
+                    if (!visualizerVisible)
+                    {
+                        visualizerLauncher.Show(graphView, serviceProvider);
+                    }
+                }
                 else if (!menuItem.Checked)
                 {
                     layoutSettings.VisualizerTypeName = typeName;


### PR DESCRIPTION
This PR modifies the visualizer menu item event handler to display the visualizer if the menu item is checked and if the visualizer is hidden.

Fixes #1841 