### PR TITLE
Add support for sorting test workflows

### DIFF
--- a/Bonsai.Core.Tests/TestWorkflow.cs
+++ b/Bonsai.Core.Tests/TestWorkflow.cs
@@ -122,6 +122,13 @@ namespace Bonsai.Core.Tests
             return Append(subjectBuilder);
         }
 
+        public TestWorkflow TopologicalSort()
+        {
+            var workflow = new ExpressionBuilderGraph();
+            workflow.InsertRange(0, Workflow.TopologicalSort());
+            return new TestWorkflow(workflow, Cursor);
+        }
+
         public ExpressionBuilderGraph ToInspectableGraph()
         {
             return Workflow.ToInspectableGraph();

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -246,6 +246,7 @@ namespace Bonsai.Editor.Tests
             var groupBuilder = ExpressionBuilder.Unwrap(groupNode?.Value) as GroupWorkflowBuilder;
             Assert.IsInstanceOfType(groupBuilder, typeof(GroupWorkflowBuilder));
             Assert.AreEqual(expected: 2, groupBuilder.Workflow.Count);
+            Assert.IsInstanceOfType(ExpressionBuilder.Unwrap(groupBuilder.Workflow[0].Value), typeof(WorkflowInputBuilder));
             Assert.IsInstanceOfType(ExpressionBuilder.Unwrap(groupBuilder.Workflow[1].Value), typeof(WorkflowOutputBuilder));
             assertIsReversible();
         }

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -48,12 +48,6 @@ namespace Bonsai.Editor.Tests
             ExpressionBuilderGraph workflow = null,
             MockGraphView graphView = null)
         {
-            if (workflow != null)
-            {
-                // Workflows must be topologically sorted to ensure all editor operations are reversible
-                workflow.InsertRange(0, workflow.TopologicalSort());
-            }
-
             graphView ??= new MockGraphView(workflow);
             var editor = new WorkflowEditor(graphView.ServiceProvider, graphView);
             editor.UpdateLayout.Subscribe(graphView.UpdateGraphLayout);
@@ -236,7 +230,7 @@ namespace Bonsai.Editor.Tests
                 .AppendBranch(source => source
                     .AppendSubject<Reactive.PublishSubject>("P")
                     .AddArguments(source.Append(new VisualizerMappingBuilder())))
-                .Workflow
+                .TopologicalSort()
                 .ToInspectableGraph();
 
             var (editor, assertIsReversible) = CreateMockEditor(workflow);


### PR DESCRIPTION
The workflow editor API requires the initial state to have all nodes topologically sorted to ensure reversibility of operations.

Here we move the sorting operation to the test infrastructure to facilitate reuse and avoid enforcing the sort in `MockGraphView` specifically to allow regression testing cases where the initial state may or may not be sorted (this is a limitation of the algorithm which we may want to remove in the future).

We also assert a missing invariant in a previous test.