### PR TITLE
Fix some lists in the NuGet package comparison log not being sorted

### DIFF
--- a/.github/workflows/compare-nuget-packages.py
+++ b/.github/workflows/compare-nuget-packages.py
@@ -194,14 +194,17 @@ with gha.JobSummary() as md:
     def list_missing_peers(heading: str, md_heading: str, packages: set[str]) -> bool:
         if len(packages) == 0:
             return False
-        
+
+        sorted_packages = list(packages)
+        sorted_packages.sort()
+
         print()
         print(heading)
         md.write_line(f"# {md_heading}")
         md.write_line()
         md.write_line(heading)
         md.write_line()
-        for package in packages:
+        for package in sorted_packages:
             print(f"  {package}")
             md.write_line(f"* {package}")
         return True


### PR DESCRIPTION
This is for improving readability on the summary of the detect changed packages action.