### PR TITLE
Fix NuGet testing feed appearing in official releases

### DIFF
--- a/.github/workflows/create-portable-zip.py
+++ b/.github/workflows/create-portable-zip.py
@@ -29,7 +29,7 @@ with zipfile.ZipFile(output_path, 'x', zipfile.ZIP_DEFLATED, compresslevel=9) as
     ]
 
     nuget_api_url = os.getenv('NUGET_API_URL')
-    if nuget_api_url is not None:
+    if nuget_api_url is not None and nuget_api_url != 'https://api.nuget.org/v3/index.json':
         nuget_config.append(f'    <add key="NuGet Package Testing Feed" value="{nuget_api_url}" />')
 
     # Unstable builds of Bonsai will automatically reference the GitHub Packages feed
@@ -48,7 +48,7 @@ with zipfile.ZipFile(output_path, 'x', zipfile.ZIP_DEFLATED, compresslevel=9) as
         nuget_config.append('      <add key="ClearTextPassword" value="YOUR_GITHUB_PERSONAL_ACCESS_TOKEN" />')
         nuget_config.append('    </Bonsai_x0020_Unstable>')
         nuget_config.append('  </packageSourceCredentials>')
-    else:    
+    else:
         nuget_config.append('  </packageSources>')
 
     nuget_config.append('</configuration>')


### PR DESCRIPTION
This was my intent from the start since I did something similar in Biohazrd, I just forgot to do it apparently. Sorry about that!

Fixes https://github.com/bonsai-rx/bonsai/issues/1911