### PR TITLE
Drop version build metadata for official releases

### DIFF
--- a/Bonsai.Core/WorkflowBuilder.cs
+++ b/Bonsai.Core/WorkflowBuilder.cs
@@ -200,8 +200,14 @@ namespace Bonsai
             writer = new XmlExtensionWriter(writer, genericTypes);
 
             var assembly = Assembly.GetExecutingAssembly();
-            var versionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
-            writer.WriteAttributeString(VersionAttributeName, versionInfo.ProductVersion);
+            var version = FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion;
+#if BUILD_KIND_OFFICIAL_RELEASE
+            // Drop build metadata for official releases
+            var plus = version.IndexOf('+');
+            if (plus >= 0)
+                version = version.Substring(0, plus);
+#endif
+            writer.WriteAttributeString(VersionAttributeName, version);
 
             var namespaceDeclarations = GetXmlSerializerNamespaces(types);
             foreach (var qname in namespaceDeclarations)

--- a/Bonsai.Editor/AboutBox.cs
+++ b/Bonsai.Editor/AboutBox.cs
@@ -60,7 +60,12 @@ namespace Bonsai.Editor
         {
             get
             {
-                return FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
+                var productVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
+#if BUILD_KIND_OFFICIAL_RELEASE
+                return SemanticVersion.Parse(productVersion).ToString();
+#else
+                return productVersion;
+#endif
             }
         }
 


### PR DESCRIPTION
To avoid cluttering official release version strings stored in workflow files and displayed in the About box, this PR drops source link build metadata from product version strings.

Fixes #1912 