### PR TITLE
Fix redundant assembly resolution resulting in duplicate assembly loading

### DIFF
--- a/Bonsai/Bonsai.csproj
+++ b/Bonsai/Bonsai.csproj
@@ -102,6 +102,7 @@
       </_IlRepackCommand>
     </PropertyGroup>
     <Exec WorkingDirectory="$(RepackedOutputPath)" Command="$(_IlRepackCommand.Replace('%0D', ' ').Replace('%0A', ' '))" UseCommandProcessor="false" />
+    <Copy SourceFiles="$(TargetDir)NuGet.config" DestinationFolder="$(RepackedOutputPath)" />
   </Target>
 
   <Target Name="UseRepackOutputForPackage" Condition="'$(UseRepackForBootstrapperPackage)' == 'true'" AfterTargets="BuiltProjectOutputGroup" DependsOnTargets="ConfigureRepack">


### PR DESCRIPTION
Also added copying the `NuGet.config` file to the repack output directory for ease of testing.

Fixes https://github.com/bonsai-rx/bonsai/issues/1901