### PR TITLE
Fix exception constructor argument order

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -34,3 +34,6 @@ dotnet_sort_system_directives_first = true
 # Predefined for members, etc does not create a message because the explicitly sized types are conveient in interop scenarios where the bit size matters.
 dotnet_style_predefined_type_for_locals_parameters_members = true:none
 dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Instantiate argument exceptions correctly
+dotnet_diagnostic.CA2208.severity = warning

--- a/Bonsai.Core/Dag/DirectedGraph.cs
+++ b/Bonsai.Core/Dag/DirectedGraph.cs
@@ -191,7 +191,7 @@ namespace Bonsai.Dag
             ThrowIfEdgeVerticesNullOrNotInGraph(from, to, nameof(to));
             if (edgeIndex < 0 || edgeIndex > from.Successors.Count)
             {
-                throw new ArgumentOutOfRangeException("The specified edge index is out of range.", nameof(edgeIndex));
+                throw new ArgumentOutOfRangeException(nameof(edgeIndex), "The specified edge index is out of range.");
             }
 
             var edge = new Edge<TNodeValue, TEdgeLabel>(to, label);
@@ -216,7 +216,7 @@ namespace Bonsai.Dag
             ThrowIfEdgeVerticesNullOrNotInGraph(from, edge?.Target, nameof(edge));
             if (edgeIndex < 0 || edgeIndex > from.Successors.Count)
             {
-                throw new ArgumentOutOfRangeException("The specified edge index is out of range.", nameof(edgeIndex));
+                throw new ArgumentOutOfRangeException(nameof(edgeIndex), "The specified edge index is out of range.");
             }
 
             from.Successors.Insert(edgeIndex, edge);
@@ -238,7 +238,7 @@ namespace Bonsai.Dag
             ThrowIfEdgeVerticesNullOrNotInGraph(from, to, nameof(to));
             if (edgeIndex < 0 || edgeIndex >= from.Successors.Count)
             {
-                throw new ArgumentOutOfRangeException("The specified edge index is out of range.", nameof(edgeIndex));
+                throw new ArgumentOutOfRangeException(nameof(edgeIndex), "The specified edge index is out of range.");
             }
 
             var edge = new Edge<TNodeValue, TEdgeLabel>(to, label);
@@ -263,7 +263,7 @@ namespace Bonsai.Dag
             ThrowIfEdgeVerticesNullOrNotInGraph(from, edge?.Target, nameof(edge));
             if (edgeIndex < 0 || edgeIndex >= from.Successors.Count)
             {
-                throw new ArgumentOutOfRangeException("The specified edge index is out of range.", nameof(edgeIndex));
+                throw new ArgumentOutOfRangeException(nameof(edgeIndex), "The specified edge index is out of range.");
             }
 
             from.Successors[edgeIndex] = edge;
@@ -313,7 +313,7 @@ namespace Bonsai.Dag
         {
             if (index < 0 || index > nodes.Count)
             {
-                throw new ArgumentOutOfRangeException("The specified index is out of range.", nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), "The specified index is out of range.");
             }
 
             var node = new Node<TNodeValue, TEdgeLabel>(value);
@@ -343,7 +343,7 @@ namespace Bonsai.Dag
 
             if (index < 0 || index > nodes.Count)
             {
-                throw new ArgumentOutOfRangeException("The specified index is out of range.", nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), "The specified index is out of range.");
             }
 
             InsertInternal(index, new[] { node });
@@ -375,7 +375,7 @@ namespace Bonsai.Dag
 
             if (index < 0 || index > nodes.Count)
             {
-                throw new ArgumentOutOfRangeException("The specified index is out of range.", nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), "The specified index is out of range.");
             }
 
             InsertInternal(index, collection);
@@ -471,7 +471,7 @@ namespace Bonsai.Dag
         {
             if (index < 0 || index >= nodes.Count)
             {
-                throw new ArgumentOutOfRangeException("The specified index is out of range.", nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), "The specified index is out of range.");
             }
 
             var node = nodes[index];
@@ -524,19 +524,19 @@ namespace Bonsai.Dag
         {
             if (index < 0)
             {
-                throw new ArgumentOutOfRangeException("The specified index is less than zero.", nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), "The specified index is less than zero.");
             }
 
             if (count < 0)
             {
-                throw new ArgumentOutOfRangeException("The count of elements to remove is less than zero.", nameof(count));
+                throw new ArgumentOutOfRangeException(nameof(count), "The count of elements to remove is less than zero.");
             }
 
             if (nodes.Count - index < count)
             {
                 throw new ArgumentOutOfRangeException(
-                    "The index and count were out of bounds or count is greater than the number of nodes from index.",
-                    nameof(count));
+                    nameof(count),
+                    "The index and count were out of bounds or count is greater than the number of nodes from index.");
             }
 
             var removed = new HashSet<Node<TNodeValue, TEdgeLabel>>();

--- a/Bonsai.Core/Reactive/Slice.cs
+++ b/Bonsai.Core/Reactive/Slice.cs
@@ -46,19 +46,19 @@ namespace Bonsai.Reactive
             var start = Start;
             if (start < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(start));
+                throw new InvalidOperationException("The specified start index is less than zero.");
             }
 
             var step = Step;
             if (step <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(step));
+                throw new InvalidOperationException("Step size must be a positive number.");
             }
 
             var stop = Stop;
             if (stop < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(stop));
+                throw new InvalidOperationException("The specified stop index is less than zero.");
             }
 
             return (stop - start) <= 0 ? Observable.Empty<TSource>() : Observable.Create<TSource>(observer =>


### PR DESCRIPTION
For some reason the order of arguments into the [`ArgumentOutOfRangeException`](https://learn.microsoft.com/en-us/dotnet/api/system.argumentoutofrangeexception.-ctor?view=net-8.0#system-argumentoutofrangeexception-ctor(system-string-system-string)) constructor was swapped in all instances of the call in the `DirectedGraph` class, most likely because it is the reverse order from the more common [`ArgumentException`](https://learn.microsoft.com/en-us/dotnet/api/system.argumentexception.-ctor?view=net-8.0#system-argumentexception-ctor(system-string-system-string)).