### PR TITLE
Make period a nullable property of reactive timer and clarify documentation

### DIFF
--- a/Bonsai.Core/Reactive/Timer.cs
+++ b/Bonsai.Core/Reactive/Timer.cs
@@ -26,12 +26,12 @@ namespace Bonsai.Reactive
         public TimeSpan DueTime { get; set; }
 
         /// <summary>
-        /// Gets or sets the period to produce subsequent values. If this value is equal
-        /// to <see cref="TimeSpan.Zero"/> the timer will recur as fast as possible.
+        /// Gets or sets the period to produce subsequent values. If this value is not specified
+        /// or equal to <see cref="TimeSpan.Zero"/> the timer will only fire once.
         /// </summary>
         [XmlIgnore]
-        [Description("The period to produce subsequent values. If this value is equal to zero the timer will recur as fast as possible.")]
-        public TimeSpan Period { get; set; }
+        [Description("The period to produce subsequent values. If this value is not specified or equal to zero the timer will only fire once.")]
+        public TimeSpan? Period { get; set; }
 
         /// <summary>
         /// Gets or sets an XML representation of the due time for serialization.
@@ -53,8 +53,8 @@ namespace Bonsai.Reactive
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string PeriodXml
         {
-            get { return XmlConvert.ToString(Period); }
-            set { Period = XmlConvert.ToTimeSpan(value); }
+            get { return Period > TimeSpan.Zero ? XmlConvert.ToString(Period.GetValueOrDefault()) : null; }
+            set { Period = string.IsNullOrEmpty(value) ? null : XmlConvert.ToTimeSpan(value); }
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Bonsai.Reactive
         {
             var period = Period;
             return period > TimeSpan.Zero
-                ? Observable.Timer(DueTime, period)
+                ? Observable.Timer(DueTime, period.GetValueOrDefault())
                 : Observable.Timer(DueTime);
         }
     }

--- a/Bonsai.Shaders/Timer.cs
+++ b/Bonsai.Shaders/Timer.cs
@@ -29,10 +29,10 @@ namespace Bonsai.Shaders
 
         /// <summary>
         /// Gets or sets the period to produce subsequent values. If this value
-        /// is undefined or equal to zero the timer will only fire once.
+        /// is not specified or equal to zero the timer will only fire once.
         /// </summary>
         [XmlIgnore]
-        [Description("The period to produce subsequent values. If this value is equal to zero the timer will recur as fast as possible.")]
+        [Description("The period to produce subsequent values. If this value is not specified or equal to zero the timer will only fire once.")]
         public TimeSpan? Period { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Ignoring the value of `TimeSpan.Zero` for the `Period` property is an unfortunate historical legacy. The property should really expose a nullable type when deciding between which `Observable.Timer` overload to call.

This PR changes the type signature of `Period` to be a nullable timespan, but retains the same behavior by requiring `Period` to be larger than zero for periodic timers. We also introduce a slight modification to its serialization behavior to ensure that a value of zero is always serialized as `null`.

This will start the migration away from using `TimeSpan.Zero` as a valid value, and might give us some room to consider reinstating the zero period as a high frequency periodic timer for 3.0.

We could also introduce an automatic conversion at the level of the editor, but this might break embedded include workflows which happen to be using the old timer semantics, since these are not converted automatically by the editor until they are ungrouped and resaved.

The embedded description string was also fixed for the shaders timer.

Fixes #1947 