### PR TITLE
Exclude build dependencies when counting inputs to new nested node

### DIFF
--- a/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
+++ b/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
@@ -17,6 +17,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Bonsai.Core.Tests\Bonsai.Core.Tests.csproj" />
     <ProjectReference Include="..\Bonsai.Editor\Bonsai.Editor.csproj" />
   </ItemGroup>
 </Project>

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -1114,9 +1114,10 @@ namespace Bonsai.Editor.GraphModel
             CreateGraphNodeType nodeType)
         {
             // Estimate number of inputs to the nested node
-            var inputCount = workflowBuilder.ArgumentRange.LowerBound;
-            if (nodeType == CreateGraphNodeType.Successor) inputCount = Math.Max(inputCount, selectedNodes.Count());
-            else inputCount = Math.Max(inputCount, selectedNodes.Sum(node => workflow.PredecessorEdges(node).Count()));
+            var inputCount = nodeType == CreateGraphNodeType.Successor
+                ? selectedNodes.Count(node => !node.Value.IsBuildDependency())
+                : selectedNodes.Sum(node => workflow.PredecessorEdges(node).Count(edge => !edge.Item1.Value.IsBuildDependency()));
+            inputCount = Math.Max(workflowBuilder.ArgumentRange.LowerBound, inputCount);
 
             // Limit number of inputs depending on nested operator argument range
             if (!(workflowBuilder is GroupWorkflowBuilder || workflowBuilder.GetType() == typeof(Defer)))


### PR DESCRIPTION
Since build dependencies always affect their target node and are not considered proper inputs to operators, they should be excluded when estimating number of inputs to a newly created nested node.

Fixes #1792 