### PR TITLE
Make package comparison in CI optional for the sake of forks

### DIFF
--- a/.github/workflows/Bonsai.yml
+++ b/.github/workflows/Bonsai.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Create build matrix
         id: create-matrix
         run: python .github/workflows/create-build-matrix.py
+        env:
+          enable_package_comparison: ${{vars.ENABLE_PACKAGE_COMPARISON}}
+          will_publish_packages: ${{github.event.inputs.will_publish_packages}}
 
   # =====================================================================================================================================================================
   # Build, test, and package
@@ -184,7 +187,7 @@ jobs:
     runs-on: ubuntu-latest
     # We technically only need the dummy build jobs, but GitHub Actions lacks the ability to depend on specific jobs in a matrix
     needs: build-and-test
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && vars.ENABLE_PACKAGE_COMPARISON == 'true'
     steps:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout


### PR DESCRIPTION
Minor change to release automation I realized should be done after I saw your fork as failing CI.

Forks won't always have the `latest` tag (and even if they do it might be stale), so don't bother with package comparison unless the fork explicitly enables it.

⚠ Before merging you need to [add an Actions variable](https://github.com/bonsai-rx/bonsai/settings/variables/actions) `ENABLE_PACKAGE_COMPARISON` = `true` to this repo.

(Forks can also choose to define that variable to assert that their `latest` tag is valid and that they want the comparisons done.)