### PR TITLE
Preload all extension types from include workflows

### DIFF
--- a/Bonsai.Core/Expressions/IncludeWorkflowBuilder.cs
+++ b/Bonsai.Core/Expressions/IncludeWorkflowBuilder.cs
@@ -344,12 +344,11 @@ namespace Bonsai.Expressions
             }
             else
             {
-                if (!File.Exists(path))
+                try { return File.OpenRead(path); }
+                catch (FileNotFoundException ex)
                 {
-                    throw new InvalidOperationException("The specified workflow could not be found.");
+                    throw new InvalidOperationException("The specified workflow could not be found.", ex);
                 }
-
-                return File.OpenRead(path);
             }
         }
 

--- a/Bonsai.Core/Expressions/IncludeWorkflowBuilder.cs
+++ b/Bonsai.Core/Expressions/IncludeWorkflowBuilder.cs
@@ -25,7 +25,7 @@ namespace Bonsai.Expressions
     {
         const char AssemblySeparator = ':';
         internal const string BuildUriPrefix = "::build:";
-        const string DefaultSerializerPropertyName = "Property";
+        const string PlaceholderSerializerPropertyName = "__Property__";
         static readonly XElement[] EmptyProperties = new XElement[0];
         static readonly XmlSerializerNamespaces DefaultSerializerNamespaces = GetXmlSerializerNamespaces();
 
@@ -243,7 +243,7 @@ namespace Bonsai.Expressions
             }
 
             var previousName = element.Name;
-            element.Name = XName.Get(DefaultSerializerPropertyName, element.Name.NamespaceName);
+            element.Name = XName.Get(PlaceholderSerializerPropertyName, element.Name.NamespaceName);
             try
             {
                 var serializer = PropertySerializer.GetXmlSerializer(property.PropertyType);
@@ -431,6 +431,9 @@ namespace Bonsai.Expressions
             return workflow.BuildNested(arguments, includeContext);
         }
 
+        // We serialize all properties using the same placeholder root name to allow us to reuse
+        // a single serializer for each different property type. This means we need to rename
+        // the actual XElement name before or after serialization and deserialization.
         static class PropertySerializer
         {
             static readonly Dictionary<Type, XmlSerializer> serializerCache = new();
@@ -443,7 +446,7 @@ namespace Bonsai.Expressions
                 {
                     if (!serializerCache.TryGetValue(type, out serializer))
                     {
-                        var xmlRoot = new XmlRootAttribute(DefaultSerializerPropertyName) { Namespace = Constants.XmlNamespace };
+                        var xmlRoot = new XmlRootAttribute(PlaceholderSerializerPropertyName) { Namespace = Constants.XmlNamespace };
                         serializer = new XmlSerializer(type, xmlRoot);
                         serializerCache.Add(type, serializer);
                     }

--- a/Bonsai.Core/Expressions/IncludeWorkflowBuilder.cs
+++ b/Bonsai.Core/Expressions/IncludeWorkflowBuilder.cs
@@ -300,7 +300,7 @@ namespace Bonsai.Expressions
             return path;
         }
 
-        static bool IsEmbeddedResourcePath(string path)
+        internal static bool IsEmbeddedResourcePath(string path)
         {
             var separatorIndex = path.IndexOf(AssemblySeparator);
             return separatorIndex >= 0 && !SystemPath.IsPathRooted(path);
@@ -318,7 +318,7 @@ namespace Bonsai.Expressions
             return name;
         }
 
-        static Stream GetWorkflowStream(string path, bool embeddedResource)
+        internal static Stream GetWorkflowStream(string path, bool embeddedResource)
         {
             if (embeddedResource)
             {

--- a/Bonsai.Core/WorkflowBuilder.cs
+++ b/Bonsai.Core/WorkflowBuilder.cs
@@ -101,6 +101,12 @@ namespace Bonsai
         /// </returns>
         public static WorkflowMetadata ReadMetadata(XmlReader reader)
         {
+            var visitedWorkflows = new HashSet<string>();
+            return ReadMetadata(reader, visitedWorkflows);
+        }
+
+        static WorkflowMetadata ReadMetadata(XmlReader reader, HashSet<string> visitedWorkflows)
+        {
             var metadata = new WorkflowMetadata();
             var serializerNamespaces = new SerializerNamespaces();
             if (reader.MoveToFirstAttribute())
@@ -128,7 +134,7 @@ namespace Bonsai
                 {
                     workflowMarkup = ConvertDescriptorMarkup(reader.ReadOuterXml());
                 }
-                else workflowMarkup = ReadXmlExtensions(reader, types, serializerNamespaces);
+                else workflowMarkup = ReadXmlExtensions(reader, types, visitedWorkflows, serializerNamespaces);
             }
 
             if (reader.ReadToNextSibling(ExtensionTypeNodeName))
@@ -824,7 +830,14 @@ namespace Bonsai
             return null;
         }
 
-        static void WriteXmlAttributes(XmlReader reader, XmlWriter writer, bool lookupTypes, HashSet<Type> types, SerializerNamespaces namespaces, ref bool includeWorkflow)
+        static void WriteXmlAttributes(
+            XmlReader reader,
+            XmlWriter writer,
+            bool lookupTypes,
+            HashSet<Type> types,
+            HashSet<string> visitedWorkflows,
+            SerializerNamespaces namespaces,
+            ref bool includeWorkflow)
         {
             do
             {
@@ -888,6 +901,17 @@ namespace Bonsai
                                         value = XmlConvert.EncodeName(typeName);
                                     }
                                 }
+                                else if (includeWorkflow &&
+                                         reader.GetAttribute(nameof(IncludeWorkflowBuilder.Path)) is string path &&
+                                         visitedWorkflows.Add(path))
+                                {
+                                    var embeddedResource = IncludeWorkflowBuilder.IsEmbeddedResourcePath(path);
+                                    using var workflowStream = IncludeWorkflowBuilder.GetWorkflowStream(path, embeddedResource);
+                                    using var workflowReader = XmlReader.Create(workflowStream, null, path);
+                                    workflowReader.MoveToContent();
+                                    var nestedMetadata = ReadMetadata(workflowReader, visitedWorkflows);
+                                    types.UnionWith(nestedMetadata.Types);
+                                }
                             }
 
                             writer.WriteString(value);
@@ -912,7 +936,7 @@ namespace Bonsai
             while (reader.MoveToNextAttribute());
         }
 
-        static string ReadXmlExtensions(XmlReader reader, HashSet<Type> types, SerializerNamespaces namespaces)
+        static string ReadXmlExtensions(XmlReader reader, HashSet<Type> types, HashSet<string> visitedWorkflows, SerializerNamespaces namespaces)
         {
             const int ChunkBufferSize = 1024;
             char[] chunkBuffer = null;
@@ -944,7 +968,7 @@ namespace Bonsai
                             {
                                 var includeWorkflow = includeDepth >= 0;
                                 var lookupTypes = elementNamespace == Constants.XmlNamespace;
-                                WriteXmlAttributes(reader, writer, lookupTypes, types, serializerNamespaces, ref includeWorkflow);
+                                WriteXmlAttributes(reader, writer, lookupTypes, types, visitedWorkflows, serializerNamespaces, ref includeWorkflow);
                                 reader.MoveToElement();
                                 if (lookupTypes && includeDepth < 0 && includeWorkflow)
                                 {

--- a/Bonsai.Core/WorkflowBuilder.cs
+++ b/Bonsai.Core/WorkflowBuilder.cs
@@ -903,6 +903,7 @@ namespace Bonsai
                                 }
                                 else if (includeWorkflow &&
                                          reader.GetAttribute(nameof(IncludeWorkflowBuilder.Path)) is string path &&
+                                         !reader.BaseURI.StartsWith(IncludeWorkflowBuilder.BuildUriPrefix) &&
                                          visitedWorkflows.Add(path))
                                 {
                                     // we don't want to fail in most cases while reading nested metadata, as this


### PR DESCRIPTION
Include workflows are loaded lazily and on-demand during the workflow build step, which means extension type discovery is performed in step-fashion for a newly loaded workflow. This gradual type discovery has dramatic implications in performance as documented in #1680, and this was having a visible impact on editor loading times, especially for complex applications with large numbers of include workflows.

This PR aims to improve the performance by preloading all extension types from included workflows ahead of time. The serialization of workflow properties was also optimized to minimize the number of required serializer instances.

The preloading optimization is disabled during builds to avoid supra-linear costs when recursively loading included workflows with deeply nested self-repeating motifs where the same workflow might be referenced multiple times.

Fixes #1680 
Fixes #824 