### PR TITLE
Rename CombineTimestamp to CreateTimestamped

### DIFF
--- a/Bonsai.Core/Reactive/CombineTimestamp.cs
+++ b/Bonsai.Core/Reactive/CombineTimestamp.cs
@@ -1,31 +1,13 @@
 ﻿using System;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Xml.Serialization;
-using System.ComponentModel;
 
 namespace Bonsai.Reactive
 {
     /// <summary>
-    /// Represents an operator that converts element-timestamp pairs of an observable
-    /// sequence into proper timestamped elements.
+    /// This type is obsolete. Please use the <see cref="CreateTimestamped"/> operator instead.
     /// </summary>
-    [Combinator]
-    [XmlType(Namespace = Constants.XmlNamespace)]
-    [Description("Converts a pair of element and timestamp into a proper timestamped type.")]
-    public class CombineTimestamp
+    [Obsolete]
+    [ProxyType(typeof(CreateTimestamped))]
+    public class CombineTimestamp : CreateTimestamped
     {
-        /// <summary>
-        /// Converts element-timestamp pairs of an observable sequence into proper
-        /// timestamped elements.
-        /// </summary>
-        /// <typeparam name="TSource">The type of the value being timestamped.</typeparam>
-        /// <param name="source">The sequence of element-timestamp pairs.</param>
-        /// <returns>An observable sequence of timestamped values.</returns>
-        public IObservable<Timestamped<TSource>> Process<TSource>(IObservable<Tuple<TSource, DateTimeOffset>> source)
-        {
-            return source.Select(xs => new Timestamped<TSource>(xs.Item1, xs.Item2));
-        }
     }
 }

--- a/Bonsai.Core/Reactive/CreateTimestamped.cs
+++ b/Bonsai.Core/Reactive/CreateTimestamped.cs
@@ -8,21 +8,21 @@ using System.ComponentModel;
 namespace Bonsai.Reactive
 {
     /// <summary>
-    /// Represents an operator that converts element-timestamp pairs of an observable
-    /// sequence into proper timestamped elements.
+    /// Represents an operator that converts element-timestamp pairs in an observable
+    /// sequence into <see cref="Timestamped{T}"/> values.
     /// </summary>
     [Combinator]
     [XmlType(Namespace = Constants.XmlNamespace)]
-    [Description("Converts a pair of element and timestamp into a proper timestamped type.")]
+    [Description("Converts a sequence of element-timestamp pairs into a sequence of timestamped values.")]
     public class CreateTimestamped
     {
         /// <summary>
-        /// Converts element-timestamp pairs of an observable sequence into proper
-        /// timestamped elements.
+        /// Converts element-timestamp pairs in an observable sequence into
+        /// <see cref="Timestamped{T}"/> values.
         /// </summary>
         /// <typeparam name="TSource">The type of the value being timestamped.</typeparam>
         /// <param name="source">The sequence of element-timestamp pairs.</param>
-        /// <returns>An observable sequence of timestamped values.</returns>
+        /// <returns>An observable sequence of <see cref="Timestamped{T}"/> values.</returns>
         public IObservable<Timestamped<TSource>> Process<TSource>(IObservable<Tuple<TSource, DateTimeOffset>> source)
         {
             return source.Select(xs => new Timestamped<TSource>(xs.Item1, xs.Item2));

--- a/Bonsai.Core/Reactive/CreateTimestamped.cs
+++ b/Bonsai.Core/Reactive/CreateTimestamped.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Xml.Serialization;
+using System.ComponentModel;
+
+namespace Bonsai.Reactive
+{
+    /// <summary>
+    /// Represents an operator that converts element-timestamp pairs of an observable
+    /// sequence into proper timestamped elements.
+    /// </summary>
+    [Combinator]
+    [XmlType(Namespace = Constants.XmlNamespace)]
+    [Description("Converts a pair of element and timestamp into a proper timestamped type.")]
+    public class CreateTimestamped
+    {
+        /// <summary>
+        /// Converts element-timestamp pairs of an observable sequence into proper
+        /// timestamped elements.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the value being timestamped.</typeparam>
+        /// <param name="source">The sequence of element-timestamp pairs.</param>
+        /// <returns>An observable sequence of timestamped values.</returns>
+        public IObservable<Timestamped<TSource>> Process<TSource>(IObservable<Tuple<TSource, DateTimeOffset>> source)
+        {
+            return source.Select(xs => new Timestamped<TSource>(xs.Item1, xs.Item2));
+        }
+    }
+}


### PR DESCRIPTION
The `CombineTimestamp` operator was introduced in one of the earliest releases of the language as a way to create timestamped values dynamically from pairs of values and timestamps. As a consequence of this early development, the naming of this operator does not follow current naming conventions.

This PR refactors `CombineTimestamp` into the new `CreateTimestamped` operator, for consistency with other creation operators and with `CreateTimestamped` used in the Harp package. Core proxy types have been leveraged to allow for automatic conversion of old workflows and the original type has been marked with the `[Obsolete]` attribute.

Fixes #1518 