### PR TITLE
Update ScintillaNET to support modern .NET

### DIFF
--- a/Bonsai.Audio/Bonsai.Audio.csproj
+++ b/Bonsai.Audio/Bonsai.Audio.csproj
@@ -3,7 +3,7 @@
     <Title>Bonsai - Audio Library</Title>
     <Description>Bonsai Audio Library containing modules for sound capture and playback.</Description>
     <PackageTags>Bonsai Rx Audio</PackageTags>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="openal.redist" Version="2.0.7" />

--- a/Bonsai.Core.Tests/Bonsai.Core.Tests.csproj
+++ b/Bonsai.Core.Tests/Bonsai.Core.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.bonsai" />

--- a/Bonsai.Core/Bonsai.Core.csproj
+++ b/Bonsai.Core/Bonsai.Core.csproj
@@ -3,10 +3,10 @@
     <Title>Bonsai - Core Library</Title>
     <Description>Bonsai Core Library containing base classes and workflow infrastructure.</Description>
     <PackageTags>Bonsai Rx Reactive Extensions</PackageTags>
-    <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>Bonsai</RootNamespace>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="Rx-Linq" Version="2.2.5" />
     <PackageReference Include="Rx-PlatformServices" Version="2.2.5" />
   </ItemGroup>

--- a/Bonsai.Design.Visualizers/Bonsai.Design.Visualizers.csproj
+++ b/Bonsai.Design.Visualizers/Bonsai.Design.Visualizers.csproj
@@ -4,7 +4,7 @@
     <Description>Bonsai Visualizers Library containing base visualizer classes and editor infrastructure.</Description>
     <PackageTags>Bonsai Rx Visualizers</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ZedGraph" Version="5.1.7" />

--- a/Bonsai.Design/Bonsai.Design.csproj
+++ b/Bonsai.Design/Bonsai.Design.csproj
@@ -4,7 +4,7 @@
     <Description>Bonsai Design Library containing base visualizer classes and editor infrastructure.</Description>
     <PackageTags>Bonsai Design Rx Reactive Extensions</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="jacobslusser.ScintillaNET" Version="3.6.3" />

--- a/Bonsai.Design/Bonsai.Design.csproj
+++ b/Bonsai.Design/Bonsai.Design.csproj
@@ -7,7 +7,7 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="jacobslusser.ScintillaNET" Version="3.6.3" />
+    <PackageReference Include="fernandreu.ScintillaNET" Version="4.2.0" />
     <PackageReference Include="System.Resources.Extensions" Version="8.0.0" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
   <ItemGroup>

--- a/Bonsai.Dsp.Design/Bonsai.Dsp.Design.csproj
+++ b/Bonsai.Dsp.Design/Bonsai.Dsp.Design.csproj
@@ -4,7 +4,7 @@
     <Description>Bonsai Design Library containing visualizer and editor classes for signal processing data types.</Description>
     <PackageTags>Bonsai Rx Dsp Visualizers</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.Design.Visualizers\Bonsai.Design.Visualizers.csproj" />

--- a/Bonsai.Dsp/Bonsai.Dsp.csproj
+++ b/Bonsai.Dsp/Bonsai.Dsp.csproj
@@ -4,7 +4,7 @@
     <Description>Bonsai Dsp Library containing reactive algorithms for digital signal processing.</Description>
     <PackageTags>Bonsai Rx Dsp Signal Processing</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />

--- a/Bonsai.Osc/Bonsai.Osc.csproj
+++ b/Bonsai.Osc/Bonsai.Osc.csproj
@@ -3,7 +3,7 @@
     <Title>Bonsai - Osc Library</Title>
     <Description>Bonsai Osc Library containing reactive infrastructure to interface with devices using the Open Sound Control protocol.</Description>
     <PackageTags>Bonsai Rx Osc</PackageTags>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.System\Bonsai.System.csproj" />

--- a/Bonsai.Scripting.Expressions.Design/Bonsai.Scripting.Expressions.Design.csproj
+++ b/Bonsai.Scripting.Expressions.Design/Bonsai.Scripting.Expressions.Design.csproj
@@ -7,9 +7,6 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="jacobslusser.ScintillaNET" Version="3.6.3" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Bonsai.Design\Bonsai.Design.csproj" />
     <ProjectReference Include="..\Bonsai.Scripting.Expressions\Bonsai.Scripting.Expressions.csproj" />
   </ItemGroup>

--- a/Bonsai.Scripting.Expressions.Design/Bonsai.Scripting.Expressions.Design.csproj
+++ b/Bonsai.Scripting.Expressions.Design/Bonsai.Scripting.Expressions.Design.csproj
@@ -4,7 +4,7 @@
     <Description>Bonsai Design Library containing editor classes for expression scripting in Bonsai.</Description>
     <PackageTags>Bonsai Rx Scripting Expressions Design</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="jacobslusser.ScintillaNET" Version="3.6.3" />

--- a/Bonsai.Scripting.Expressions/Bonsai.Scripting.Expressions.csproj
+++ b/Bonsai.Scripting.Expressions/Bonsai.Scripting.Expressions.csproj
@@ -3,7 +3,7 @@
     <Title>Bonsai - Expression Scripting Library</Title>
     <Description>Bonsai Scripting Library containing expression scripting infrastructure for Bonsai.</Description>
     <PackageTags>Bonsai Rx Scripting Expressions</PackageTags>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Linq.Dynamic" Version="1.0.7" />

--- a/Bonsai.Shaders.Design/Bonsai.Shaders.Design.csproj
+++ b/Bonsai.Shaders.Design/Bonsai.Shaders.Design.csproj
@@ -4,7 +4,7 @@
     <Description>Bonsai Design Library containing editor classes for shader configuration.</Description>
     <PackageTags>Bonsai Rx Shaders Design Graphics OpenGL</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="jacobslusser.ScintillaNET" Version="3.6.3" />

--- a/Bonsai.Shaders.Design/Bonsai.Shaders.Design.csproj
+++ b/Bonsai.Shaders.Design/Bonsai.Shaders.Design.csproj
@@ -7,9 +7,6 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="jacobslusser.ScintillaNET" Version="3.6.3" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Bonsai.Design\Bonsai.Design.csproj" />
     <ProjectReference Include="..\Bonsai.Shaders\Bonsai.Shaders.csproj" />
     <ProjectReference Include="..\Bonsai.System.Design\Bonsai.System.Design.csproj" />

--- a/Bonsai.Shaders.Rendering/Bonsai.Shaders.Rendering.csproj
+++ b/Bonsai.Shaders.Rendering/Bonsai.Shaders.Rendering.csproj
@@ -3,7 +3,7 @@
     <Title>Bonsai - Shaders Rendering Library</Title>
     <Description>Bonsai Shaders Rendering Library containing modules for rendering complex 3D scenes.</Description>
     <PackageTags>Bonsai Rx Shaders Rendering Assets Graphics OpenGL</PackageTags>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AssimpNet" Version="4.1.0" />

--- a/Bonsai.Shaders/Bonsai.Shaders.csproj
+++ b/Bonsai.Shaders/Bonsai.Shaders.csproj
@@ -3,7 +3,7 @@
     <Title>Bonsai - Shaders Library</Title>
     <Description>Bonsai Shaders Library containing modules for dynamic control of shader primitives.</Description>
     <PackageTags>Bonsai Rx Shaders Graphics OpenGL</PackageTags>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />

--- a/Bonsai.StarterPack/Bonsai.StarterPack.csproj
+++ b/Bonsai.StarterPack/Bonsai.StarterPack.csproj
@@ -6,7 +6,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
 
     <!--
     This warning basically happens because this package has no assemblies but does have dependencies

--- a/Bonsai.System.Design/Bonsai.System.Design.csproj
+++ b/Bonsai.System.Design/Bonsai.System.Design.csproj
@@ -4,7 +4,7 @@
     <Description>Bonsai Design Library containing editor classes for IO and other system configurations.</Description>
     <PackageTags>Bonsai Rx Reactive Extensions IO Resources Design</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.Design\Bonsai.Design.csproj" />

--- a/Bonsai.System.Tests/Bonsai.System.Tests.csproj
+++ b/Bonsai.System.Tests/Bonsai.System.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/Bonsai.System/Bonsai.System.csproj
+++ b/Bonsai.System/Bonsai.System.csproj
@@ -3,7 +3,7 @@
     <Title>Bonsai - System Library</Title>
     <Description>Bonsai System Library containing reactive infrastructure to interface with the underlying operating system.</Description>
     <PackageTags>Bonsai Rx Reactive Extensions IO Serial Port Resources</PackageTags>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.IO.Ports" Version="6.0.0" />

--- a/Bonsai.Vision.Design/Bonsai.Vision.Design.csproj
+++ b/Bonsai.Vision.Design/Bonsai.Vision.Design.csproj
@@ -4,7 +4,7 @@
     <Description>Bonsai Design Library containing visualizer and editor classes for image processing types.</Description>
     <PackageTags>Bonsai Rx Vision Visualizers</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />

--- a/Bonsai.Vision/Bonsai.Vision.csproj
+++ b/Bonsai.Vision/Bonsai.Vision.csproj
@@ -3,7 +3,7 @@
     <Title>Bonsai - Vision Library</Title>
     <Description>Bonsai Vision Library containing reactive algorithms for computer vision and image processing.</Description>
     <PackageTags>Bonsai Rx Image Processing Computer Vision</PackageTags>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />

--- a/Bonsai.Windows.Input/Bonsai.Windows.Input.csproj
+++ b/Bonsai.Windows.Input/Bonsai.Windows.Input.csproj
@@ -4,7 +4,7 @@
     <Description>Bonsai Windows Library containing reactive interfaces to the standard operating system input devices.</Description>
     <PackageTags>Bonsai Rx Windows Input</PackageTags>
     <UseWindowsForms>true</UseWindowsForms>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.Core\Bonsai.Core.csproj" />


### PR DESCRIPTION
In preparation for modernizing the editor to run with the .NET Core stack there are a number of core dependencies which need to be upgraded or modified to run beyond .NET Framework. [jacobslusser/ScintillaNET](https://github.com/jacobslusser/ScintillaNET) was until now one of the big concerns, since the project has been stale for almost 6+ years.

Fortunately, [fernandreu/ScintillaNET](https://github.com/fernandreu/ScintillaNET) now provides a .NET 6.0 compatible fork with a published NuGet package and the source code updates seem to be in great shape. Even though it still only targets windows, the component has even been updated with a new `arm64` runtime, which is a welcome addition for possibly targeting Windows on ARM.

Since this fork only targets .NET 4.7.1 we took the chance to update all projects to target .NET 4.7.2 at a minimum, which is now our recommended target for new packages anyway.

Closes #1706 