### PR TITLE
Fix `Period` description in `Timer` operator

### DIFF
--- a/Bonsai.Core/Reactive/Timer.cs
+++ b/Bonsai.Core/Reactive/Timer.cs
@@ -27,7 +27,7 @@ namespace Bonsai.Reactive
 
         /// <summary>
         /// Gets or sets the period to produce subsequent values. If this value is equal
-        /// to <see cref="TimeSpan.Zero"/> the timer will recur as fast as possible.
+        /// to <see cref="TimeSpan.Zero"/> the timer will only fire once.
         /// </summary>
         [XmlIgnore]
         [Description("The period to produce subsequent values. If this value is equal to zero the timer will recur as fast as possible.")]


### PR DESCRIPTION
This PR clarifies/corrects the description of the behavior of `Timer` when the `Period` property is set to 0. With this value, the `Timer` will emit a single event, potentially delayed by `DueTime` and terminate the sequence immediately.

Fixes #1947 documentation gap.