### PR TITLE
Ensure multicast subject preserves source type

### DIFF
--- a/Bonsai.Core.Tests/SubjectTests.cs
+++ b/Bonsai.Core.Tests/SubjectTests.cs
@@ -33,6 +33,21 @@ namespace Bonsai.Core.Tests
         }
 
         [TestMethod]
+        public void Build_MulticastSourceToObjectSubject_PreservesTypeOfSourceSequence()
+        {
+            // related to https://github.com/bonsai-rx/bonsai/issues/1914
+            var workflow = new TestWorkflow()
+                .Append(new BehaviorSubject<object> { Name = nameof(BehaviorSubject) })
+                .ResetCursor()
+                .AppendCombinator(new IntProperty())
+                .Append(new MulticastSubject { Name = nameof(BehaviorSubject) })
+                .AppendOutput()
+                .Workflow;
+            var expression = workflow.Build();
+            Assert.AreEqual(typeof(IObservable<int>), expression.Type);
+        }
+
+        [TestMethod]
         public void ResourceSubject_SourceTerminatesExceptionally_ShouldNotTryToDispose()
         {
             var workflowBuilder = new TestWorkflow()

--- a/Bonsai.Core.Tests/TestWorkflow.cs
+++ b/Bonsai.Core.Tests/TestWorkflow.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq.Expressions;
 using Bonsai.Dag;
 using Bonsai.Expressions;
 
@@ -96,6 +97,13 @@ namespace Bonsai.Core.Tests
         public ExpressionBuilderGraph ToInspectableGraph()
         {
             return Workflow.ToInspectableGraph();
+        }
+
+        public IObservable<T> BuildObservable<T>()
+        {
+            var expression = Workflow.Build();
+            var observableFactory = Expression.Lambda<Func<IObservable<T>>>(expression).Compile();
+            return observableFactory();
         }
     }
 }


### PR DESCRIPTION
In its current implementation, `MulticastSubject` would automatically cast the values of the source sequence into the subject type, which constitutes a fundamental violation of the contract for `Sink` operators.

This PR ensures that the conversion is applied only when raising notifications to the subject, and that otherwise the type and values of the original sequence are left untouched.

Fixes #1914 