### PR TITLE
Update launch settings to target artifacts folder

### DIFF
--- a/Bonsai.Audio/Properties/launchSettings.json
+++ b/Bonsai.Audio/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(BonsaiExecutablePath)",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/Bonsai.Design.Visualizers/Properties/launchSettings.json
+++ b/Bonsai.Design.Visualizers/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(BonsaiExecutablePath)",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/Bonsai.Dsp.Design/Properties/launchSettings.json
+++ b/Bonsai.Dsp.Design/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(BonsaiExecutablePath)",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/Bonsai.Dsp/Properties/launchSettings.json
+++ b/Bonsai.Dsp/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(BonsaiExecutablePath)",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/Bonsai.Osc/Properties/launchSettings.json
+++ b/Bonsai.Osc/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(BonsaiExecutablePath)",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/Bonsai.Scripting.Expressions.Design/Properties/launchSettings.json
+++ b/Bonsai.Scripting.Expressions.Design/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(BonsaiExecutablePath)",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/Bonsai.Scripting.Expressions/Properties/launchSettings.json
+++ b/Bonsai.Scripting.Expressions/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(BonsaiExecutablePath)",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/Bonsai.Shaders.Design/Properties/launchSettings.json
+++ b/Bonsai.Shaders.Design/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(BonsaiExecutablePath)",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/Bonsai.Shaders.Rendering/Properties/launchSettings.json
+++ b/Bonsai.Shaders.Rendering/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(BonsaiExecutablePath)",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/Bonsai.Shaders/Properties/launchSettings.json
+++ b/Bonsai.Shaders/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(BonsaiExecutablePath)",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/Bonsai.System.Design/Properties/launchSettings.json
+++ b/Bonsai.System.Design/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(BonsaiExecutablePath)",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/Bonsai.System/Properties/launchSettings.json
+++ b/Bonsai.System/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(BonsaiExecutablePath)",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/Bonsai.Vision.Design/Properties/launchSettings.json
+++ b/Bonsai.Vision.Design/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(BonsaiExecutablePath)",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/Bonsai.Vision/Properties/launchSettings.json
+++ b/Bonsai.Vision/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(BonsaiExecutablePath)",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/Bonsai.Windows.Input/Properties/launchSettings.json
+++ b/Bonsai.Windows.Input/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)Bonsai/bin/$(Configuration)/net472/Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(BonsaiExecutablePath)",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
     }
   }
 }

--- a/tooling/Common.props
+++ b/tooling/Common.props
@@ -34,4 +34,9 @@
 
     <PackageOutputPath>$(ArtifactsPath)/package/$(Configuration.ToLowerInvariant())</PackageOutputPath>
   </PropertyGroup>
+
+  <!-- For configuring launchSettings.json we cannot use property functions so we need to resolve the bootstrapper output path here -->
+  <PropertyGroup>
+    <BonsaiExecutablePath>$(ArtifactsPath)/bin/Bonsai/$(Configuration.ToLowerInvariant())/Bonsai.exe</BonsaiExecutablePath>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
A set of `launchSettings.json` files are used to debug projects in the context of the local bootstrapper build. Unfortunately these have a tendency to go stale as build configuration evolves. This PR attempts to centralize their configuration by leveraging the `Common.props` file and the ability to expand simple property macros in the contents of `launchSettings.json`.

It also updates other settings to ensure native debugging and support for folder paths with spaces.

Fixes #1920 