### PR TITLE
Use forward slashes for package configuration

### DIFF
--- a/Bonsai.Configuration/AssemblyLocationCollection.cs
+++ b/Bonsai.Configuration/AssemblyLocationCollection.cs
@@ -4,16 +4,16 @@ using System.Reflection;
 namespace Bonsai.Configuration
 {
     [Serializable]
-    public class AssemblyLocationCollection : SortedKeyedCollection<Tuple<string, ProcessorArchitecture>, AssemblyLocation>
+    public class AssemblyLocationCollection : SortedKeyedCollection<(string, ProcessorArchitecture), AssemblyLocation>
     {
         public void Add(string name, ProcessorArchitecture processorArchitecture, string path)
         {
             Add(new AssemblyLocation(name, processorArchitecture, path));
         }
 
-        protected override Tuple<string, ProcessorArchitecture> GetKeyForItem(AssemblyLocation item)
+        protected override (string, ProcessorArchitecture) GetKeyForItem(AssemblyLocation item)
         {
-            return Tuple.Create(item.AssemblyName, item.ProcessorArchitecture);
+            return (item.AssemblyName, item.ProcessorArchitecture);
         }
     }
 }

--- a/Bonsai.Configuration/ConfigurationHelper.cs
+++ b/Bonsai.Configuration/ConfigurationHelper.cs
@@ -53,13 +53,13 @@ namespace Bonsai.Configuration
 
         public static string GetAssemblyLocation(this PackageConfiguration configuration, string assemblyName)
         {
-            var msilAssembly = Tuple.Create(assemblyName, ProcessorArchitecture.MSIL);
+            var msilAssembly = (assemblyName, ProcessorArchitecture.MSIL);
             if (configuration.AssemblyLocations.Contains(msilAssembly))
             {
                 return configuration.AssemblyLocations[msilAssembly].Location;
             }
 
-            var architectureSpecificAssembly = Tuple.Create(assemblyName, Environment.Is64BitProcess ? ProcessorArchitecture.Amd64 : ProcessorArchitecture.X86);
+            var architectureSpecificAssembly = (assemblyName, Environment.Is64BitProcess ? ProcessorArchitecture.Amd64 : ProcessorArchitecture.X86);
             if (configuration.AssemblyLocations.Contains(architectureSpecificAssembly))
             {
                 return configuration.AssemblyLocations[architectureSpecificAssembly].Location;
@@ -209,7 +209,7 @@ namespace Bonsai.Configuration
                 catch (BadImageFormatException) { continue; }
                 catch (IOException) { continue; }
 
-                var locationKey = Tuple.Create(assemblyName.Name, assemblyName.ProcessorArchitecture);
+                var locationKey = (assemblyName.Name, assemblyName.ProcessorArchitecture);
                 if (!configuration.AssemblyLocations.Contains(locationKey))
                 {
                     configuration.AssemblyReferences.Add(assemblyName.Name);


### PR DESCRIPTION
The local environment `.config` file has relied so far on OS-specific path strings to determine assembly locations and native library folders. However, because of this it is currently not possible to version `.config` files across platforms, e.g. Windows and Linux, since the direction of slashes is different.

This PR normalizes config file manipulations to prefer Unix paths for all package install, update and removal operations. To allow for the greatest backwards compatibility as well as OS-specific path strings passed through the CLI interface, the behavior of the `PackageConfiguration` and `ConfigurationHelper` classes was not modified. Instead, normalization was implemented via the `PackageConfigurationUpdater`, which is responsible for actually manipulating the serializable representation of the `.config` file.

When initializing the updater object, all existing paths are normalized to Unix forward slashes, and any further modifications are then performed and persisted using forward slash path separators.

Fixes #1864 