### PR TITLE
Log all unhandled bootstrapper exceptions

### DIFF
--- a/Bonsai.Configuration/ConsoleBootstrapper.cs
+++ b/Bonsai.Configuration/ConsoleBootstrapper.cs
@@ -1,6 +1,4 @@
 ﻿using Bonsai.NuGet;
-using System;
-using System.Threading.Tasks;
 
 namespace Bonsai.Configuration
 {
@@ -11,16 +9,6 @@ namespace Bonsai.Configuration
         {
             PackageManager.Logger = ConsoleLogger.Default;
             PackageManager.RequiringLicenseAcceptance += (sender, e) => e.LicenseAccepted = true;
-        }
-
-        protected override async Task RunPackageOperationAsync(Func<Task> operationFactory)
-        {
-            try { await operationFactory(); }
-            catch (Exception ex)
-            {
-                PackageManager.Logger.LogError(ex.ToString());
-                throw;
-            }
         }
     }
 }

--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -174,7 +174,8 @@ namespace Bonsai
                 try { bootstrapper.RunAsync(Launcher.ProjectFramework, packageConfiguration, editorPath, editorPackageName).Wait(); }
                 catch (AggregateException ex)
                 {
-                    Console.Error.WriteLine(ex);
+                    var error = ex.InnerExceptions.Count == 1 ? ex.InnerExceptions[0] : ex;
+                    Console.Error.WriteLine(error);
                     return ErrorExitCode;
                 }
 


### PR DESCRIPTION
During release automation development we realized that unhandled exceptions in the bootstrapper might still be swallowed by the main process, e.g. due to assembly resolution failures. This was fixed in #1873 but with the side-effect that multiple exception traces would now be printed for console bootstrapper package resolution errors, since exceptions were also being routed and printed by the internal bootstrapper console logger.

This PR simplifies error handling to let all exceptions from the console bootstrapper surface naturally, while simultaneously preventing stack trace complexity by flattening the most common case where the `AggregateException` contains a single inner exception.

Fixes #1804 