### PR TITLE
Allow building workflows as typed sequences

### DIFF
--- a/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
+++ b/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
@@ -238,6 +238,16 @@ namespace Bonsai.Core.Tests
                 .BuildObservable<Unit>();
         }
 
+        [TestMethod]
+        public void BuildObservable_CovariantWorkflowType_IsCompatibleAssignment()
+        {
+            var workflow = new TestWorkflow()
+                .AppendValue("")
+                .AppendOutput()
+                .BuildObservable<object>();
+            Assert.IsNotNull(workflow);
+        }
+
         class MergeBranchVisitor : ExpressionVisitor
         {
             public int BranchCount { get; private set; }

--- a/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
+++ b/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
@@ -228,6 +228,16 @@ namespace Bonsai.Core.Tests
             Assert.IsFalse(visitor.HasPublishBranch);
         }
 
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void BuildObservable_InvalidWorkflowType_ThrowsArgumentException()
+        {
+            new TestWorkflow()
+                .AppendValue(0)
+                .AppendOutput()
+                .BuildObservable<Unit>();
+        }
+
         class MergeBranchVisitor : ExpressionVisitor
         {
             public int BranchCount { get; private set; }

--- a/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
+++ b/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
@@ -229,7 +229,7 @@ namespace Bonsai.Core.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
+        [ExpectedException(typeof(InvalidOperationException))]
         public void BuildObservable_InvalidWorkflowType_ThrowsArgumentException()
         {
             new TestWorkflow()
@@ -245,6 +245,16 @@ namespace Bonsai.Core.Tests
                 .AppendValue("")
                 .AppendOutput()
                 .BuildObservable<object>();
+            Assert.IsNotNull(workflow);
+        }
+
+        [TestMethod]
+        public void BuildObservable_ConvertibleWorkflowType_IsCompatibleAssignment()
+        {
+            var workflow = new TestWorkflow()
+                .AppendValue(1)
+                .AppendOutput()
+                .BuildObservable<double>();
             Assert.IsNotNull(workflow);
         }
 

--- a/Bonsai.Core.Tests/TestWorkflow.cs
+++ b/Bonsai.Core.Tests/TestWorkflow.cs
@@ -108,9 +108,7 @@ namespace Bonsai.Core.Tests
 
         public IObservable<T> BuildObservable<T>()
         {
-            var expression = Workflow.Build();
-            var observableFactory = Expression.Lambda<Func<IObservable<T>>>(expression).Compile();
-            return observableFactory();
+            return Workflow.BuildObservable<T>();
         }
     }
 }

--- a/Bonsai.Core/Expressions/ExpressionBuilder.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilder.cs
@@ -474,7 +474,7 @@ namespace Bonsai.Expressions
                 var argument = arguments[k + offset];
                 if (argument.Type != arrayType)
                 {
-                    argument = CoerceMethodArgument(arrayType, argument);
+                    argument = ConvertExpression(argument, arrayType);
                 }
                 initializers[k] = argument;
             }
@@ -489,23 +489,23 @@ namespace Bonsai.Expressions
             return expandedArguments;
         }
 
-        internal static Expression CoerceMethodArgument(Type parameterType, Expression argument)
+        internal static Expression ConvertExpression(Expression expression, Type parameterType)
         {
-            if (argument.Type.IsGenericType && parameterType.IsGenericType &&
-                argument.Type.GetGenericTypeDefinition() == typeof(IObservable<>) &&
+            if (expression.Type.IsGenericType && parameterType.IsGenericType &&
+                expression.Type.GetGenericTypeDefinition() == typeof(IObservable<>) &&
                 parameterType.GetGenericTypeDefinition() == typeof(IObservable<>) &&
-                !parameterType.IsAssignableFrom(argument.Type))
+                !parameterType.IsAssignableFrom(expression.Type))
             {
-                var argumentObservableType = argument.Type.GetGenericArguments()[0];
+                var argumentObservableType = expression.Type.GetGenericArguments()[0];
                 var parameterObservableType = parameterType.GetGenericArguments()[0];
                 var conversionParameter = Expression.Parameter(argumentObservableType);
                 var conversion = Expression.Convert(conversionParameter, parameterObservableType);
                 var select = selectMethod.MakeGenericMethod(argumentObservableType, parameterObservableType);
-                return Expression.Call(select, argument, Expression.Lambda(conversion, conversionParameter));
+                return Expression.Call(select, expression, Expression.Lambda(conversion, conversionParameter));
             }
             else
             {
-                return Expression.Convert(argument, parameterType);
+                return Expression.Convert(expression, parameterType);
             }
         }
 
@@ -519,7 +519,7 @@ namespace Bonsai.Expressions
                 if (argument.Type != parameterType)
                 {
                     isCoerced |= !parameterType.IsAssignableFrom(argument.Type);
-                    argument = CoerceMethodArgument(parameterType, argument);
+                    argument = ConvertExpression(argument, parameterType);
                 }
                 return argument;
             });

--- a/Bonsai.Core/Expressions/ExpressionBuilder.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilder.cs
@@ -493,7 +493,8 @@ namespace Bonsai.Expressions
         {
             if (argument.Type.IsGenericType && parameterType.IsGenericType &&
                 argument.Type.GetGenericTypeDefinition() == typeof(IObservable<>) &&
-                parameterType.GetGenericTypeDefinition() == typeof(IObservable<>))
+                parameterType.GetGenericTypeDefinition() == typeof(IObservable<>) &&
+                !parameterType.IsAssignableFrom(argument.Type))
             {
                 var argumentObservableType = argument.Type.GetGenericArguments()[0];
                 var parameterObservableType = parameterType.GetGenericArguments()[0];

--- a/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
@@ -1041,7 +1041,7 @@ namespace Bonsai.Expressions
             var workflow = source.Build();
             if (!typeof(IObservable<TResult>).IsAssignableFrom(workflow.Type))
             {
-                throw new ArgumentException("The type of the compiled observable sequence is not assignable to the specified sequence type.", nameof(source));
+                workflow = ExpressionBuilder.CoerceMethodArgument(typeof(IObservable<TResult>), workflow);
             }
 
             var observableFactory = Expression.Lambda<Func<IObservable<TResult>>>(workflow).Compile();

--- a/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
@@ -1023,6 +1023,31 @@ namespace Bonsai.Expressions
             return observableFactory();
         }
 
+        /// <summary>
+        /// Builds and compiles an expression builder workflow into an observable sequence
+        /// with the specified element type.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the elements in the observable sequence.</typeparam>
+        /// <param name="source">The expression builder workflow to compile.</param>
+        /// <returns>
+        /// An observable sequence with the specified element type.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// The specified expression builder workflow does not compile into an observable sequence
+        /// with the expected element type.
+        /// </exception>
+        public static IObservable<TResult> BuildObservable<TResult>(this ExpressionBuilderGraph source)
+        {
+            var workflow = source.Build();
+            if (workflow.Type != typeof(IObservable<TResult>))
+            {
+                throw new ArgumentException("The compiled observable sequence does not match the specified element type.", nameof(source));
+            }
+
+            var observableFactory = Expression.Lambda<Func<IObservable<TResult>>>(workflow).Compile();
+            return observableFactory();
+        }
+
         static WorkflowExpressionBuilder Clone(this WorkflowExpressionBuilder builder, ExpressionBuilderGraph workflow)
         {
             var workflowExpression = (WorkflowExpressionBuilder)Activator.CreateInstance(builder.GetType(), workflow);

--- a/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
@@ -1039,9 +1039,9 @@ namespace Bonsai.Expressions
         public static IObservable<TResult> BuildObservable<TResult>(this ExpressionBuilderGraph source)
         {
             var workflow = source.Build();
-            if (workflow.Type != typeof(IObservable<TResult>))
+            if (!typeof(IObservable<TResult>).IsAssignableFrom(workflow.Type))
             {
-                throw new ArgumentException("The compiled observable sequence does not match the specified element type.", nameof(source));
+                throw new ArgumentException("The type of the compiled observable sequence is not assignable to the specified sequence type.", nameof(source));
             }
 
             var observableFactory = Expression.Lambda<Func<IObservable<TResult>>>(workflow).Compile();

--- a/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
@@ -1041,7 +1041,7 @@ namespace Bonsai.Expressions
             var workflow = source.Build();
             if (!typeof(IObservable<TResult>).IsAssignableFrom(workflow.Type))
             {
-                workflow = ExpressionBuilder.CoerceMethodArgument(typeof(IObservable<TResult>), workflow);
+                workflow = ExpressionBuilder.ConvertExpression(workflow, typeof(IObservable<TResult>));
             }
 
             var observableFactory = Expression.Lambda<Func<IObservable<TResult>>>(workflow).Compile();

--- a/Bonsai.Core/Expressions/ExternalizedDateTimeOffset.cs
+++ b/Bonsai.Core/Expressions/ExternalizedDateTimeOffset.cs
@@ -60,7 +60,7 @@ namespace Bonsai.Expressions
                 var propertySourceType = typeof(IObservable<DateTimeOffset>);
                 if (source.Type != propertySourceType)
                 {
-                    source = CoerceMethodArgument(propertySourceType, source);
+                    source = ConvertExpression(source, propertySourceType);
                 }
 
                 return source;

--- a/Bonsai.Core/Expressions/ExternalizedProperty.cs
+++ b/Bonsai.Core/Expressions/ExternalizedProperty.cs
@@ -176,7 +176,7 @@ namespace Bonsai.Expressions
                 var propertySourceType = typeof(IObservable<TValue>);
                 if (source.Type != propertySourceType)
                 {
-                    source = CoerceMethodArgument(propertySourceType, source);
+                    source = ConvertExpression(source, propertySourceType);
                 }
 
                 return source;

--- a/Bonsai.Core/Expressions/ExternalizedTimeSpan.cs
+++ b/Bonsai.Core/Expressions/ExternalizedTimeSpan.cs
@@ -60,7 +60,7 @@ namespace Bonsai.Expressions
                 var propertySourceType = typeof(IObservable<TimeSpan>);
                 if (source.Type != propertySourceType)
                 {
-                    source = CoerceMethodArgument(propertySourceType, source);
+                    source = ConvertExpression(source, propertySourceType);
                 }
 
                 return source;


### PR DESCRIPTION
To support more flexible programmatic manipulation of expression builder workflows, this PR introduces a new overload to compile an expression builder graph into an observable sequence where the type of the elements in the sequence is known.

This makes it possible to load a workflow and perform a type-safe subscription to access the results of the compiled observable sequence, as shown in the example below:

```c#
using var reader = XmlReader.Create(path);
var workflowBuilder = (WorkflowBuilder)WorkflowBuilder.Serializer.Deserialize(reader);
var observable = workflowBuilder.Workflow.BuildObservable<object>();
```

Both covariance and explicit type conversions are allowed in case of type mismatch between the type of the compiled expression and the expected result type.

Fixes #1915 