### PR TITLE
Avoid packing internal project dependencies

### DIFF
--- a/Bonsai.Configuration/Bonsai.Configuration.csproj
+++ b/Bonsai.Configuration/Bonsai.Configuration.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
   </PropertyGroup>

--- a/Bonsai.NuGet.Design/Bonsai.NuGet.Design.csproj
+++ b/Bonsai.NuGet.Design/Bonsai.NuGet.Design.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
     <UseWindowsForms>true</UseWindowsForms>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>

--- a/Bonsai.NuGet/Bonsai.NuGet.csproj
+++ b/Bonsai.NuGet/Bonsai.NuGet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
Replace `GeneratePackageOnBuild` with `IsPackable` to avoid these packages being packed and processed by the release automation scripts. This was a leftover from the days of migrating from `packages.config`.