### PR TITLE
Fix test target framework issues

### DIFF
--- a/.github/workflows/Bonsai.yml
+++ b/.github/workflows/Bonsai.yml
@@ -101,7 +101,7 @@ jobs:
           release_version: ${{github.event.release.tag_name}}
           workflow_dispatch_version: ${{github.event.inputs.version}}
           workflow_dispatch_will_publish_packages: ${{github.event.inputs.will_publish_packages}}
-   
+
       # ----------------------------------------------------------------------- Build
       - name: Restore
         run: dotnet restore Bonsai.sln
@@ -122,9 +122,15 @@ jobs:
         run: dotnet pack Bonsai.sln --no-restore --no-build --configuration ${{matrix.configuration}}
 
       # ----------------------------------------------------------------------- Test
-      - name: Test
+      - name: Test .NET Framework 4.7.2
         if: '!matrix.dummy-build'
-        run: dotnet test Bonsai.sln --no-restore --no-build --configuration ${{matrix.configuration}} --verbosity normal
+        run: dotnet test Bonsai.sln --no-restore --no-build --configuration ${{matrix.configuration}} --verbosity normal --framework net472
+      - name: Test .NET 8
+        if: '!matrix.dummy-build'
+        run: dotnet test Bonsai.sln --no-restore --no-build --configuration ${{matrix.configuration}} --verbosity normal --framework net8.0
+      - name: Test .NET 8 Windows
+        if: ${{!matrix.dummy-build && matrix.platform.rid == 'win-x64'}}
+        run: dotnet test Bonsai.sln --no-restore --no-build --configuration ${{matrix.configuration}} --verbosity normal --framework net8.0-windows
 
       # ----------------------------------------------------------------------- Create portable zip
       - name: Create portable zip
@@ -153,7 +159,7 @@ jobs:
         id: create-installer
         if: matrix.create-installer
         run: msbuild /nologo /maxCpuCount Bonsai.Setup.sln /p:Configuration=${{matrix.configuration}}
-      
+
       # ----------------------------------------------------------------------- Collect artifacts
       - name: Collect NuGet packages
         uses: actions/upload-artifact@v4
@@ -412,7 +418,7 @@ jobs:
         env:
           version_file_path: tooling/CurrentVersion.props
           just_released_version: ${{github.event.release.tag_name}}
-      
+
       # ----------------------------------------------------------------------- Commit and push changes
       - name: Commit changes
         if: steps.main-revision.outputs.sha == github.sha

--- a/Bonsai.Core.Tests/Bonsai.Core.Tests.csproj
+++ b/Bonsai.Core.Tests/Bonsai.Core.Tests.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFrameworks>net472;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
+++ b/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
+++ b/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.bonsai" />

--- a/Bonsai.System.Tests/Bonsai.System.Tests.csproj
+++ b/Bonsai.System.Tests/Bonsai.System.Tests.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFrameworks>net472;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/tooling/Common.Tests.csproj.props
+++ b/tooling/Common.Tests.csproj.props
@@ -1,0 +1,24 @@
+<Project>
+  <PropertyGroup>
+    <!-- Common test properties -->
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+  <Target Name="VerifyTestTargetFramework" BeforeTargets="Build" Condition="'$(TargetFramework)' != ''">
+    <ItemGroup>
+      <!--
+        Due to limitations in `dotnet test`, tests must only target specific target frameworks which are explicitly ran by CI.
+        Do not add any target frameworks to this list without also updating the CI workflow.
+      -->
+      <_PermittedTestFramework Remove="*" />
+      <_PermittedTestFramework Include="net472" />
+      <_PermittedTestFramework Include="net8.0" />
+      <_PermittedTestFramework Include="net8.0-windows" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_IsPermittedTestFramework>false</_IsPermittedTestFramework>
+      <_IsPermittedTestFramework Condition="'%(_PermittedTestFramework.Identity)' == '$(TargetFramework)'">true</_IsPermittedTestFramework>
+    </PropertyGroup>
+    <Error Condition="'$(_IsPermittedTestFramework)' != 'true'" Text="Test project targets '$(TargetFramework)', which is not permitted for test projects." />
+  </Target>
+</Project>

--- a/tooling/Common.csproj.props
+++ b/tooling/Common.csproj.props
@@ -24,6 +24,9 @@
     <!-- Ignore warnings about PackageLicenseUrl and PackageIconUrl, we still use them for MyGet support -->
     <NoWarn>$(NoWarn);NU5125;NU5048</NoWarn>
 
+    <!-- Error when restore graph contains mismatched target frameworks -->
+    <WarningsAsErrors>$(WarningsAsErrors);NU1701</WarningsAsErrors>
+
     <!-- Embed untracked sources in the PDB when building from CI -->
     <EmbedUntrackedSources>false</EmbedUntrackedSources>
     <EmbedUntrackedSources Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</EmbedUntrackedSources>

--- a/tooling/Common.csproj.props
+++ b/tooling/Common.csproj.props
@@ -42,4 +42,5 @@
     <DebugType Condition="'$(IsReferenceDummyBuild)' == 'true'">none</DebugType>
   </PropertyGroup>
   <Import Project="Versioning.props" />
+  <Import Project="Common.Tests.csproj.props" Condition="$(MSBuildProjectName.EndsWith('.Tests'))" />
 </Project>


### PR DESCRIPTION
This fixes a mistake made in https://github.com/bonsai-rx/bonsai/pull/1952

* `Bonsai.Editor.Tests` now targets `net8.0-windows` as appropriate
* Made the relevant NuGet warning into an error to avoid this mistake in the future
* Disabled running `net8.0-windows` tests on Linux

The last one was somewhat annoying as `dotnet test` doesn't have a great way to just run tests for all target frameworks except one or something similar. In the end I opted to run `net472`, `net8.0`, and `net8.0-windows` all as discrete steps (which will actually be kinda nice anyway.)

As a result, test projects are only allowed to target one of those three target frameworks. This is enforced by the build system in order to avoid the easy mistake of having an entire test suite skipped without knowing.

-------------

I also looked into why GitHub Actions didn't highlight these warnings in the workflow summary. Turns out it actually [did highlight them](https://github.com/bonsai-rx/bonsai/actions/runs/10257331564), so we're just bad and both missed it. The warnings just didn't show up on the PR because they aren't associated with any particular file within the PR.

It might be nice if warnings like that ended up on the PR anyway. Not sure if there's an easy way to do that unfortunately. Easiest solution is probably that we just get in the habit of reviewing the workflow run as part of code reviews.

As an aside though, I did find out more about how this GitHub Actions feature works. They're called problem matchers and [are documented here](https://github.com/actions/toolkit/blob/f003268b3250d192cf66f306694b34a278011d9b/docs/problem-matchers.md). They can be customized, and it turns out `setup-dotnet` and such tend to add [their own relevant patterns](https://github.com/actions/setup-dotnet/blob/dbebe359e495844f078430a9de2b64d21656c21a/.github/csc.json).

Relates to https://github.com/bonsai-rx/bonsai/issues/1948