### PR TITLE
Hide embedded DLLs from the solution explorer

### DIFF
--- a/Bonsai/Bonsai.csproj
+++ b/Bonsai/Bonsai.csproj
@@ -46,11 +46,11 @@
     <PackageReference Include="System.Buffers" Version="4.5.1" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" GeneratePathProperty="true" PrivateAssets="all" />
-    <EmbeddedResource Include="$(PkgSystem_Resources_Extensions)/lib/net462/System.Resources.Extensions.dll" />
-    <EmbeddedResource Include="$(PkgSystem_Memory)/lib/net461/System.Memory.dll" />
-    <EmbeddedResource Include="$(PkgSystem_Buffers)/lib/net461/System.Buffers.dll" />
-    <EmbeddedResource Include="$(PkgSystem_Numerics_Vectors)/lib/net46/System.Numerics.Vectors.dll" />
-    <EmbeddedResource Include="$(PkgSystem_Runtime_CompilerServices_Unsafe)/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
+    <EmbeddedResource Include="$(PkgSystem_Resources_Extensions)/lib/net462/System.Resources.Extensions.dll" Visible="false" />
+    <EmbeddedResource Include="$(PkgSystem_Memory)/lib/net461/System.Memory.dll" Visible="false" />
+    <EmbeddedResource Include="$(PkgSystem_Buffers)/lib/net461/System.Buffers.dll" Visible="false" />
+    <EmbeddedResource Include="$(PkgSystem_Numerics_Vectors)/lib/net46/System.Numerics.Vectors.dll" Visible="false" />
+    <EmbeddedResource Include="$(PkgSystem_Runtime_CompilerServices_Unsafe)/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" Visible="false" />
   </ItemGroup>
 
   <Target Name="NuGetConfig" AfterTargets="Build">


### PR DESCRIPTION
Another minor echo of the release automation changes.

This hides the DLLs embedded in the bootstrapper for `System.Resources.Extensions` and its dependencies from the solution explorer, which are unintentionally left visible before this change:

![Screenshot of Visual Studio solution explorer with DLL files listed](https://github.com/bonsai-rx/bonsai/assets/278957/d75b7cde-c892-4102-a68f-9507fbfc7429)

These don't live in the project folder, and without the context of reading the csproj they're just confusing noise.

(That being said if you like being reminded that they're there we can just leave them. Could also hide them in a folder as an in-between option.)

Relates to https://github.com/bonsai-rx/bonsai/pull/1873