### PR TITLE
Add support for watching individual operator state

### DIFF
--- a/Bonsai.Core/Expressions/InspectBuilder.cs
+++ b/Bonsai.Core/Expressions/InspectBuilder.cs
@@ -11,7 +11,7 @@ using System.Reactive.Disposables;
 namespace Bonsai.Expressions
 {
     /// <summary>
-    /// Represents an expression builder that replays the latest notification from all the
+    /// Represents an expression builder that monitors the notifications from all the
     /// subscriptions made to its decorated builder.
     /// </summary>
     public sealed class InspectBuilder : ExpressionBuilder, INamedElement
@@ -23,7 +23,7 @@ namespace Bonsai.Expressions
         /// specified expression builder.
         /// </summary>
         /// <param name="builder">
-        /// The expression builder whose notifications will be replayed by this inspector.
+        /// The expression builder whose notifications will be monitored by this inspector.
         /// </param>
         public InspectBuilder(ExpressionBuilder builder)
             : base(builder, decorator: false)
@@ -107,6 +107,12 @@ namespace Bonsai.Expressions
         public IObservable<Exception> ErrorEx { get; private set; }
 
         /// <summary>
+        /// Gets an observable sequence that multicasts watch notifications from all
+        /// the subscriptions made to the output of the decorated expression builder.
+        /// </summary>
+        public IObservable<IObservable<WatchNotification>> Watch { get; private set; }
+
+        /// <summary>
         /// Gets the range of input arguments that the decorated expression builder accepts.
         /// </summary>
         public override Range<int> ArgumentRange
@@ -147,6 +153,7 @@ namespace Bonsai.Expressions
             if (VisualizerElement != null)
             {
                 Output = VisualizerElement.Output;
+                Watch = VisualizerElement.Watch;
                 ErrorEx = Observable.Empty<Exception>();
                 VisualizerElement = BuildVisualizerElement(VisualizerElement, VisualizerMappings);
                 return source;
@@ -167,6 +174,7 @@ namespace Bonsai.Expressions
             else
             {
                 Output = Observable.Empty<IObservable<object>>();
+                Watch = Observable.Empty<IObservable<WatchNotification>>();
                 ErrorEx = Observable.Empty<Exception>();
                 if (VisualizerElement != null)
                 {
@@ -246,17 +254,15 @@ namespace Bonsai.Expressions
             return null;
         }
 
-        ReplaySubject<IObservable<TSource>> CreateInspectorSubject<TSource>()
+        ReplaySubject<Inspector<TSource>> CreateInspectorSubject<TSource>()
         {
-            var subject = new ReplaySubject<IObservable<TSource>>(1);
-            Output = subject.Select(ys => ys.Select(xs => (object)xs));
+            var subject = new ReplaySubject<Inspector<TSource>>(1);
+            Output = subject.Select(ys => ys.Output);
 #pragma warning disable CS0612 // Type or member is obsolete
-            Error = subject.Merge().IgnoreElements().Select(xs => Unit.Default);
+            Error = subject.SelectMany(ys => ys.Error);
 #pragma warning restore CS0612 // Type or member is obsolete
-            ErrorEx = subject.SelectMany(xs => xs
-                .IgnoreElements()
-                .Select(x => default(Exception))
-                .Catch<Exception, Exception>(ex => Observable.Return(ex)));
+            ErrorEx = subject.SelectMany(xs => xs.ErrorEx);
+            Watch = subject.Select(xs => xs.Watch);
             return subject;
         }
 
@@ -265,13 +271,13 @@ namespace Bonsai.Expressions
             return source;
         }
 
-        IObservable<TSource> Process<TSource>(IObservable<TSource> source, ReplaySubject<IObservable<TSource>> subject)
+        IObservable<TSource> Process<TSource>(IObservable<TSource> source, ReplaySubject<Inspector<TSource>> subject)
         {
             return Observable.Create<TSource>(observer =>
             {
-                var sourceInspector = new Subject<TSource>();
+                var sourceInspector = new Inspector<TSource>();
                 subject.OnNext(sourceInspector);
-                var subscription = source.Do(sourceInspector).SubscribeSafe(observer);
+                var subscription = source.Do(sourceInspector.Subject).SubscribeSafe(observer);
                 return Disposable.Create(() =>
                 {
                     try { subscription.Dispose(); }
@@ -280,9 +286,52 @@ namespace Bonsai.Expressions
                     {
                         throw new WorkflowRuntimeException(ex.Message, this, ex);
                     }
-                    finally { sourceInspector.OnCompleted(); }
+                    finally
+                    {
+                        if (!sourceInspector.Subject.HasTerminated)
+                        {
+                            sourceInspector.IsCanceled = true;
+                            sourceInspector.Subject.OnCompleted();
+                        }
+                    }
                 });
             });
+        }
+
+        class Inspector<T>
+        {
+            public InspectSubject<T> Subject { get; } = new();
+
+            public bool IsCanceled { get; internal set; }
+
+            public IObservable<object> Output => Subject.Select(value => (object)value);
+
+            public IObservable<Unit> Error => Subject.IgnoreElements().Select(xs => Unit.Default);
+
+            public IObservable<Exception> ErrorEx => Subject
+                .IgnoreElements()
+                .Select(x => default(Exception))
+                .Catch<Exception, Exception>(ex => Observable.Return(ex));
+
+            public IObservable<WatchNotification> Watch =>
+                Observable.Create<WatchNotification>(observer =>
+                {
+                    observer.OnNext(WatchNotification.Subscribe);
+                    var notificationObserver = Observer.Create<T>(
+                        value => observer.OnNext(WatchNotification.OnNext),
+                        error =>
+                        {
+                            observer.OnNext(WatchNotification.OnError);
+                            observer.OnNext(WatchNotification.Unsubscribe);
+                        },
+                        () =>
+                        {
+                            if (!IsCanceled)
+                                observer.OnNext(WatchNotification.OnCompleted);
+                            observer.OnNext(WatchNotification.Unsubscribe);
+                        });
+                    return Subject.SubscribeSafe(notificationObserver);
+                });
         }
 
         class VisualizerMappingList

--- a/Bonsai.Core/Expressions/InspectSubject.cs
+++ b/Bonsai.Core/Expressions/InspectSubject.cs
@@ -1,0 +1,296 @@
+﻿// Adapted from https://github.com/dotnet/reactive
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information. 
+
+using System;
+using System.Reactive.Disposables;
+using System.Reactive.Subjects;
+using System.Threading;
+
+namespace Bonsai.Expressions
+{
+    internal sealed class InspectSubject<T> : ISubject<T>
+    {
+        private SubjectDisposable[] _observers;
+        private Exception _exception;
+#pragma warning disable CA1825,IDE0300 // (Avoid zero-length array allocations. Use collection expressions) The identity of these arrays matters, so we can't use the shared Array.Empty<T>() instance either explicitly, or indirectly via a collection expression
+        private static readonly SubjectDisposable[] Terminated = new SubjectDisposable[0];
+        private static readonly SubjectDisposable[] Disposed = new SubjectDisposable[0];
+#pragma warning restore CA1825,IDE0300
+
+        #region Constructors
+
+        public InspectSubject()
+        {
+            _observers = Array.Empty<SubjectDisposable>();
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Indicates whether the subject has observers subscribed to it.
+        /// </summary>
+        public bool HasObservers => Volatile.Read(ref _observers).Length != 0;
+
+        /// <summary>
+        /// Indicates whether the subject has been disposed.
+        /// </summary>
+        public bool IsDisposed => Volatile.Read(ref _observers) == Disposed;
+
+        /// <summary>
+        /// Indicates whether the sequence has terminated.
+        /// </summary>
+        public bool HasTerminated => Volatile.Read(ref _observers) == Terminated;
+
+        #endregion
+
+        #region Methods
+
+        #region IObserver<T> implementation
+
+        private static void ThrowDisposed() => throw new ObjectDisposedException(string.Empty);
+
+        /// <summary>
+        /// Notifies all subscribed observers about the end of the sequence.
+        /// </summary>
+        public void OnCompleted()
+        {
+            for (; ; )
+            {
+                var observers = Volatile.Read(ref _observers);
+
+                if (observers == Disposed)
+                {
+                    _exception = null;
+                    ThrowDisposed();
+                    break;
+                }
+
+                if (observers == Terminated)
+                {
+                    break;
+                }
+
+                if (Interlocked.CompareExchange(ref _observers, Terminated, observers) == observers)
+                {
+                    foreach (var observer in observers)
+                    {
+                        observer.Observer?.OnCompleted();
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Notifies all subscribed observers about the specified exception.
+        /// </summary>
+        /// <param name="error">The exception to send to all currently subscribed observers.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="error"/> is null.</exception>
+        public void OnError(Exception error)
+        {
+            if (error == null)
+            {
+                throw new ArgumentNullException(nameof(error));
+            }
+
+            for (; ; )
+            {
+                var observers = Volatile.Read(ref _observers);
+
+                if (observers == Disposed)
+                {
+                    _exception = null;
+                    ThrowDisposed();
+                    break;
+                }
+
+                if (observers == Terminated)
+                {
+                    break;
+                }
+
+                _exception = error;
+
+                if (Interlocked.CompareExchange(ref _observers, Terminated, observers) == observers)
+                {
+                    foreach (var observer in observers)
+                    {
+                        observer.Observer?.OnError(error);
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Notifies all subscribed observers about the arrival of the specified element in the sequence.
+        /// </summary>
+        /// <param name="value">The value to send to all currently subscribed observers.</param>
+        public void OnNext(T value)
+        {
+            var observers = Volatile.Read(ref _observers);
+
+            if (observers == Disposed)
+            {
+                _exception = null;
+                ThrowDisposed();
+                return;
+            }
+
+            foreach (var observer in observers)
+            {
+                observer.Observer?.OnNext(value);
+            }
+        }
+
+        #endregion
+
+        #region IObservable<T> implementation
+
+        /// <summary>
+        /// Subscribes an observer to the subject.
+        /// </summary>
+        /// <param name="observer">Observer to subscribe to the subject.</param>
+        /// <returns>Disposable object that can be used to unsubscribe the observer from the subject.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="observer"/> is null.</exception>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            if (observer == null)
+            {
+                throw new ArgumentNullException(nameof(observer));
+            }
+
+            var disposable = default(SubjectDisposable);
+            for (; ; )
+            {
+                var observers = Volatile.Read(ref _observers);
+
+                if (observers == Disposed)
+                {
+                    _exception = null;
+                    ThrowDisposed();
+
+                    break;
+                }
+
+                if (observers == Terminated)
+                {
+                    var ex = _exception;
+
+                    if (ex != null)
+                    {
+                        observer.OnError(ex);
+                    }
+                    else
+                    {
+                        observer.OnCompleted();
+                    }
+
+                    break;
+                }
+
+                disposable ??= new SubjectDisposable(this, observer);
+
+                var n = observers.Length;
+                var b = new SubjectDisposable[n + 1];
+
+                Array.Copy(observers, 0, b, 0, n);
+
+                b[n] = disposable;
+
+                if (Interlocked.CompareExchange(ref _observers, b, observers) == observers)
+                {
+                    return disposable;
+                }
+            }
+
+            return Disposable.Empty;
+        }
+
+        private void Unsubscribe(SubjectDisposable observer)
+        {
+            for (; ; )
+            {
+                var a = Volatile.Read(ref _observers);
+                var n = a.Length;
+
+                if (n == 0)
+                {
+                    break;
+                }
+
+                var j = Array.IndexOf(a, observer);
+
+                if (j < 0)
+                {
+                    break;
+                }
+
+                SubjectDisposable[] b;
+
+                if (n == 1)
+                {
+                    b = Array.Empty<SubjectDisposable>();
+                }
+                else
+                {
+                    b = new SubjectDisposable[n - 1];
+
+                    Array.Copy(a, 0, b, 0, j);
+                    Array.Copy(a, j + 1, b, j, n - j - 1);
+                }
+
+                if (Interlocked.CompareExchange(ref _observers, b, a) == a)
+                {
+                    break;
+                }
+            }
+        }
+
+        private sealed class SubjectDisposable : IDisposable
+        {
+            private InspectSubject<T> _subject;
+            private volatile IObserver<T> _observer;
+
+            public SubjectDisposable(InspectSubject<T> subject, IObserver<T> observer)
+            {
+                _subject = subject;
+                _observer = observer;
+            }
+
+            public IObserver<T> Observer => _observer;
+
+            public void Dispose()
+            {
+                var observer = Interlocked.Exchange(ref _observer, null);
+                if (observer == null)
+                {
+                    return;
+                }
+
+                _subject.Unsubscribe(this);
+                _subject = null!;
+            }
+        }
+
+        #endregion
+
+        #region IDisposable implementation
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _observers, Disposed);
+            _exception = null;
+        }
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/Bonsai.Core/Expressions/WatchNotification.cs
+++ b/Bonsai.Core/Expressions/WatchNotification.cs
@@ -1,0 +1,33 @@
+﻿namespace Bonsai.Expressions
+{
+    /// <summary>
+    /// Indicates the type of an inspector watch notification.
+    /// </summary>
+    public enum WatchNotification
+    {
+        /// <summary>
+        /// Indicates the sequence was subscribed to.
+        /// </summary>
+        Subscribe,
+
+        /// <summary>
+        /// Indicates the sequence has emitted a value.
+        /// </summary>
+        OnNext,
+
+        /// <summary>
+        /// Indicates the sequence has terminated with an error.
+        /// </summary>
+        OnError,
+
+        /// <summary>
+        /// Indicates the sequence has terminated successfully.
+        /// </summary>
+        OnCompleted,
+
+        /// <summary>
+        /// Indicates the subscription to the sequence has been disposed.
+        /// </summary>
+        Unsubscribe
+    }
+}

--- a/Bonsai.Editor/Diagnostics/NotificationCounter.cs
+++ b/Bonsai.Editor/Diagnostics/NotificationCounter.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading;
+
+namespace Bonsai.Editor.Diagnostics
+{
+    internal struct NotificationCounter
+    {
+        private long count;
+        private long lastCount;
+
+        public void Increment()
+        {
+            Interlocked.Increment(ref count);
+        }
+
+        public long Read()
+        {
+            return Interlocked.Read(ref count);
+        }
+
+        public long ReadDelta(out long count)
+        {
+            count = Read();
+            var delta = count - lastCount;
+            lastCount = count;
+            return delta;
+        }
+    }
+}

--- a/Bonsai.Editor/Diagnostics/WorkflowElementCounter.cs
+++ b/Bonsai.Editor/Diagnostics/WorkflowElementCounter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Reactive.Linq;
-using System.Threading;
 using Bonsai.Expressions;
 
 namespace Bonsai.Editor.Diagnostics
@@ -9,70 +8,69 @@ namespace Bonsai.Editor.Diagnostics
     internal class WorkflowElementCounter : IDisposable
     {
         readonly IDisposable subscription;
-        private long subscribeCount;
-        private long onNextCount;
-        private long onCompletedCount;
-        private long onErrorCount;
-        private long disposeCount;
-        private long lastNotificationCount;
+        private NotificationCounter subscribeCounter;
+        private NotificationCounter onNextCounter;
+        private NotificationCounter onCompletedCounter;
+        private NotificationCounter onErrorCounter;
+        private NotificationCounter unsubscribeCounter;
+        private WorkflowElementStatus lastInactiveStatus;
 
         public WorkflowElementCounter(InspectBuilder inspectBuilder)
         {
             InspectBuilder = inspectBuilder ?? throw new ArgumentNullException(nameof(inspectBuilder));
-            subscription = InspectBuilder.Output.SelectMany(source =>
+            subscription = InspectBuilder.Watch.SelectMany(source => source.Do(notification =>
             {
-                Interlocked.Increment(ref subscribeCount);
-                return source
-                    .Do(value => Interlocked.Increment(ref onNextCount),
-                        error => Interlocked.Increment(ref onErrorCount),
-                        () => Interlocked.Increment(ref onCompletedCount))
-                    .IgnoreElements()
-                    .Finally(() => Interlocked.Increment(ref disposeCount));
-            }).Subscribe();
+                switch (notification)
+                {
+                    case WatchNotification.Subscribe: subscribeCounter.Increment(); break;
+                    case WatchNotification.OnNext: onNextCounter.Increment(); break;
+                    case WatchNotification.OnError: onErrorCounter.Increment(); break;
+                    case WatchNotification.OnCompleted: onCompletedCounter.Increment(); break;
+                    case WatchNotification.Unsubscribe: unsubscribeCounter.Increment(); break;
+                }
+            }).IgnoreElements()).Subscribe();
         }
 
         public InspectBuilder InspectBuilder { get; }
 
-        public long SubscribeCount => subscribeCount;
+        public long SubscribeCount => subscribeCounter.Read();
 
-        public long OnNextCount => onNextCount;
+        public long OnNextCount => onNextCounter.Read();
 
-        public long OnErrorCount => onErrorCount;
+        public long OnErrorCount => onErrorCounter.Read();
 
-        public long OnCompletedCount => onCompletedCount;
+        public long OnCompletedCount => onCompletedCounter.Read();
 
-        public long DisposeCount => disposeCount;
+        public long UnsubscribeCount => unsubscribeCounter.Read();
 
         public long TotalCount =>
-            Interlocked.Read(ref subscribeCount) +
-            Interlocked.Read(ref onNextCount) +
-            Interlocked.Read(ref onErrorCount) +
-            Interlocked.Read(ref onCompletedCount) +
-            Interlocked.Read(ref disposeCount);
+            SubscribeCount +
+            OnNextCount +
+            OnErrorCount +
+            OnCompletedCount +
+            UnsubscribeCount;
 
         public WorkflowElementStatus GetStatus()
         {
-            var notificationCount = Interlocked.Read(ref onNextCount);
-            var activeSubscriptions = Interlocked.Read(ref subscribeCount) - Interlocked.Read(ref disposeCount);
+            var notificationDelta = onNextCounter.ReadDelta(out long notificationCount);
+            var unsubscribeDelta = unsubscribeCounter.ReadDelta(out long unsubscribeCount);
+            var activeSubscriptions = SubscribeCount - unsubscribeCount;
             if (activeSubscriptions > 0)
             {
-                if (notificationCount > lastNotificationCount)
-                {
-                    lastNotificationCount = notificationCount;
-                    return WorkflowElementStatus.Notifying;
-                }
-
-                return WorkflowElementStatus.Active;
+                return notificationDelta > 0
+                    ? WorkflowElementStatus.Notifying
+                    : WorkflowElementStatus.Active;
             }
-            else
+            else if (unsubscribeDelta > 0)
             {
-                lastNotificationCount = notificationCount;
-                var errorCount = Interlocked.Read(ref onErrorCount);
-                var completedCount = Interlocked.Read(ref onCompletedCount);
-                if (errorCount > 0) return WorkflowElementStatus.Error;
-                else if (completedCount > 0) return WorkflowElementStatus.Completed;
-                return WorkflowElementStatus.Ready;
+                var errorDelta = onErrorCounter.ReadDelta(out long _);
+                var completedDelta = onCompletedCounter.ReadDelta(out long _);
+                if (errorDelta > 0) lastInactiveStatus = WorkflowElementStatus.Error;
+                else if (completedDelta > 0) lastInactiveStatus = WorkflowElementStatus.Completed;
+                else lastInactiveStatus = WorkflowElementStatus.Canceled;
             }
+
+            return lastInactiveStatus;
         }
 
         public void Dispose()

--- a/Bonsai.Editor/Diagnostics/WorkflowElementCounter.cs
+++ b/Bonsai.Editor/Diagnostics/WorkflowElementCounter.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading;
+using Bonsai.Expressions;
+
+namespace Bonsai.Editor.Diagnostics
+{
+    internal class WorkflowElementCounter : IDisposable
+    {
+        readonly IDisposable subscription;
+        private long subscribeCount;
+        private long onNextCount;
+        private long onCompletedCount;
+        private long onErrorCount;
+        private long disposeCount;
+        private long lastNotificationCount;
+
+        public WorkflowElementCounter(InspectBuilder inspectBuilder)
+        {
+            InspectBuilder = inspectBuilder ?? throw new ArgumentNullException(nameof(inspectBuilder));
+            subscription = InspectBuilder.Output.SelectMany(source =>
+            {
+                Interlocked.Increment(ref subscribeCount);
+                return source
+                    .Do(value => Interlocked.Increment(ref onNextCount),
+                        error => Interlocked.Increment(ref onErrorCount),
+                        () => Interlocked.Increment(ref onCompletedCount))
+                    .IgnoreElements()
+                    .Finally(() => Interlocked.Increment(ref disposeCount));
+            }).Subscribe();
+        }
+
+        public InspectBuilder InspectBuilder { get; }
+
+        public long SubscribeCount => subscribeCount;
+
+        public long OnNextCount => onNextCount;
+
+        public long OnErrorCount => onErrorCount;
+
+        public long OnCompletedCount => onCompletedCount;
+
+        public long DisposeCount => disposeCount;
+
+        public long TotalCount =>
+            Interlocked.Read(ref subscribeCount) +
+            Interlocked.Read(ref onNextCount) +
+            Interlocked.Read(ref onErrorCount) +
+            Interlocked.Read(ref onCompletedCount) +
+            Interlocked.Read(ref disposeCount);
+
+        public WorkflowElementStatus GetStatus()
+        {
+            var notificationCount = Interlocked.Read(ref onNextCount);
+            var activeSubscriptions = Interlocked.Read(ref subscribeCount) - Interlocked.Read(ref disposeCount);
+            if (activeSubscriptions > 0)
+            {
+                if (notificationCount > lastNotificationCount)
+                {
+                    lastNotificationCount = notificationCount;
+                    return WorkflowElementStatus.Notifying;
+                }
+
+                return WorkflowElementStatus.Active;
+            }
+            else
+            {
+                lastNotificationCount = notificationCount;
+                var errorCount = Interlocked.Read(ref onErrorCount);
+                var completedCount = Interlocked.Read(ref onCompletedCount);
+                if (errorCount > 0) return WorkflowElementStatus.Error;
+                else if (completedCount > 0) return WorkflowElementStatus.Completed;
+                return WorkflowElementStatus.Ready;
+            }
+        }
+
+        public void Dispose()
+        {
+            subscription.Dispose();
+        }
+    }
+}

--- a/Bonsai.Editor/Diagnostics/WorkflowElementStatus.cs
+++ b/Bonsai.Editor/Diagnostics/WorkflowElementStatus.cs
@@ -7,5 +7,6 @@
         Notifying,
         Completed,
         Error,
+        Canceled
     }
 }

--- a/Bonsai.Editor/Diagnostics/WorkflowElementStatus.cs
+++ b/Bonsai.Editor/Diagnostics/WorkflowElementStatus.cs
@@ -1,0 +1,11 @@
+﻿namespace Bonsai.Editor.Diagnostics
+{
+    internal enum WorkflowElementStatus
+    {
+        Ready,
+        Active,
+        Notifying,
+        Completed,
+        Error,
+    }
+}

--- a/Bonsai.Editor/Diagnostics/WorkflowMeter.cs
+++ b/Bonsai.Editor/Diagnostics/WorkflowMeter.cs
@@ -36,13 +36,16 @@ namespace Bonsai.Editor.Diagnostics
                     }
 
                     var inspectBuilder = (InspectBuilder)nodeEnumerator.Current.Value;
-                    yield return inspectBuilder;
-
-                    if (inspectBuilder.Builder is IWorkflowExpressionBuilder workflowBuilder &&
-                        workflowBuilder.Workflow != null)
+                    if (inspectBuilder.Output != null)
                     {
-                        stack.Push(workflowBuilder.Workflow.GetEnumerator());
-                        break;
+                        yield return inspectBuilder;
+
+                        if (inspectBuilder.Builder is IWorkflowExpressionBuilder workflowBuilder &&
+                            workflowBuilder.Workflow != null)
+                        {
+                            stack.Push(workflowBuilder.Workflow.GetEnumerator());
+                            break;
+                        }
                     }
                 }
             }

--- a/Bonsai.Editor/Diagnostics/WorkflowMeter.cs
+++ b/Bonsai.Editor/Diagnostics/WorkflowMeter.cs
@@ -41,13 +41,13 @@ namespace Bonsai.Editor.Diagnostics
                         watchMap.Contains(inspectBuilder))
                     {
                         yield return inspectBuilder;
+                    }
 
-                        if (inspectBuilder.Builder is IWorkflowExpressionBuilder workflowBuilder &&
-                            workflowBuilder.Workflow is not null)
-                        {
-                            stack.Push(workflowBuilder.Workflow.GetEnumerator());
-                            break;
-                        }
+                    if (inspectBuilder.Builder is IWorkflowExpressionBuilder workflowBuilder &&
+                        workflowBuilder.Workflow is not null)
+                    {
+                        stack.Push(workflowBuilder.Workflow.GetEnumerator());
+                        break;
                     }
                 }
             }

--- a/Bonsai.Editor/Diagnostics/WorkflowMeter.cs
+++ b/Bonsai.Editor/Diagnostics/WorkflowMeter.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bonsai.Dag;
+using Bonsai.Expressions;
+
+namespace Bonsai.Editor.Diagnostics
+{
+    internal class WorkflowMeter : IDisposable
+    {
+        readonly Dictionary<ExpressionBuilder, WorkflowElementCounter> counters;
+
+        public WorkflowMeter(ExpressionBuilderGraph workflow)
+        {
+            counters = GetElements(workflow).ToDictionary(
+                inspectBuilder => (ExpressionBuilder)inspectBuilder,
+                inspectBuilder => new WorkflowElementCounter(inspectBuilder));
+        }
+
+        public IReadOnlyDictionary<ExpressionBuilder, WorkflowElementCounter> Counters => counters;
+
+        static IEnumerable<InspectBuilder> GetElements(ExpressionBuilderGraph workflow)
+        {
+            var stack = new Stack<IEnumerator<Node<ExpressionBuilder, ExpressionBuilderArgument>>>();
+            stack.Push(workflow.GetEnumerator());
+
+            while (stack.Count > 0)
+            {
+                var nodeEnumerator = stack.Peek();
+                while (true)
+                {
+                    if (!nodeEnumerator.MoveNext())
+                    {
+                        stack.Pop();
+                        break;
+                    }
+
+                    var inspectBuilder = (InspectBuilder)nodeEnumerator.Current.Value;
+                    yield return inspectBuilder;
+
+                    if (inspectBuilder.Builder is IWorkflowExpressionBuilder workflowBuilder &&
+                        workflowBuilder.Workflow != null)
+                    {
+                        stack.Push(workflowBuilder.Workflow.GetEnumerator());
+                        break;
+                    }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var counter in counters.Values)
+            {
+                counter.Dispose();
+            }
+            counters.Clear();
+        }
+    }
+}

--- a/Bonsai.Editor/Diagnostics/WorkflowMeter.cs
+++ b/Bonsai.Editor/Diagnostics/WorkflowMeter.cs
@@ -10,16 +10,16 @@ namespace Bonsai.Editor.Diagnostics
     {
         readonly Dictionary<ExpressionBuilder, WorkflowElementCounter> counters;
 
-        public WorkflowMeter(ExpressionBuilderGraph workflow)
+        public WorkflowMeter(ExpressionBuilderGraph workflow, WorkflowWatchMap watchMap)
         {
-            counters = GetElements(workflow).ToDictionary(
+            counters = GetElements(workflow, watchMap).ToDictionary(
                 inspectBuilder => (ExpressionBuilder)inspectBuilder,
                 inspectBuilder => new WorkflowElementCounter(inspectBuilder));
         }
 
         public IReadOnlyDictionary<ExpressionBuilder, WorkflowElementCounter> Counters => counters;
 
-        static IEnumerable<InspectBuilder> GetElements(ExpressionBuilderGraph workflow)
+        static IEnumerable<InspectBuilder> GetElements(ExpressionBuilderGraph workflow, WorkflowWatchMap watchMap)
         {
             var stack = new Stack<IEnumerator<Node<ExpressionBuilder, ExpressionBuilderArgument>>>();
             stack.Push(workflow.GetEnumerator());
@@ -36,7 +36,9 @@ namespace Bonsai.Editor.Diagnostics
                     }
 
                     var inspectBuilder = (InspectBuilder)nodeEnumerator.Current.Value;
-                    if (inspectBuilder.PublishNotifications && inspectBuilder.Watch is not null)
+                    if (inspectBuilder.PublishNotifications &&
+                        inspectBuilder.Watch is not null &&
+                        watchMap.Contains(inspectBuilder))
                     {
                         yield return inspectBuilder;
 

--- a/Bonsai.Editor/Diagnostics/WorkflowMeter.cs
+++ b/Bonsai.Editor/Diagnostics/WorkflowMeter.cs
@@ -36,12 +36,12 @@ namespace Bonsai.Editor.Diagnostics
                     }
 
                     var inspectBuilder = (InspectBuilder)nodeEnumerator.Current.Value;
-                    if (inspectBuilder.Output != null)
+                    if (inspectBuilder.PublishNotifications && inspectBuilder.Watch is not null)
                     {
                         yield return inspectBuilder;
 
                         if (inspectBuilder.Builder is IWorkflowExpressionBuilder workflowBuilder &&
-                            workflowBuilder.Workflow != null)
+                            workflowBuilder.Workflow is not null)
                         {
                             stack.Push(workflowBuilder.Workflow.GetEnumerator());
                             break;

--- a/Bonsai.Editor/Docking/DockPanelHelper.cs
+++ b/Bonsai.Editor/Docking/DockPanelHelper.cs
@@ -152,12 +152,12 @@ namespace Bonsai.Editor.Docking
             return null;
         }
 
-        public static XDocument SaveAsXml(this DockPanel dockPanel)
+        public static XElement SaveAsXml(this DockPanel dockPanel)
         {
             using var memoryStream = new MemoryStream();
             dockPanel.SaveAsXml(memoryStream, Encoding.UTF8, upstream: true);
             memoryStream.Position = 0;
-            return XDocument.Load(memoryStream);
+            return XElement.Load(memoryStream);
         }
     }
 }

--- a/Bonsai.Editor/Docking/EditorToolWindow.cs
+++ b/Bonsai.Editor/Docking/EditorToolWindow.cs
@@ -9,7 +9,7 @@ namespace Bonsai.Editor.Docking
         readonly IServiceProvider serviceProvider;
         readonly ThemeRenderer themeRenderer;
 
-        private EditorToolWindow()
+        protected EditorToolWindow()
         {
         }
 

--- a/Bonsai.Editor/Docking/NavigateToolWindow.cs
+++ b/Bonsai.Editor/Docking/NavigateToolWindow.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Text;
+using System.Windows.Forms;
+using Bonsai.Editor.GraphModel;
+using Bonsai.Expressions;
+
+namespace Bonsai.Editor.Docking
+{
+    internal class NavigateToolWindow : EditorToolWindow
+    {
+        static readonly object EventNavigate = new();
+
+        protected NavigateToolWindow()
+        {
+        }
+
+        protected NavigateToolWindow(IServiceProvider provider)
+            : base(provider)
+        {
+        }
+
+        public event WorkflowNavigateEventHandler Navigate
+        {
+            add { Events.AddHandler(EventNavigate, value); }
+            remove { Events.RemoveHandler(EventNavigate, value); }
+        }
+
+        protected virtual void OnNavigate(WorkflowNavigateEventArgs e)
+        {
+            if (Events[EventNavigate] is WorkflowNavigateEventHandler handler)
+            {
+                handler(this, e);
+            }
+        }
+
+        protected ListViewItem CreateNavigationViewItem(
+            InspectBuilder inspectBuilder,
+            WorkflowEditorPath workflowPath,
+            WorkflowBuilder workflowBuilder)
+        {
+            var name = ExpressionBuilder.GetElementDisplayName(inspectBuilder);
+            var elementType = ExpressionBuilder.GetWorkflowElement(inspectBuilder).GetType();
+            var containerPath = GetElementDisplayPath(workflowBuilder, workflowPath.Parent);
+            var item = new ListViewItem(name);
+            item.Tag = workflowPath;
+            item.SubItems.Add(containerPath);
+            item.SubItems.Add(TypeHelper.GetTypeName(elementType));
+            item.SubItems.Add(inspectBuilder.ObservableType is not null
+                ? TypeHelper.GetTypeName(inspectBuilder.ObservableType)
+                : string.Empty);
+            return item;
+        }
+
+        static string GetElementDisplayPath(WorkflowBuilder workflowBuilder, WorkflowEditorPath path)
+        {
+            var sb = new StringBuilder();
+            foreach (var pathElement in WorkflowEditorPath.GetPathDisplayElements(path, workflowBuilder))
+            {
+                if (sb.Length > 0)
+                    sb.Append(" > ");
+                sb.Append(pathElement.Key);
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Bonsai.Editor/Docking/WatchToolWindow.Designer.cs
+++ b/Bonsai.Editor/Docking/WatchToolWindow.Designer.cs
@@ -1,0 +1,186 @@
+﻿namespace Bonsai.Editor.Docking
+{
+    partial class WatchToolWindow
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.watchListView = new Bonsai.Editor.ListView();
+            this.nameColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.pathColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.operatorTypeColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.observableTypeColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.showToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.openNewTabToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.openNewWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.deleteWatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.selectAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.clearAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.contextMenuStrip.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // watchListView
+            // 
+            this.watchListView.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.watchListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.nameColumnHeader,
+            this.pathColumnHeader,
+            this.operatorTypeColumnHeader,
+            this.observableTypeColumnHeader});
+            this.watchListView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.watchListView.FullRowSelect = true;
+            this.watchListView.HideSelection = false;
+            this.watchListView.Location = new System.Drawing.Point(0, 0);
+            this.watchListView.Name = "watchListView";
+            this.watchListView.Size = new System.Drawing.Size(568, 261);
+            this.watchListView.TabIndex = 0;
+            this.watchListView.UseCompatibleStateImageBehavior = false;
+            this.watchListView.View = System.Windows.Forms.View.Details;
+            this.watchListView.ItemActivate += new System.EventHandler(this.watchListView_ItemActivate);
+            this.watchListView.MouseClick += new System.Windows.Forms.MouseEventHandler(this.watchListView_MouseClick);
+            // 
+            // nameColumnHeader
+            // 
+            this.nameColumnHeader.Text = "Name";
+            this.nameColumnHeader.Width = 40;
+            // 
+            // pathColumnHeader
+            // 
+            this.pathColumnHeader.Text = "Workflow Path";
+            this.pathColumnHeader.Width = 82;
+            // 
+            // operatorTypeColumnHeader
+            // 
+            this.operatorTypeColumnHeader.Text = "Operator Type";
+            this.operatorTypeColumnHeader.Width = 80;
+            // 
+            // observableTypeColumnHeader
+            // 
+            this.observableTypeColumnHeader.Text = "Observable Type";
+            this.observableTypeColumnHeader.Width = 362;
+            // 
+            // contextMenuStrip
+            // 
+            this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.showToolStripMenuItem,
+            this.openNewTabToolStripMenuItem,
+            this.openNewWindowToolStripMenuItem,
+            this.toolStripSeparator1,
+            this.deleteWatchToolStripMenuItem,
+            this.selectAllToolStripMenuItem,
+            this.clearAllToolStripMenuItem});
+            this.contextMenuStrip.Name = "contextMenuStrip";
+            this.contextMenuStrip.Size = new System.Drawing.Size(234, 164);
+            // 
+            // showToolStripMenuItem
+            // 
+            this.showToolStripMenuItem.Name = "showToolStripMenuItem";
+            this.showToolStripMenuItem.ShortcutKeyDisplayString = "Enter";
+            this.showToolStripMenuItem.Size = new System.Drawing.Size(233, 22);
+            this.showToolStripMenuItem.Text = "Show";
+            this.showToolStripMenuItem.Click += new System.EventHandler(this.watchListView_ItemActivate);
+            // 
+            // openNewTabToolStripMenuItem
+            // 
+            this.openNewTabToolStripMenuItem.Name = "openNewTabToolStripMenuItem";
+            this.openNewTabToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.T)));
+            this.openNewTabToolStripMenuItem.Size = new System.Drawing.Size(233, 22);
+            this.openNewTabToolStripMenuItem.Text = "Show in New Tab";
+            this.openNewTabToolStripMenuItem.Click += new System.EventHandler(this.openNewTabToolStripMenuItem_Click);
+            // 
+            // openNewWindowToolStripMenuItem
+            // 
+            this.openNewWindowToolStripMenuItem.Name = "openNewWindowToolStripMenuItem";
+            this.openNewWindowToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
+            this.openNewWindowToolStripMenuItem.Size = new System.Drawing.Size(233, 22);
+            this.openNewWindowToolStripMenuItem.Text = "Show in New Window";
+            this.openNewWindowToolStripMenuItem.Click += new System.EventHandler(this.openNewWindowToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(230, 6);
+            // 
+            // deleteWatchToolStripMenuItem
+            // 
+            this.deleteWatchToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.DeleteWatchMenuImage;
+            this.deleteWatchToolStripMenuItem.Name = "deleteWatchToolStripMenuItem";
+            this.deleteWatchToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Delete;
+            this.deleteWatchToolStripMenuItem.Size = new System.Drawing.Size(233, 22);
+            this.deleteWatchToolStripMenuItem.Text = "Delete Watch";
+            this.deleteWatchToolStripMenuItem.Click += new System.EventHandler(this.deleteWatchToolStripMenuItem_Click);
+            // 
+            // selectAllToolStripMenuItem
+            // 
+            this.selectAllToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.SelectAllMenuImage;
+            this.selectAllToolStripMenuItem.Name = "selectAllToolStripMenuItem";
+            this.selectAllToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
+            this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(233, 22);
+            this.selectAllToolStripMenuItem.Text = "Select All";
+            this.selectAllToolStripMenuItem.Click += new System.EventHandler(this.selectAllToolStripMenuItem_Click);
+            // 
+            // clearAllToolStripMenuItem
+            // 
+            this.clearAllToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.ClearAllMenuImage;
+            this.clearAllToolStripMenuItem.Name = "clearAllToolStripMenuItem";
+            this.clearAllToolStripMenuItem.Size = new System.Drawing.Size(233, 22);
+            this.clearAllToolStripMenuItem.Text = "Clear All";
+            this.clearAllToolStripMenuItem.Click += new System.EventHandler(this.clearAllToolStripMenuItem_Click);
+            // 
+            // WatchToolWindow
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(568, 261);
+            this.Controls.Add(this.watchListView);
+            this.Icon = global::Bonsai.Editor.Properties.Resources.Icon;
+            this.Name = "WatchToolWindow";
+            this.Text = "Watch";
+            this.contextMenuStrip.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private Bonsai.Editor.ListView watchListView;
+        private System.Windows.Forms.ColumnHeader nameColumnHeader;
+        private System.Windows.Forms.ColumnHeader pathColumnHeader;
+        private System.Windows.Forms.ColumnHeader operatorTypeColumnHeader;
+        private System.Windows.Forms.ColumnHeader observableTypeColumnHeader;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStrip;
+        private System.Windows.Forms.ToolStripMenuItem openNewTabToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem openNewWindowToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem deleteWatchToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+        private System.Windows.Forms.ToolStripMenuItem selectAllToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem clearAllToolStripMenuItem;
+    }
+}

--- a/Bonsai.Editor/Docking/WatchToolWindow.cs
+++ b/Bonsai.Editor/Docking/WatchToolWindow.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using Bonsai.Editor.GraphModel;
+using Bonsai.Editor.GraphView;
+using Bonsai.Editor.Themes;
+using Bonsai.Expressions;
+
+namespace Bonsai.Editor.Docking
+{
+    partial class WatchToolWindow : NavigateToolWindow
+    {
+        readonly WorkflowEditorControl editorControl;
+        readonly WorkflowWatchMap watchMap;
+
+        public WatchToolWindow(IServiceProvider provider, WorkflowEditorControl owner)
+            : base(provider)
+        {
+            InitializeComponent();
+            editorControl = owner ?? throw new ArgumentNullException(nameof(owner));
+            watchMap = (WorkflowWatchMap)provider.GetService(typeof(WorkflowWatchMap));
+            watchListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+        }
+
+        protected override void InitializeTheme(ThemeRenderer themeRenderer)
+        {
+            var colorTable = themeRenderer.ToolStripRenderer.ColorTable;
+            watchListView.BackColor = colorTable.WindowBackColor;
+            watchListView.ForeColor = colorTable.ControlForeColor;
+        }
+
+        public WorkflowWatchMap WatchMap => watchMap;
+
+        public void UpdateWatchList()
+        {
+            watchListView.BeginUpdate();
+            if (watchListView.Items.Count > 0)
+                watchListView.Items.Clear();
+
+            if (watchMap is not null)
+            {
+                var workflowBuilder = (WorkflowBuilder)ServiceProvider.GetService(typeof(WorkflowBuilder));
+                foreach (var watch in workflowBuilder.FindAll(watchMap.Contains, unwrap: false))
+                {
+                    var inspectBuilder = (InspectBuilder)watch.Builder;
+                    var item = CreateNavigationViewItem(inspectBuilder, watch.Path, workflowBuilder);
+                    watchListView.Items.Add(item);
+                }
+
+                if (watchListView.Items.Count > 0)
+                {
+                    watchListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
+                    watchListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+                }
+            }
+            watchListView.EndUpdate();
+        }
+
+        private void DeleteSelectedItems()
+        {
+            if (watchListView.SelectedItems.Count == 0)
+                return;
+
+            watchListView.BeginUpdate();
+            var updatedPaths = new HashSet<WorkflowEditorPath>();
+            var workflowBuilder = (WorkflowBuilder)ServiceProvider.GetService(typeof(WorkflowBuilder));
+            for (int i = watchListView.SelectedItems.Count - 1; i >= 0; i--)
+            {
+                var selectedItem = watchListView.SelectedItems[i];
+                var workflowPath = (WorkflowEditorPath)selectedItem.Tag;
+                var inspectBuilder = (InspectBuilder)workflowPath.Resolve(workflowBuilder);
+                watchListView.Items.RemoveAt(selectedItem.Index);
+                if (watchMap.Remove(inspectBuilder))
+                {
+                    updatedPaths.Add(workflowPath.Parent);
+                }
+            }
+            watchListView.EndUpdate();
+            editorControl.UpdateWatchLayout(updatedPaths);
+        }
+
+        private void SelectAllItems()
+        {
+            watchListView.BeginUpdate();
+            foreach (ListViewItem item in watchListView.Items)
+            {
+                item.Selected = true;
+            }
+            watchListView.EndUpdate();
+        }
+
+        private void NavigateToSelectedItem(NavigationPreference navigationPreference)
+        {
+            if (watchListView.SelectedItems.Count == 0)
+                return;
+
+            var selectedItem = watchListView.SelectedItems[0];
+            var workflowPath = (WorkflowEditorPath)selectedItem.Tag;
+            OnNavigate(new WorkflowNavigateEventArgs(workflowPath, navigationPreference));
+        }
+
+        private void watchListView_MouseClick(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right)
+            {
+                var focusedItem = watchListView.FocusedItem;
+                if (focusedItem is not null && focusedItem.Bounds.Contains(e.Location))
+                {
+                    contextMenuStrip.Show(Cursor.Position);
+                }
+            }
+        }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (keyData == openNewTabToolStripMenuItem.ShortcutKeys)
+                openNewTabToolStripMenuItem_Click(this, EventArgs.Empty);
+            if (keyData == openNewWindowToolStripMenuItem.ShortcutKeys)
+                openNewWindowToolStripMenuItem_Click(this, EventArgs.Empty);
+            if (keyData == deleteWatchToolStripMenuItem.ShortcutKeys)
+                deleteWatchToolStripMenuItem_Click(this, EventArgs.Empty);
+            if (keyData == selectAllToolStripMenuItem.ShortcutKeys)
+                selectAllToolStripMenuItem_Click(this, EventArgs.Empty);
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        private void watchListView_ItemActivate(object sender, EventArgs e)
+        {
+            NavigateToSelectedItem(NavigationPreference.Current);
+        }
+
+        private void openNewTabToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            NavigateToSelectedItem(NavigationPreference.NewTab);
+        }
+
+        private void openNewWindowToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            NavigateToSelectedItem(NavigationPreference.NewWindow);
+        }
+
+        private void deleteWatchToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            DeleteSelectedItems();
+        }
+
+        private void selectAllToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SelectAllItems();
+        }
+
+        private void clearAllToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SelectAllItems();
+            DeleteSelectedItems();
+        }
+    }
+}

--- a/Bonsai.Editor/Docking/WatchToolWindow.cs
+++ b/Bonsai.Editor/Docking/WatchToolWindow.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Forms;
 using Bonsai.Editor.GraphModel;
 using Bonsai.Editor.GraphView;
@@ -31,7 +32,7 @@ namespace Bonsai.Editor.Docking
 
         public WorkflowWatchMap WatchMap => watchMap;
 
-        public void UpdateWatchList()
+        public void UpdateWatchList(IEnumerable<InspectBuilder> selectedItems = default)
         {
             watchListView.BeginUpdate();
             if (watchListView.Items.Count > 0)
@@ -44,6 +45,7 @@ namespace Bonsai.Editor.Docking
                 {
                     var inspectBuilder = (InspectBuilder)watch.Builder;
                     var item = CreateNavigationViewItem(inspectBuilder, watch.Path, workflowBuilder);
+                    item.Selected = selectedItems?.Contains(inspectBuilder) is true;
                     watchListView.Items.Add(item);
                 }
 

--- a/Bonsai.Editor/Docking/WatchToolWindow.resx
+++ b/Bonsai.Editor/Docking/WatchToolWindow.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/Bonsai.Editor/Docking/WorkflowDockPaneCaption.cs
+++ b/Bonsai.Editor/Docking/WorkflowDockPaneCaption.cs
@@ -282,7 +282,7 @@ namespace Bonsai.Editor.Docking
             // set the size and location for close and auto-hide buttons
             Rectangle rectCaption = ClientRectangle;
             Size buttonSize = GetButtonSize(rectCaption);
-            int x = rectCaption.X + rectCaption.Width - ButtonGapRight - m_buttonClose.Width;
+            int x = rectCaption.X + rectCaption.Width - ButtonGapRight - ButtonClose.Width;
             int y = rectCaption.Y + ButtonGapTop;
             Point point = new Point(x, y);
             ButtonClose.Bounds = DrawHelper.RtlTransform(this, new Rectangle(point, buttonSize));

--- a/Bonsai.Editor/Docking/WorkflowFindToolWindow.Designer.cs
+++ b/Bonsai.Editor/Docking/WorkflowFindToolWindow.Designer.cs
@@ -35,9 +35,9 @@
             this.operatorTypeColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.observableTypeColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.showToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openNewTabToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openNewWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.selectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.contextMenuStrip.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -86,35 +86,35 @@
             // contextMenuStrip
             // 
             this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.selectToolStripMenuItem,
+            this.showToolStripMenuItem,
             this.openNewTabToolStripMenuItem,
             this.openNewWindowToolStripMenuItem});
             this.contextMenuStrip.Name = "contextMenuStrip";
-            this.contextMenuStrip.Size = new System.Drawing.Size(236, 92);
+            this.contextMenuStrip.Size = new System.Drawing.Size(234, 70);
+            // 
+            // showToolStripMenuItem
+            // 
+            this.showToolStripMenuItem.Name = "showToolStripMenuItem";
+            this.showToolStripMenuItem.ShortcutKeyDisplayString = "Enter";
+            this.showToolStripMenuItem.Size = new System.Drawing.Size(233, 22);
+            this.showToolStripMenuItem.Text = "Show";
+            this.showToolStripMenuItem.Click += new System.EventHandler(this.findListView_ItemActivate);
             // 
             // openNewTabToolStripMenuItem
             // 
             this.openNewTabToolStripMenuItem.Name = "openNewTabToolStripMenuItem";
             this.openNewTabToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.T)));
-            this.openNewTabToolStripMenuItem.Size = new System.Drawing.Size(235, 22);
-            this.openNewTabToolStripMenuItem.Text = "Select in New Tab";
+            this.openNewTabToolStripMenuItem.Size = new System.Drawing.Size(233, 22);
+            this.openNewTabToolStripMenuItem.Text = "Show in New Tab";
             this.openNewTabToolStripMenuItem.Click += new System.EventHandler(this.openNewTabToolStripMenuItem_Click);
             // 
             // openNewWindowToolStripMenuItem
             // 
             this.openNewWindowToolStripMenuItem.Name = "openNewWindowToolStripMenuItem";
             this.openNewWindowToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-            this.openNewWindowToolStripMenuItem.Size = new System.Drawing.Size(235, 22);
-            this.openNewWindowToolStripMenuItem.Text = "Select in New Window";
+            this.openNewWindowToolStripMenuItem.Size = new System.Drawing.Size(233, 22);
+            this.openNewWindowToolStripMenuItem.Text = "Show in New Window";
             this.openNewWindowToolStripMenuItem.Click += new System.EventHandler(this.openNewWindowToolStripMenuItem_Click);
-            // 
-            // selectToolStripMenuItem
-            // 
-            this.selectToolStripMenuItem.Name = "selectToolStripMenuItem";
-            this.selectToolStripMenuItem.ShortcutKeyDisplayString = "Enter";
-            this.selectToolStripMenuItem.Size = new System.Drawing.Size(235, 22);
-            this.selectToolStripMenuItem.Text = "Select";
-            this.selectToolStripMenuItem.Click += new System.EventHandler(this.findListView_ItemActivate);
             // 
             // WorkflowFindToolWindow
             // 
@@ -140,6 +140,6 @@
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem openNewTabToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openNewWindowToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem selectToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showToolStripMenuItem;
     }
 }

--- a/Bonsai.Editor/EditorForm.Designer.cs
+++ b/Bonsai.Editor/EditorForm.Designer.cs
@@ -71,6 +71,8 @@
             this.startWithoutDebuggingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.stopToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.restartToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
+            this.watchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.packageManagerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.galleryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -480,7 +482,9 @@
             this.startToolStripMenuItem,
             this.startWithoutDebuggingToolStripMenuItem,
             this.stopToolStripMenuItem,
-            this.restartToolStripMenuItem});
+            this.restartToolStripMenuItem,
+            this.toolStripSeparator11,
+            this.watchToolStripMenuItem});
             this.workflowToolStripMenuItem.Name = "workflowToolStripMenuItem";
             this.workflowToolStripMenuItem.Size = new System.Drawing.Size(70, 20);
             this.workflowToolStripMenuItem.Text = "&Workflow";
@@ -527,6 +531,22 @@
             this.restartToolStripMenuItem.Text = "&Restart";
             this.restartToolStripMenuItem.Visible = false;
             this.restartToolStripMenuItem.Click += new System.EventHandler(this.restartToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator11
+            // 
+            this.toolStripSeparator11.Name = "toolStripSeparator11";
+            this.toolStripSeparator11.Size = new System.Drawing.Size(249, 6);
+            // 
+            // watchToolStripMenuItem
+            // 
+            this.watchToolStripMenuItem.Checked = true;
+            this.watchToolStripMenuItem.CheckOnClick = true;
+            this.watchToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.watchToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.WatchMenuImage;
+            this.watchToolStripMenuItem.Name = "watchToolStripMenuItem";
+            this.watchToolStripMenuItem.Size = new System.Drawing.Size(252, 22);
+            this.watchToolStripMenuItem.Text = "&Watch";
+            this.watchToolStripMenuItem.Click += new System.EventHandler(this.watchToolStripMenuItem_Click);
             // 
             // toolsToolStripMenuItem
             // 
@@ -1581,6 +1601,8 @@
         private System.Windows.Forms.ContextMenuStrip statusContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem statusCopyToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem toolboxDocsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
+        private System.Windows.Forms.ToolStripMenuItem watchToolStripMenuItem;
         private System.Windows.Forms.SplitContainer explorerSplitContainer;
         private Bonsai.Editor.TableLayoutPanel explorerLayoutPanel;
         private Bonsai.Editor.Label explorerLabel;

--- a/Bonsai.Editor/EditorForm.Designer.cs
+++ b/Bonsai.Editor/EditorForm.Designer.cs
@@ -53,8 +53,7 @@
             this.undoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.redoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
-            this.addWatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.deleteWatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toggleWatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.cutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -118,8 +117,7 @@
             this.editExtensionsToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.reloadExtensionsToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
-            this.addWatchToolStripButton = new System.Windows.Forms.ToolStripButton();
-            this.deleteWatchToolStripButton = new System.Windows.Forms.ToolStripButton();
+            this.toggleWatchToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.statusStrip = new System.Windows.Forms.StatusStrip();
             this.statusImageLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.statusContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -331,8 +329,7 @@
             this.undoToolStripMenuItem,
             this.redoToolStripMenuItem,
             this.toolStripSeparator13,
-            this.addWatchToolStripMenuItem,
-            this.deleteWatchToolStripMenuItem,
+            this.toggleWatchToolStripMenuItem,
             this.toolStripSeparator3,
             this.cutToolStripMenuItem,
             this.copyToolStripMenuItem,
@@ -376,23 +373,14 @@
             this.toolStripSeparator13.Name = "toolStripSeparator13";
             this.toolStripSeparator13.Size = new System.Drawing.Size(223, 6);
             // 
-            // addWatchToolStripMenuItem
+            // toggleWatchToolStripMenuItem
             // 
-            this.addWatchToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.WatchMenuImage;
-            this.addWatchToolStripMenuItem.Name = "addWatchToolStripMenuItem";
-            this.addWatchToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F9;
-            this.addWatchToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
-            this.addWatchToolStripMenuItem.Text = "Add Watch";
-            this.addWatchToolStripMenuItem.Click += new System.EventHandler(this.addWatchToolStripMenuItem_Click);
-            // 
-            // deleteWatchToolStripMenuItem
-            // 
-            this.deleteWatchToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.DeleteWatchMenuImage;
-            this.deleteWatchToolStripMenuItem.Name = "deleteWatchToolStripMenuItem";
-            this.deleteWatchToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F9)));
-            this.deleteWatchToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
-            this.deleteWatchToolStripMenuItem.Text = "Delete Watch";
-            this.deleteWatchToolStripMenuItem.Click += new System.EventHandler(this.deleteWatchToolStripMenuItem_Click);
+            this.toggleWatchToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.WatchMenuImage;
+            this.toggleWatchToolStripMenuItem.Name = "toggleWatchToolStripMenuItem";
+            this.toggleWatchToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F9)));
+            this.toggleWatchToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
+            this.toggleWatchToolStripMenuItem.Text = "Toggle Watch";
+            this.toggleWatchToolStripMenuItem.Click += new System.EventHandler(this.toggleWatchToolStripMenuItem_Click);
             // 
             // toolStripSeparator3
             // 
@@ -745,8 +733,7 @@
             this.editExtensionsToolStripButton,
             this.reloadExtensionsToolStripButton,
             this.toolStripSeparator12,
-            this.addWatchToolStripButton,
-            this.deleteWatchToolStripButton});
+            this.toggleWatchToolStripButton});
             this.toolStrip.Location = new System.Drawing.Point(0, 24);
             this.toolStrip.Name = "toolStrip";
             this.toolStrip.Size = new System.Drawing.Size(684, 25);
@@ -945,25 +932,15 @@
             this.toolStripSeparator12.Name = "toolStripSeparator12";
             this.toolStripSeparator12.Size = new System.Drawing.Size(6, 25);
             // 
-            // addWatchToolStripButton
+            // toggleWatchToolStripButton
             // 
-            this.addWatchToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.addWatchToolStripButton.Image = global::Bonsai.Editor.Properties.Resources.WatchMenuImage;
-            this.addWatchToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.addWatchToolStripButton.Name = "addWatchToolStripButton";
-            this.addWatchToolStripButton.Size = new System.Drawing.Size(23, 22);
-            this.addWatchToolStripButton.Text = "Add &Watch (F9)";
-            this.addWatchToolStripButton.Click += new System.EventHandler(this.addWatchToolStripMenuItem_Click);
-            // 
-            // deleteWatchToolStripButton
-            // 
-            this.deleteWatchToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.deleteWatchToolStripButton.Image = global::Bonsai.Editor.Properties.Resources.DeleteWatchMenuImage;
-            this.deleteWatchToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.deleteWatchToolStripButton.Name = "deleteWatchToolStripButton";
-            this.deleteWatchToolStripButton.Size = new System.Drawing.Size(23, 22);
-            this.deleteWatchToolStripButton.Text = "Delete Watc&h (Shift+F9)";
-            this.deleteWatchToolStripButton.Click += new System.EventHandler(this.deleteWatchToolStripMenuItem_Click);
+            this.toggleWatchToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toggleWatchToolStripButton.Image = global::Bonsai.Editor.Properties.Resources.WatchMenuImage;
+            this.toggleWatchToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toggleWatchToolStripButton.Name = "toggleWatchToolStripButton";
+            this.toggleWatchToolStripButton.Size = new System.Drawing.Size(23, 22);
+            this.toggleWatchToolStripButton.Text = "Toggle &Watch (Shift+F9)";
+            this.toggleWatchToolStripButton.Click += new System.EventHandler(this.toggleWatchToolStripMenuItem_Click);
             // 
             // statusStrip
             // 
@@ -1671,11 +1648,9 @@
         private Bonsai.Editor.Label explorerLabel;
         private Bonsai.Editor.ExplorerTreeView explorerTreeView;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator12;
-        private System.Windows.Forms.ToolStripButton addWatchToolStripButton;
-        private System.Windows.Forms.ToolStripButton deleteWatchToolStripButton;
+        private System.Windows.Forms.ToolStripButton toggleWatchToolStripButton;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator13;
-        private System.Windows.Forms.ToolStripMenuItem addWatchToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem deleteWatchToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem toggleWatchToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator14;
         private System.Windows.Forms.ToolStripMenuItem showFindResultsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showWatchToolStripMenuItem;

--- a/Bonsai.Editor/EditorForm.Designer.cs
+++ b/Bonsai.Editor/EditorForm.Designer.cs
@@ -52,6 +52,9 @@
             this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.undoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.redoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
+            this.addWatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.deleteWatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.cutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -71,8 +74,6 @@
             this.startWithoutDebuggingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.stopToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.restartToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
-            this.watchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.packageManagerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.galleryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -82,6 +83,9 @@
             this.reloadExtensionsDebugToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
             this.themeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator14 = new System.Windows.Forms.ToolStripSeparator();
+            this.showFindResultsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showWatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.welcomeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.docsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -113,28 +117,35 @@
             this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
             this.editExtensionsToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.reloadExtensionsToolStripButton = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
+            this.addWatchToolStripButton = new System.Windows.Forms.ToolStripButton();
+            this.deleteWatchToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.statusStrip = new System.Windows.Forms.StatusStrip();
             this.statusImageLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.statusContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.statusCopyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.propertyGridContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.resetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.descriptionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.panelSplitContainer = new System.Windows.Forms.SplitContainer();
+            this.explorerSplitContainer = new System.Windows.Forms.SplitContainer();
+            this.toolboxLayoutPanel = new Bonsai.Editor.TableLayoutPanel();
             this.toolboxSplitContainer = new Bonsai.Editor.SelectableSplitContainer();
             this.toolboxTableLayoutPanel = new Bonsai.Editor.TableLayoutPanel();
             this.searchTextBox = new Bonsai.Editor.CueBannerTextBox();
             this.toolboxTreeView = new Bonsai.Editor.ToolboxTreeView();
             this.toolboxDescriptionPanel = new Bonsai.Editor.BorderPanel();
             this.toolboxDescriptionTextBox = new System.Windows.Forms.RichTextBox();
+            this.toolboxLabel = new Bonsai.Editor.Label();
+            this.explorerLayoutPanel = new Bonsai.Editor.TableLayoutPanel();
+            this.explorerTreeView = new Bonsai.Editor.ExplorerTreeView();
+            this.explorerLabel = new Bonsai.Editor.Label();
+            this.workflowSplitContainer = new System.Windows.Forms.SplitContainer();
+            this.propertiesLayoutPanel = new Bonsai.Editor.TableLayoutPanel();
             this.propertiesSplitContainer = new System.Windows.Forms.SplitContainer();
             this.propertiesDescriptionPanel = new Bonsai.Editor.BorderPanel();
             this.propertiesDescriptionTextBox = new System.Windows.Forms.RichTextBox();
             this.propertyGrid = new Bonsai.Editor.PropertyGrid();
-            this.propertyGridContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.resetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.descriptionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.panelSplitContainer = new System.Windows.Forms.SplitContainer();
-            this.toolboxLayoutPanel = new Bonsai.Editor.TableLayoutPanel();
-            this.toolboxLabel = new Bonsai.Editor.Label();
-            this.workflowSplitContainer = new System.Windows.Forms.SplitContainer();
-            this.propertiesLayoutPanel = new Bonsai.Editor.TableLayoutPanel();
             this.propertiesLabel = new Bonsai.Editor.Label();
             this.toolboxContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.toolboxDocsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -153,42 +164,38 @@
             this.commandExecutor = new Bonsai.Design.CommandExecutor();
             this.workflowFileWatcher = new System.IO.FileSystemWatcher();
             this.exportImageDialog = new System.Windows.Forms.SaveFileDialog();
-            this.explorerSplitContainer = new System.Windows.Forms.SplitContainer();
-            this.explorerLayoutPanel = new Bonsai.Editor.TableLayoutPanel();
-            this.explorerLabel = new Bonsai.Editor.Label();
-            this.explorerTreeView = new Bonsai.Editor.ExplorerTreeView();
             this.menuStrip.SuspendLayout();
             this.toolStrip.SuspendLayout();
             this.statusStrip.SuspendLayout();
             this.statusContextMenuStrip.SuspendLayout();
+            this.propertyGridContextMenuStrip.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.panelSplitContainer)).BeginInit();
+            this.panelSplitContainer.Panel1.SuspendLayout();
+            this.panelSplitContainer.Panel2.SuspendLayout();
+            this.panelSplitContainer.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.explorerSplitContainer)).BeginInit();
+            this.explorerSplitContainer.Panel1.SuspendLayout();
+            this.explorerSplitContainer.Panel2.SuspendLayout();
+            this.explorerSplitContainer.SuspendLayout();
+            this.toolboxLayoutPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.toolboxSplitContainer)).BeginInit();
             this.toolboxSplitContainer.Panel1.SuspendLayout();
             this.toolboxSplitContainer.Panel2.SuspendLayout();
             this.toolboxSplitContainer.SuspendLayout();
             this.toolboxTableLayoutPanel.SuspendLayout();
             this.toolboxDescriptionPanel.SuspendLayout();
+            this.explorerLayoutPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.workflowSplitContainer)).BeginInit();
+            this.workflowSplitContainer.Panel2.SuspendLayout();
+            this.workflowSplitContainer.SuspendLayout();
+            this.propertiesLayoutPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.propertiesSplitContainer)).BeginInit();
             this.propertiesSplitContainer.Panel1.SuspendLayout();
             this.propertiesSplitContainer.Panel2.SuspendLayout();
             this.propertiesSplitContainer.SuspendLayout();
             this.propertiesDescriptionPanel.SuspendLayout();
-            this.propertyGridContextMenuStrip.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.panelSplitContainer)).BeginInit();
-            this.panelSplitContainer.Panel1.SuspendLayout();
-            this.panelSplitContainer.Panel2.SuspendLayout();
-            this.panelSplitContainer.SuspendLayout();
-            this.toolboxLayoutPanel.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.workflowSplitContainer)).BeginInit();
-            this.workflowSplitContainer.Panel2.SuspendLayout();
-            this.workflowSplitContainer.SuspendLayout();
-            this.propertiesLayoutPanel.SuspendLayout();
             this.toolboxContextMenuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.workflowFileWatcher)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.explorerSplitContainer)).BeginInit();
-            this.explorerSplitContainer.Panel1.SuspendLayout();
-            this.explorerSplitContainer.Panel2.SuspendLayout();
-            this.explorerSplitContainer.SuspendLayout();
-            this.explorerLayoutPanel.SuspendLayout();
             this.SuspendLayout();
             // 
             // menuStrip
@@ -323,6 +330,9 @@
             this.editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.undoToolStripMenuItem,
             this.redoToolStripMenuItem,
+            this.toolStripSeparator13,
+            this.addWatchToolStripMenuItem,
+            this.deleteWatchToolStripMenuItem,
             this.toolStripSeparator3,
             this.cutToolStripMenuItem,
             this.copyToolStripMenuItem,
@@ -360,6 +370,29 @@
             this.redoToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
             this.redoToolStripMenuItem.Text = "&Redo";
             this.redoToolStripMenuItem.Click += new System.EventHandler(this.redoToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator13
+            // 
+            this.toolStripSeparator13.Name = "toolStripSeparator13";
+            this.toolStripSeparator13.Size = new System.Drawing.Size(223, 6);
+            // 
+            // addWatchToolStripMenuItem
+            // 
+            this.addWatchToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.WatchMenuImage;
+            this.addWatchToolStripMenuItem.Name = "addWatchToolStripMenuItem";
+            this.addWatchToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F9;
+            this.addWatchToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
+            this.addWatchToolStripMenuItem.Text = "Add Watch";
+            this.addWatchToolStripMenuItem.Click += new System.EventHandler(this.addWatchToolStripMenuItem_Click);
+            // 
+            // deleteWatchToolStripMenuItem
+            // 
+            this.deleteWatchToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.DeleteWatchMenuImage;
+            this.deleteWatchToolStripMenuItem.Name = "deleteWatchToolStripMenuItem";
+            this.deleteWatchToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F9)));
+            this.deleteWatchToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
+            this.deleteWatchToolStripMenuItem.Text = "Delete Watch";
+            this.deleteWatchToolStripMenuItem.Click += new System.EventHandler(this.deleteWatchToolStripMenuItem_Click);
             // 
             // toolStripSeparator3
             // 
@@ -482,9 +515,7 @@
             this.startToolStripMenuItem,
             this.startWithoutDebuggingToolStripMenuItem,
             this.stopToolStripMenuItem,
-            this.restartToolStripMenuItem,
-            this.toolStripSeparator11,
-            this.watchToolStripMenuItem});
+            this.restartToolStripMenuItem});
             this.workflowToolStripMenuItem.Name = "workflowToolStripMenuItem";
             this.workflowToolStripMenuItem.Size = new System.Drawing.Size(70, 20);
             this.workflowToolStripMenuItem.Text = "&Workflow";
@@ -532,22 +563,6 @@
             this.restartToolStripMenuItem.Visible = false;
             this.restartToolStripMenuItem.Click += new System.EventHandler(this.restartToolStripMenuItem_Click);
             // 
-            // toolStripSeparator11
-            // 
-            this.toolStripSeparator11.Name = "toolStripSeparator11";
-            this.toolStripSeparator11.Size = new System.Drawing.Size(249, 6);
-            // 
-            // watchToolStripMenuItem
-            // 
-            this.watchToolStripMenuItem.Checked = true;
-            this.watchToolStripMenuItem.CheckOnClick = true;
-            this.watchToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.watchToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.WatchMenuImage;
-            this.watchToolStripMenuItem.Name = "watchToolStripMenuItem";
-            this.watchToolStripMenuItem.Size = new System.Drawing.Size(252, 22);
-            this.watchToolStripMenuItem.Text = "&Watch";
-            this.watchToolStripMenuItem.Click += new System.EventHandler(this.watchToolStripMenuItem_Click);
-            // 
             // toolsToolStripMenuItem
             // 
             this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -558,16 +573,19 @@
             this.reloadExtensionsToolStripMenuItem,
             this.reloadExtensionsDebugToolStripMenuItem,
             this.toolStripSeparator10,
-            this.themeToolStripMenuItem});
+            this.themeToolStripMenuItem,
+            this.toolStripSeparator14,
+            this.showFindResultsToolStripMenuItem,
+            this.showWatchToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 20);
             this.toolsToolStripMenuItem.Text = "&Tools";
             // 
             // packageManagerToolStripMenuItem
             // 
             this.packageManagerToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.PackageManagerMenuImage;
             this.packageManagerToolStripMenuItem.Name = "packageManagerToolStripMenuItem";
-            this.packageManagerToolStripMenuItem.Size = new System.Drawing.Size(257, 22);
+            this.packageManagerToolStripMenuItem.Size = new System.Drawing.Size(256, 22);
             this.packageManagerToolStripMenuItem.Text = "&Manage Packages...";
             this.packageManagerToolStripMenuItem.Click += new System.EventHandler(this.packageManagerToolStripMenuItem_Click);
             // 
@@ -575,20 +593,20 @@
             // 
             this.galleryToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.GalleryMenuImage;
             this.galleryToolStripMenuItem.Name = "galleryToolStripMenuItem";
-            this.galleryToolStripMenuItem.Size = new System.Drawing.Size(257, 22);
+            this.galleryToolStripMenuItem.Size = new System.Drawing.Size(256, 22);
             this.galleryToolStripMenuItem.Text = "Bonsai &Gallery";
             this.galleryToolStripMenuItem.Click += new System.EventHandler(this.galleryToolStripMenuItem_Click);
             // 
             // toolStripSeparator7
             // 
             this.toolStripSeparator7.Name = "toolStripSeparator7";
-            this.toolStripSeparator7.Size = new System.Drawing.Size(254, 6);
+            this.toolStripSeparator7.Size = new System.Drawing.Size(253, 6);
             // 
             // editExtensionsToolStripMenuItem
             // 
             this.editExtensionsToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.EditExtensionsMenuImage;
             this.editExtensionsToolStripMenuItem.Name = "editExtensionsToolStripMenuItem";
-            this.editExtensionsToolStripMenuItem.Size = new System.Drawing.Size(257, 22);
+            this.editExtensionsToolStripMenuItem.Size = new System.Drawing.Size(256, 22);
             this.editExtensionsToolStripMenuItem.Text = "&Edit Extensions";
             this.editExtensionsToolStripMenuItem.Click += new System.EventHandler(this.editExtensionsToolStripMenuItem_Click);
             // 
@@ -596,29 +614,48 @@
             // 
             this.reloadExtensionsToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.ReloadExtensionsMenuImage;
             this.reloadExtensionsToolStripMenuItem.Name = "reloadExtensionsToolStripMenuItem";
-            this.reloadExtensionsToolStripMenuItem.Size = new System.Drawing.Size(257, 22);
+            this.reloadExtensionsToolStripMenuItem.Size = new System.Drawing.Size(256, 22);
             this.reloadExtensionsToolStripMenuItem.Text = "&Reload Extensions";
             this.reloadExtensionsToolStripMenuItem.Click += new System.EventHandler(this.reloadExtensionsToolStripMenuItem_Click);
             // 
             // reloadExtensionsDebugToolStripMenuItem
             // 
             this.reloadExtensionsDebugToolStripMenuItem.Name = "reloadExtensionsDebugToolStripMenuItem";
-            this.reloadExtensionsDebugToolStripMenuItem.Size = new System.Drawing.Size(257, 22);
+            this.reloadExtensionsDebugToolStripMenuItem.Size = new System.Drawing.Size(256, 22);
             this.reloadExtensionsDebugToolStripMenuItem.Text = "Reload Extensions with &Debugging";
             this.reloadExtensionsDebugToolStripMenuItem.Click += new System.EventHandler(this.reloadExtensionsDebugToolStripMenuItem_Click);
             // 
             // toolStripSeparator10
             // 
             this.toolStripSeparator10.Name = "toolStripSeparator10";
-            this.toolStripSeparator10.Size = new System.Drawing.Size(254, 6);
+            this.toolStripSeparator10.Size = new System.Drawing.Size(253, 6);
             // 
             // themeToolStripMenuItem
             // 
             this.themeToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.ThemeMenuImage;
             this.themeToolStripMenuItem.Name = "themeToolStripMenuItem";
-            this.themeToolStripMenuItem.Size = new System.Drawing.Size(257, 22);
+            this.themeToolStripMenuItem.Size = new System.Drawing.Size(256, 22);
             this.themeToolStripMenuItem.Text = "Dark &Theme";
             this.themeToolStripMenuItem.Click += new System.EventHandler(this.themeToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator14
+            // 
+            this.toolStripSeparator14.Name = "toolStripSeparator14";
+            this.toolStripSeparator14.Size = new System.Drawing.Size(253, 6);
+            // 
+            // showFindResultsToolStripMenuItem
+            // 
+            this.showFindResultsToolStripMenuItem.Name = "showFindResultsToolStripMenuItem";
+            this.showFindResultsToolStripMenuItem.Size = new System.Drawing.Size(256, 22);
+            this.showFindResultsToolStripMenuItem.Text = "Show &Find Results";
+            this.showFindResultsToolStripMenuItem.Click += new System.EventHandler(this.showFindResultsToolStripMenuItem_Click);
+            // 
+            // showWatchToolStripMenuItem
+            // 
+            this.showWatchToolStripMenuItem.Name = "showWatchToolStripMenuItem";
+            this.showWatchToolStripMenuItem.Size = new System.Drawing.Size(256, 22);
+            this.showWatchToolStripMenuItem.Text = "Show &Watch";
+            this.showWatchToolStripMenuItem.Click += new System.EventHandler(this.showWatchToolStripMenuItem_Click);
             // 
             // helpToolStripMenuItem
             // 
@@ -636,7 +673,7 @@
             // welcomeToolStripMenuItem
             // 
             this.welcomeToolStripMenuItem.Name = "welcomeToolStripMenuItem";
-            this.welcomeToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.welcomeToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.welcomeToolStripMenuItem.Text = "&Welcome...";
             this.welcomeToolStripMenuItem.Click += new System.EventHandler(this.welcomeToolStripMenuItem_Click);
             // 
@@ -645,7 +682,7 @@
             this.docsToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.DocsMenuImage;
             this.docsToolStripMenuItem.Name = "docsToolStripMenuItem";
             this.docsToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F1;
-            this.docsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.docsToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.docsToolStripMenuItem.Text = "&View Help";
             this.docsToolStripMenuItem.Click += new System.EventHandler(this.docsToolStripMenuItem_Click);
             // 
@@ -653,7 +690,7 @@
             // 
             this.forumToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.ForumMenuImage;
             this.forumToolStripMenuItem.Name = "forumToolStripMenuItem";
-            this.forumToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.forumToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.forumToolStripMenuItem.Text = "Bonsai &Forums";
             this.forumToolStripMenuItem.Click += new System.EventHandler(this.forumToolStripMenuItem_Click);
             // 
@@ -661,19 +698,19 @@
             // 
             this.reportBugToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.ReportBugMenuImage;
             this.reportBugToolStripMenuItem.Name = "reportBugToolStripMenuItem";
-            this.reportBugToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.reportBugToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.reportBugToolStripMenuItem.Text = "&Report a Bug";
             this.reportBugToolStripMenuItem.Click += new System.EventHandler(this.reportBugToolStripMenuItem_Click);
             // 
             // toolStripSeparator5
             // 
             this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(177, 6);
+            this.toolStripSeparator5.Size = new System.Drawing.Size(149, 6);
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.aboutToolStripMenuItem.Text = "&About...";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
@@ -706,7 +743,10 @@
             this.browseDirectoryToolStripButton,
             this.toolStripSeparator9,
             this.editExtensionsToolStripButton,
-            this.reloadExtensionsToolStripButton});
+            this.reloadExtensionsToolStripButton,
+            this.toolStripSeparator12,
+            this.addWatchToolStripButton,
+            this.deleteWatchToolStripButton});
             this.toolStrip.Location = new System.Drawing.Point(0, 24);
             this.toolStrip.Name = "toolStrip";
             this.toolStrip.Size = new System.Drawing.Size(684, 25);
@@ -900,6 +940,31 @@
             this.reloadExtensionsToolStripButton.Text = "Reload Extensions";
             this.reloadExtensionsToolStripButton.Click += new System.EventHandler(this.reloadExtensionsToolStripMenuItem_Click);
             // 
+            // toolStripSeparator12
+            // 
+            this.toolStripSeparator12.Name = "toolStripSeparator12";
+            this.toolStripSeparator12.Size = new System.Drawing.Size(6, 25);
+            // 
+            // addWatchToolStripButton
+            // 
+            this.addWatchToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.addWatchToolStripButton.Image = global::Bonsai.Editor.Properties.Resources.WatchMenuImage;
+            this.addWatchToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.addWatchToolStripButton.Name = "addWatchToolStripButton";
+            this.addWatchToolStripButton.Size = new System.Drawing.Size(23, 22);
+            this.addWatchToolStripButton.Text = "Add &Watch (F9)";
+            this.addWatchToolStripButton.Click += new System.EventHandler(this.addWatchToolStripMenuItem_Click);
+            // 
+            // deleteWatchToolStripButton
+            // 
+            this.deleteWatchToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.deleteWatchToolStripButton.Image = global::Bonsai.Editor.Properties.Resources.DeleteWatchMenuImage;
+            this.deleteWatchToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.deleteWatchToolStripButton.Name = "deleteWatchToolStripButton";
+            this.deleteWatchToolStripButton.Size = new System.Drawing.Size(23, 22);
+            this.deleteWatchToolStripButton.Text = "Delete Watc&h (Shift+F9)";
+            this.deleteWatchToolStripButton.Click += new System.EventHandler(this.deleteWatchToolStripMenuItem_Click);
+            // 
             // statusStrip
             // 
             this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -934,6 +999,85 @@
             this.statusCopyToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
             this.statusCopyToolStripMenuItem.Text = "&Copy";
             this.statusCopyToolStripMenuItem.Click += new System.EventHandler(this.statusCopyToolStripMenuItem_Click);
+            // 
+            // propertyGridContextMenuStrip
+            // 
+            this.propertyGridContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.resetToolStripMenuItem,
+            this.descriptionToolStripMenuItem});
+            this.propertyGridContextMenuStrip.Name = "propertyGridContextMenuStrip";
+            this.propertyGridContextMenuStrip.Size = new System.Drawing.Size(135, 48);
+            this.propertyGridContextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.propertyGridContextMenuStrip_Opening);
+            // 
+            // resetToolStripMenuItem
+            // 
+            this.resetToolStripMenuItem.Name = "resetToolStripMenuItem";
+            this.resetToolStripMenuItem.Size = new System.Drawing.Size(134, 22);
+            this.resetToolStripMenuItem.Text = "&Reset";
+            this.resetToolStripMenuItem.Click += new System.EventHandler(this.resetToolStripMenuItem_Click);
+            // 
+            // descriptionToolStripMenuItem
+            // 
+            this.descriptionToolStripMenuItem.Checked = true;
+            this.descriptionToolStripMenuItem.CheckOnClick = true;
+            this.descriptionToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.descriptionToolStripMenuItem.Name = "descriptionToolStripMenuItem";
+            this.descriptionToolStripMenuItem.Size = new System.Drawing.Size(134, 22);
+            this.descriptionToolStripMenuItem.Text = "&Description";
+            this.descriptionToolStripMenuItem.Click += new System.EventHandler(this.descriptionToolStripMenuItem_Click);
+            // 
+            // panelSplitContainer
+            // 
+            this.panelSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.panelSplitContainer.Location = new System.Drawing.Point(0, 49);
+            this.panelSplitContainer.Name = "panelSplitContainer";
+            // 
+            // panelSplitContainer.Panel1
+            // 
+            this.panelSplitContainer.Panel1.Controls.Add(this.explorerSplitContainer);
+            // 
+            // panelSplitContainer.Panel2
+            // 
+            this.panelSplitContainer.Panel2.Controls.Add(this.workflowSplitContainer);
+            this.panelSplitContainer.Size = new System.Drawing.Size(684, 340);
+            this.panelSplitContainer.SplitterDistance = 200;
+            this.panelSplitContainer.TabIndex = 4;
+            this.panelSplitContainer.TabStop = false;
+            // 
+            // explorerSplitContainer
+            // 
+            this.explorerSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.explorerSplitContainer.Location = new System.Drawing.Point(0, 0);
+            this.explorerSplitContainer.Name = "explorerSplitContainer";
+            this.explorerSplitContainer.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // explorerSplitContainer.Panel1
+            // 
+            this.explorerSplitContainer.Panel1.Controls.Add(this.toolboxLayoutPanel);
+            // 
+            // explorerSplitContainer.Panel2
+            // 
+            this.explorerSplitContainer.Panel2.Controls.Add(this.explorerLayoutPanel);
+            this.explorerSplitContainer.Size = new System.Drawing.Size(200, 340);
+            this.explorerSplitContainer.SplitterDistance = 170;
+            this.explorerSplitContainer.TabIndex = 2;
+            // 
+            // toolboxLayoutPanel
+            // 
+            this.toolboxLayoutPanel.ColumnCount = 1;
+            this.toolboxLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.toolboxLayoutPanel.Controls.Add(this.toolboxSplitContainer, 0, 1);
+            this.toolboxLayoutPanel.Controls.Add(this.toolboxLabel, 0, 0);
+            this.toolboxLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.toolboxLayoutPanel.Location = new System.Drawing.Point(0, 0);
+            this.toolboxLayoutPanel.Name = "toolboxLayoutPanel";
+            this.toolboxLayoutPanel.Padding = new System.Windows.Forms.Padding(0, 6, 0, 0);
+            this.toolboxLayoutPanel.RowCount = 2;
+            this.toolboxLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 23F));
+            this.toolboxLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.toolboxLayoutPanel.Size = new System.Drawing.Size(200, 170);
+            this.toolboxLayoutPanel.TabIndex = 1;
             // 
             // toolboxSplitContainer
             // 
@@ -1042,6 +1186,90 @@
             this.toolboxDescriptionTextBox.TabStop = false;
             this.toolboxDescriptionTextBox.Text = "";
             // 
+            // toolboxLabel
+            // 
+            this.toolboxLabel.AutoSize = true;
+            this.toolboxLabel.BackColor = System.Drawing.SystemColors.ScrollBar;
+            this.toolboxLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.toolboxLabel.Location = new System.Drawing.Point(3, 6);
+            this.toolboxLabel.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            this.toolboxLabel.Name = "toolboxLabel";
+            this.toolboxLabel.Size = new System.Drawing.Size(197, 23);
+            this.toolboxLabel.TabIndex = 2;
+            this.toolboxLabel.Text = "Toolbox";
+            this.toolboxLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // explorerLayoutPanel
+            // 
+            this.explorerLayoutPanel.ColumnCount = 1;
+            this.explorerLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.explorerLayoutPanel.Controls.Add(this.explorerTreeView, 0, 1);
+            this.explorerLayoutPanel.Controls.Add(this.explorerLabel, 0, 0);
+            this.explorerLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.explorerLayoutPanel.Location = new System.Drawing.Point(0, 0);
+            this.explorerLayoutPanel.Name = "explorerLayoutPanel";
+            this.explorerLayoutPanel.Padding = new System.Windows.Forms.Padding(0, 6, 0, 0);
+            this.explorerLayoutPanel.RowCount = 2;
+            this.explorerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 23F));
+            this.explorerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.explorerLayoutPanel.Size = new System.Drawing.Size(200, 166);
+            this.explorerLayoutPanel.TabIndex = 2;
+            // 
+            // explorerTreeView
+            // 
+            this.explorerTreeView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.explorerTreeView.Location = new System.Drawing.Point(3, 29);
+            this.explorerTreeView.Margin = new System.Windows.Forms.Padding(3, 0, 0, 3);
+            this.explorerTreeView.Name = "explorerTreeView";
+            this.explorerTreeView.Renderer = null;
+            this.explorerTreeView.Size = new System.Drawing.Size(197, 134);
+            this.explorerTreeView.TabIndex = 3;
+            this.explorerTreeView.Navigate += new Bonsai.Editor.WorkflowNavigateEventHandler(this.explorerTreeView_Navigate);
+            // 
+            // explorerLabel
+            // 
+            this.explorerLabel.AutoSize = true;
+            this.explorerLabel.BackColor = System.Drawing.SystemColors.ScrollBar;
+            this.explorerLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.explorerLabel.Location = new System.Drawing.Point(3, 6);
+            this.explorerLabel.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            this.explorerLabel.Name = "explorerLabel";
+            this.explorerLabel.Size = new System.Drawing.Size(197, 23);
+            this.explorerLabel.TabIndex = 2;
+            this.explorerLabel.Text = "Explorer";
+            this.explorerLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // workflowSplitContainer
+            // 
+            this.workflowSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.workflowSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
+            this.workflowSplitContainer.Location = new System.Drawing.Point(0, 0);
+            this.workflowSplitContainer.Name = "workflowSplitContainer";
+            // 
+            // workflowSplitContainer.Panel2
+            // 
+            this.workflowSplitContainer.Panel2.Controls.Add(this.propertiesLayoutPanel);
+            this.workflowSplitContainer.Size = new System.Drawing.Size(480, 340);
+            this.workflowSplitContainer.SplitterDistance = 280;
+            this.workflowSplitContainer.TabIndex = 0;
+            this.workflowSplitContainer.TabStop = false;
+            // 
+            // propertiesLayoutPanel
+            // 
+            this.propertiesLayoutPanel.ColumnCount = 1;
+            this.propertiesLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.propertiesLayoutPanel.Controls.Add(this.propertiesSplitContainer, 0, 1);
+            this.propertiesLayoutPanel.Controls.Add(this.propertiesLabel, 0, 0);
+            this.propertiesLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.propertiesLayoutPanel.Location = new System.Drawing.Point(0, 0);
+            this.propertiesLayoutPanel.Name = "propertiesLayoutPanel";
+            this.propertiesLayoutPanel.Padding = new System.Windows.Forms.Padding(0, 6, 0, 0);
+            this.propertiesLayoutPanel.RowCount = 2;
+            this.propertiesLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 23F));
+            this.propertiesLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.propertiesLayoutPanel.Size = new System.Drawing.Size(196, 340);
+            this.propertiesLayoutPanel.TabIndex = 3;
+            // 
             // propertiesSplitContainer
             // 
             this.propertiesSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -1101,111 +1329,6 @@
             this.propertyGrid.DragEnter += new System.Windows.Forms.DragEventHandler(this.propertyGrid_DragEnter);
             this.propertyGrid.Validated += new System.EventHandler(this.propertyGrid_Validated);
             // 
-            // propertyGridContextMenuStrip
-            // 
-            this.propertyGridContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.resetToolStripMenuItem,
-            this.descriptionToolStripMenuItem});
-            this.propertyGridContextMenuStrip.Name = "propertyGridContextMenuStrip";
-            this.propertyGridContextMenuStrip.Size = new System.Drawing.Size(135, 48);
-            this.propertyGridContextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.propertyGridContextMenuStrip_Opening);
-            // 
-            // resetToolStripMenuItem
-            // 
-            this.resetToolStripMenuItem.Name = "resetToolStripMenuItem";
-            this.resetToolStripMenuItem.Size = new System.Drawing.Size(134, 22);
-            this.resetToolStripMenuItem.Text = "&Reset";
-            this.resetToolStripMenuItem.Click += new System.EventHandler(this.resetToolStripMenuItem_Click);
-            // 
-            // descriptionToolStripMenuItem
-            // 
-            this.descriptionToolStripMenuItem.Checked = true;
-            this.descriptionToolStripMenuItem.CheckOnClick = true;
-            this.descriptionToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.descriptionToolStripMenuItem.Name = "descriptionToolStripMenuItem";
-            this.descriptionToolStripMenuItem.Size = new System.Drawing.Size(134, 22);
-            this.descriptionToolStripMenuItem.Text = "&Description";
-            this.descriptionToolStripMenuItem.Click += new System.EventHandler(this.descriptionToolStripMenuItem_Click);
-            // 
-            // panelSplitContainer
-            // 
-            this.panelSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
-            this.panelSplitContainer.Location = new System.Drawing.Point(0, 49);
-            this.panelSplitContainer.Name = "panelSplitContainer";
-            // 
-            // panelSplitContainer.Panel1
-            // 
-            this.panelSplitContainer.Panel1.Controls.Add(this.explorerSplitContainer);
-            // 
-            // panelSplitContainer.Panel2
-            // 
-            this.panelSplitContainer.Panel2.Controls.Add(this.workflowSplitContainer);
-            this.panelSplitContainer.Size = new System.Drawing.Size(684, 340);
-            this.panelSplitContainer.SplitterDistance = 200;
-            this.panelSplitContainer.TabIndex = 4;
-            this.panelSplitContainer.TabStop = false;
-            // 
-            // toolboxLayoutPanel
-            // 
-            this.toolboxLayoutPanel.ColumnCount = 1;
-            this.toolboxLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.toolboxLayoutPanel.Controls.Add(this.toolboxSplitContainer, 0, 1);
-            this.toolboxLayoutPanel.Controls.Add(this.toolboxLabel, 0, 0);
-            this.toolboxLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.toolboxLayoutPanel.Location = new System.Drawing.Point(0, 0);
-            this.toolboxLayoutPanel.Name = "toolboxLayoutPanel";
-            this.toolboxLayoutPanel.Padding = new System.Windows.Forms.Padding(0, 6, 0, 0);
-            this.toolboxLayoutPanel.RowCount = 2;
-            this.toolboxLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 23F));
-            this.toolboxLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.toolboxLayoutPanel.Size = new System.Drawing.Size(200, 170);
-            this.toolboxLayoutPanel.TabIndex = 1;
-            // 
-            // toolboxLabel
-            // 
-            this.toolboxLabel.AutoSize = true;
-            this.toolboxLabel.BackColor = System.Drawing.SystemColors.ScrollBar;
-            this.toolboxLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.toolboxLabel.Location = new System.Drawing.Point(3, 6);
-            this.toolboxLabel.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
-            this.toolboxLabel.Name = "toolboxLabel";
-            this.toolboxLabel.Size = new System.Drawing.Size(197, 23);
-            this.toolboxLabel.TabIndex = 2;
-            this.toolboxLabel.Text = "Toolbox";
-            this.toolboxLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // workflowSplitContainer
-            // 
-            this.workflowSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.workflowSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            this.workflowSplitContainer.Location = new System.Drawing.Point(0, 0);
-            this.workflowSplitContainer.Name = "workflowSplitContainer";
-            // 
-            // workflowSplitContainer.Panel2
-            // 
-            this.workflowSplitContainer.Panel2.Controls.Add(this.propertiesLayoutPanel);
-            this.workflowSplitContainer.Size = new System.Drawing.Size(480, 340);
-            this.workflowSplitContainer.SplitterDistance = 280;
-            this.workflowSplitContainer.TabIndex = 0;
-            this.workflowSplitContainer.TabStop = false;
-            // 
-            // propertiesLayoutPanel
-            // 
-            this.propertiesLayoutPanel.ColumnCount = 1;
-            this.propertiesLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.propertiesLayoutPanel.Controls.Add(this.propertiesSplitContainer, 0, 1);
-            this.propertiesLayoutPanel.Controls.Add(this.propertiesLabel, 0, 0);
-            this.propertiesLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.propertiesLayoutPanel.Location = new System.Drawing.Point(0, 0);
-            this.propertiesLayoutPanel.Name = "propertiesLayoutPanel";
-            this.propertiesLayoutPanel.Padding = new System.Windows.Forms.Padding(0, 6, 0, 0);
-            this.propertiesLayoutPanel.RowCount = 2;
-            this.propertiesLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 23F));
-            this.propertiesLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.propertiesLayoutPanel.Size = new System.Drawing.Size(196, 340);
-            this.propertiesLayoutPanel.TabIndex = 3;
-            // 
             // propertiesLabel
             // 
             this.propertiesLabel.AutoSize = true;
@@ -1236,7 +1359,7 @@
             this.goToDefinitionToolStripMenuItem,
             this.findAllReferencesToolStripMenuItem});
             this.toolboxContextMenuStrip.Name = "toolboxContextMenuStrip";
-            this.toolboxContextMenuStrip.Size = new System.Drawing.Size(232, 312);
+            this.toolboxContextMenuStrip.Size = new System.Drawing.Size(232, 290);
             // 
             // toolboxDocsToolStripMenuItem
             // 
@@ -1244,7 +1367,7 @@
             this.toolboxDocsToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolboxDocsToolStripMenuItem.Name = "toolboxDocsToolStripMenuItem";
             this.toolboxDocsToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F1;
-            this.toolboxDocsToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.toolboxDocsToolStripMenuItem.Size = new System.Drawing.Size(231, 22);
             this.toolboxDocsToolStripMenuItem.Text = "View Help";
             this.toolboxDocsToolStripMenuItem.Click += new System.EventHandler(this.docsToolStripMenuItem_Click);
             // 
@@ -1252,7 +1375,7 @@
             // 
             this.insertAfterToolStripMenuItem.Name = "insertAfterToolStripMenuItem";
             this.insertAfterToolStripMenuItem.ShortcutKeyDisplayString = "Enter";
-            this.insertAfterToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.insertAfterToolStripMenuItem.Size = new System.Drawing.Size(231, 22);
             this.insertAfterToolStripMenuItem.Text = "Insert After";
             this.insertAfterToolStripMenuItem.Click += new System.EventHandler(this.insertAfterToolStripMenuItem_Click);
             // 
@@ -1260,7 +1383,7 @@
             // 
             this.insertBeforeToolStripMenuItem.Name = "insertBeforeToolStripMenuItem";
             this.insertBeforeToolStripMenuItem.ShortcutKeyDisplayString = "Shift+Enter";
-            this.insertBeforeToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.insertBeforeToolStripMenuItem.Size = new System.Drawing.Size(231, 22);
             this.insertBeforeToolStripMenuItem.Text = "Insert Before";
             this.insertBeforeToolStripMenuItem.Click += new System.EventHandler(this.insertBeforeToolStripMenuItem_Click);
             // 
@@ -1268,7 +1391,7 @@
             // 
             this.createBranchToolStripMenuItem.Name = "createBranchToolStripMenuItem";
             this.createBranchToolStripMenuItem.ShortcutKeyDisplayString = "Alt+Enter";
-            this.createBranchToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.createBranchToolStripMenuItem.Size = new System.Drawing.Size(231, 22);
             this.createBranchToolStripMenuItem.Text = "Create Branch";
             this.createBranchToolStripMenuItem.Click += new System.EventHandler(this.createBranchToolStripMenuItem_Click);
             // 
@@ -1276,7 +1399,7 @@
             // 
             this.createGroupToolStripMenuItem.Name = "createGroupToolStripMenuItem";
             this.createGroupToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+Enter";
-            this.createGroupToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.createGroupToolStripMenuItem.Size = new System.Drawing.Size(231, 22);
             this.createGroupToolStripMenuItem.Text = "Create Group";
             this.createGroupToolStripMenuItem.Click += new System.EventHandler(this.createGroupToolStripMenuItem_Click);
             // 
@@ -1284,7 +1407,7 @@
             // 
             this.subscribeSubjectToolStripMenuItem.Name = "subscribeSubjectToolStripMenuItem";
             this.subscribeSubjectToolStripMenuItem.ShortcutKeyDisplayString = "Enter";
-            this.subscribeSubjectToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.subscribeSubjectToolStripMenuItem.Size = new System.Drawing.Size(231, 22);
             this.subscribeSubjectToolStripMenuItem.Text = "Subscribe";
             this.subscribeSubjectToolStripMenuItem.Click += new System.EventHandler(this.insertAfterToolStripMenuItem_Click);
             // 
@@ -1292,7 +1415,7 @@
             // 
             this.multicastSubjectToolStripMenuItem.Name = "multicastSubjectToolStripMenuItem";
             this.multicastSubjectToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+Enter";
-            this.multicastSubjectToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.multicastSubjectToolStripMenuItem.Size = new System.Drawing.Size(231, 22);
             this.multicastSubjectToolStripMenuItem.Text = "Multicast";
             this.multicastSubjectToolStripMenuItem.Click += new System.EventHandler(this.createGroupToolStripMenuItem_Click);
             // 
@@ -1300,7 +1423,7 @@
             // 
             this.replaceToolStripMenuItem.Name = "replaceToolStripMenuItem";
             this.replaceToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+Alt+Enter";
-            this.replaceToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.replaceToolStripMenuItem.Size = new System.Drawing.Size(231, 22);
             this.replaceToolStripMenuItem.Text = "Replace";
             this.replaceToolStripMenuItem.Click += new System.EventHandler(this.replaceToolStripMenuItem_Click);
             // 
@@ -1308,7 +1431,7 @@
             // 
             this.renameSubjectToolStripMenuItem.Name = "renameSubjectToolStripMenuItem";
             this.renameSubjectToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F2;
-            this.renameSubjectToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.renameSubjectToolStripMenuItem.Size = new System.Drawing.Size(231, 22);
             this.renameSubjectToolStripMenuItem.Text = "Rename";
             this.renameSubjectToolStripMenuItem.Click += new System.EventHandler(this.renameSubjectToolStripMenuItem_Click);
             // 
@@ -1318,7 +1441,7 @@
             this.findNextToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.findNextToolStripMenuItem.Name = "findNextToolStripMenuItem";
             this.findNextToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
-            this.findNextToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.findNextToolStripMenuItem.Size = new System.Drawing.Size(231, 22);
             this.findNextToolStripMenuItem.Text = "Find Next";
             this.findNextToolStripMenuItem.Click += new System.EventHandler(this.findNextToolStripMenuItem_Click);
             // 
@@ -1328,7 +1451,7 @@
             this.findPreviousToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.findPreviousToolStripMenuItem.Name = "findPreviousToolStripMenuItem";
             this.findPreviousToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F3)));
-            this.findPreviousToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.findPreviousToolStripMenuItem.Size = new System.Drawing.Size(231, 22);
             this.findPreviousToolStripMenuItem.Text = "Find Previous";
             this.findPreviousToolStripMenuItem.Click += new System.EventHandler(this.findPreviousToolStripMenuItem_Click);
             // 
@@ -1336,7 +1459,7 @@
             // 
             this.goToDefinitionToolStripMenuItem.Name = "goToDefinitionToolStripMenuItem";
             this.goToDefinitionToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F12;
-            this.goToDefinitionToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.goToDefinitionToolStripMenuItem.Size = new System.Drawing.Size(231, 22);
             this.goToDefinitionToolStripMenuItem.Text = "Go To Definition";
             this.goToDefinitionToolStripMenuItem.Click += new System.EventHandler(this.goToDefinitionToolStripMenuItem_Click);
             // 
@@ -1363,64 +1486,6 @@
     "*.tiff)|*.tif;*.tiff|PNG (*.png)|*.png|SVG (*.svg)|*.svg";
             this.exportImageDialog.FilterIndex = 6;
             // 
-            // explorerSplitContainer
-            // 
-            this.explorerSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.explorerSplitContainer.Location = new System.Drawing.Point(0, 0);
-            this.explorerSplitContainer.Name = "explorerSplitContainer";
-            this.explorerSplitContainer.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            // 
-            // explorerSplitContainer.Panel1
-            // 
-            this.explorerSplitContainer.Panel1.Controls.Add(this.toolboxLayoutPanel);
-            // 
-            // explorerSplitContainer.Panel2
-            // 
-            this.explorerSplitContainer.Panel2.Controls.Add(this.explorerLayoutPanel);
-            this.explorerSplitContainer.Size = new System.Drawing.Size(200, 340);
-            this.explorerSplitContainer.SplitterDistance = 170;
-            this.explorerSplitContainer.TabIndex = 2;
-            // 
-            // explorerLayoutPanel
-            // 
-            this.explorerLayoutPanel.ColumnCount = 1;
-            this.explorerLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.explorerLayoutPanel.Controls.Add(this.explorerTreeView, 0, 1);
-            this.explorerLayoutPanel.Controls.Add(this.explorerLabel, 0, 0);
-            this.explorerLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.explorerLayoutPanel.Location = new System.Drawing.Point(0, 0);
-            this.explorerLayoutPanel.Name = "explorerLayoutPanel";
-            this.explorerLayoutPanel.Padding = new System.Windows.Forms.Padding(0, 6, 0, 0);
-            this.explorerLayoutPanel.RowCount = 2;
-            this.explorerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 23F));
-            this.explorerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.explorerLayoutPanel.Size = new System.Drawing.Size(200, 166);
-            this.explorerLayoutPanel.TabIndex = 2;
-            // 
-            // explorerLabel
-            // 
-            this.explorerLabel.AutoSize = true;
-            this.explorerLabel.BackColor = System.Drawing.SystemColors.ScrollBar;
-            this.explorerLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.explorerLabel.Location = new System.Drawing.Point(3, 6);
-            this.explorerLabel.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
-            this.explorerLabel.Name = "explorerLabel";
-            this.explorerLabel.Size = new System.Drawing.Size(197, 23);
-            this.explorerLabel.TabIndex = 2;
-            this.explorerLabel.Text = "Explorer";
-            this.explorerLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // explorerTreeView
-            // 
-            this.explorerTreeView.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.explorerTreeView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.explorerTreeView.Location = new System.Drawing.Point(0, 29);
-            this.explorerTreeView.Margin = new System.Windows.Forms.Padding(3, 0, 0, 3);
-            this.explorerTreeView.Name = "explorerTreeView";
-            this.explorerTreeView.Size = new System.Drawing.Size(200, 137);
-            this.explorerTreeView.TabIndex = 3;
-            this.explorerTreeView.Navigate += new Bonsai.Editor.WorkflowNavigateEventHandler(explorerTreeView_Navigate);
-            // 
             // EditorForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1446,6 +1511,17 @@
             this.statusStrip.ResumeLayout(false);
             this.statusStrip.PerformLayout();
             this.statusContextMenuStrip.ResumeLayout(false);
+            this.propertyGridContextMenuStrip.ResumeLayout(false);
+            this.panelSplitContainer.Panel1.ResumeLayout(false);
+            this.panelSplitContainer.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.panelSplitContainer)).EndInit();
+            this.panelSplitContainer.ResumeLayout(false);
+            this.explorerSplitContainer.Panel1.ResumeLayout(false);
+            this.explorerSplitContainer.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.explorerSplitContainer)).EndInit();
+            this.explorerSplitContainer.ResumeLayout(false);
+            this.toolboxLayoutPanel.ResumeLayout(false);
+            this.toolboxLayoutPanel.PerformLayout();
             this.toolboxSplitContainer.Panel1.ResumeLayout(false);
             this.toolboxSplitContainer.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.toolboxSplitContainer)).EndInit();
@@ -1453,31 +1529,20 @@
             this.toolboxTableLayoutPanel.ResumeLayout(false);
             this.toolboxTableLayoutPanel.PerformLayout();
             this.toolboxDescriptionPanel.ResumeLayout(false);
-            this.propertiesSplitContainer.Panel1.ResumeLayout(false);
-            this.propertiesSplitContainer.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.propertiesSplitContainer)).EndInit();
-            this.propertiesSplitContainer.ResumeLayout(false);
-            this.propertiesDescriptionPanel.ResumeLayout(false);
-            this.propertyGridContextMenuStrip.ResumeLayout(false);
-            this.panelSplitContainer.Panel1.ResumeLayout(false);
-            this.panelSplitContainer.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.panelSplitContainer)).EndInit();
-            this.panelSplitContainer.ResumeLayout(false);
-            this.toolboxLayoutPanel.ResumeLayout(false);
-            this.toolboxLayoutPanel.PerformLayout();
+            this.explorerLayoutPanel.ResumeLayout(false);
+            this.explorerLayoutPanel.PerformLayout();
             this.workflowSplitContainer.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.workflowSplitContainer)).EndInit();
             this.workflowSplitContainer.ResumeLayout(false);
             this.propertiesLayoutPanel.ResumeLayout(false);
             this.propertiesLayoutPanel.PerformLayout();
+            this.propertiesSplitContainer.Panel1.ResumeLayout(false);
+            this.propertiesSplitContainer.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.propertiesSplitContainer)).EndInit();
+            this.propertiesSplitContainer.ResumeLayout(false);
+            this.propertiesDescriptionPanel.ResumeLayout(false);
             this.toolboxContextMenuStrip.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.workflowFileWatcher)).EndInit();
-            this.explorerSplitContainer.Panel1.ResumeLayout(false);
-            this.explorerSplitContainer.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.explorerSplitContainer)).EndInit();
-            this.explorerSplitContainer.ResumeLayout(false);
-            this.explorerLayoutPanel.ResumeLayout(false);
-            this.explorerLayoutPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1601,12 +1666,19 @@
         private System.Windows.Forms.ContextMenuStrip statusContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem statusCopyToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem toolboxDocsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
-        private System.Windows.Forms.ToolStripMenuItem watchToolStripMenuItem;
         private System.Windows.Forms.SplitContainer explorerSplitContainer;
         private Bonsai.Editor.TableLayoutPanel explorerLayoutPanel;
         private Bonsai.Editor.Label explorerLabel;
         private Bonsai.Editor.ExplorerTreeView explorerTreeView;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator12;
+        private System.Windows.Forms.ToolStripButton addWatchToolStripButton;
+        private System.Windows.Forms.ToolStripButton deleteWatchToolStripButton;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator13;
+        private System.Windows.Forms.ToolStripMenuItem addWatchToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem deleteWatchToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator14;
+        private System.Windows.Forms.ToolStripMenuItem showFindResultsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showWatchToolStripMenuItem;
     }
 }
 

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2291,21 +2291,12 @@ namespace Bonsai.Editor
             }
         }
 
-        private void addWatchToolStripMenuItem_Click(object sender, EventArgs e)
+        private void toggleWatchToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var model = selectionModel.SelectedView;
             if (model?.GraphView.Focused is true)
             {
-                model.AddWatch(selectionModel.SelectedNodes);
-            }
-        }
-
-        private void deleteWatchToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            var model = selectionModel.SelectedView;
-            if (model?.GraphView.Focused is true)
-            {
-                model.DeleteWatch(selectionModel.SelectedNodes);
+                model.ToggleWatch(selectionModel.SelectedNodes);
             }
         }
 
@@ -2737,8 +2728,7 @@ namespace Bonsai.Editor
                 HandleMenuItemShortcutKeys(e, siteForm.findNextToolStripMenuItem, siteForm.findNextToolStripMenuItem_Click);
                 HandleMenuItemShortcutKeys(e, siteForm.findPreviousToolStripMenuItem, siteForm.findPreviousToolStripMenuItem_Click);
                 HandleMenuItemShortcutKeys(e, siteForm.findAllReferencesToolStripMenuItem, siteForm.findAllReferencesToolStripMenuItem_Click);
-                HandleMenuItemShortcutKeys(e, siteForm.addWatchToolStripMenuItem, siteForm.addWatchToolStripMenuItem_Click);
-                HandleMenuItemShortcutKeys(e, siteForm.deleteWatchToolStripMenuItem, siteForm.deleteWatchToolStripMenuItem_Click);
+                HandleMenuItemShortcutKeys(e, siteForm.toggleWatchToolStripMenuItem, siteForm.toggleWatchToolStripMenuItem_Click);
                 HandleMenuItemShortcutKeys(e, siteForm.docsToolStripMenuItem, siteForm.docsToolStripMenuItem_Click);
             }
 

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1289,7 +1289,6 @@ namespace Bonsai.Editor
                 groupToolStripMenuItem.Enabled = true;
                 cutToolStripMenuItem.Enabled = true;
                 pasteToolStripMenuItem.Enabled = true;
-                watchToolStripMenuItem.Enabled = true;
                 startToolStripSplitButton.Enabled = startToolStripMenuItem.Enabled = startWithoutDebuggingToolStripMenuItem.Enabled = true;
                 stopToolStripButton.Visible = stopToolStripMenuItem.Visible = stopToolStripButton.Enabled = stopToolStripMenuItem.Enabled = false;
                 restartToolStripButton.Visible = restartToolStripMenuItem.Visible = restartToolStripButton.Enabled = restartToolStripMenuItem.Enabled = false;
@@ -1359,7 +1358,6 @@ namespace Bonsai.Editor
             groupToolStripMenuItem.Enabled = false;
             cutToolStripMenuItem.Enabled = false;
             pasteToolStripMenuItem.Enabled = false;
-            watchToolStripMenuItem.Enabled = false;
             startToolStripSplitButton.Enabled = startToolStripMenuItem.Enabled = startWithoutDebuggingToolStripMenuItem.Enabled = false;
             stopToolStripButton.Visible = stopToolStripMenuItem.Visible = stopToolStripButton.Enabled = stopToolStripMenuItem.Enabled = true;
             restartToolStripButton.Visible = restartToolStripMenuItem.Visible = restartToolStripButton.Enabled = restartToolStripMenuItem.Enabled = true;
@@ -2293,13 +2291,32 @@ namespace Bonsai.Editor
             }
         }
 
-        #endregion
-
-        #region Watch
-
-        private void watchToolStripMenuItem_Click(object sender, EventArgs e)
+        private void addWatchToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            workflowWatch.Enabled = watchToolStripMenuItem.Checked;
+            var model = selectionModel.SelectedView;
+            if (model?.GraphView.Focused is true)
+            {
+                model.AddWatch(selectionModel.SelectedNodes);
+            }
+        }
+
+        private void deleteWatchToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var model = selectionModel.SelectedView;
+            if (model?.GraphView.Focused is true)
+            {
+                model.DeleteWatch(selectionModel.SelectedNodes);
+            }
+        }
+
+        private void showFindResultsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            editorControl.ShowFindResults();
+        }
+
+        private void showWatchToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            editorControl.ShowWatchTool();
         }
 
         #endregion
@@ -2720,6 +2737,8 @@ namespace Bonsai.Editor
                 HandleMenuItemShortcutKeys(e, siteForm.findNextToolStripMenuItem, siteForm.findNextToolStripMenuItem_Click);
                 HandleMenuItemShortcutKeys(e, siteForm.findPreviousToolStripMenuItem, siteForm.findPreviousToolStripMenuItem_Click);
                 HandleMenuItemShortcutKeys(e, siteForm.findAllReferencesToolStripMenuItem, siteForm.findAllReferencesToolStripMenuItem_Click);
+                HandleMenuItemShortcutKeys(e, siteForm.addWatchToolStripMenuItem, siteForm.addWatchToolStripMenuItem_Click);
+                HandleMenuItemShortcutKeys(e, siteForm.deleteWatchToolStripMenuItem, siteForm.deleteWatchToolStripMenuItem_Click);
                 HandleMenuItemShortcutKeys(e, siteForm.docsToolStripMenuItem, siteForm.docsToolStripMenuItem_Click);
             }
 

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -72,6 +72,7 @@ namespace Bonsai.Editor
         readonly List<WorkflowElementDescriptor> workflowExtensions;
         readonly WorkflowRuntimeExceptionCache exceptionCache;
         readonly CancellationTokenSource formCancellation;
+        readonly WorkflowWatch workflowWatch;
         readonly string definitionsPath;
         AttributeCollection browsableAttributes;
         DirectoryInfo extensionsPath;
@@ -152,6 +153,7 @@ namespace Bonsai.Editor
             }
 
             serviceProvider = provider;
+            workflowWatch = new WorkflowWatch();
             treeCache = new List<TreeNode>();
             editorSite = new EditorSite(this);
             hotKeys = new HotKeyMessageFilter();
@@ -1294,6 +1296,7 @@ namespace Bonsai.Editor
                 }
 
                 running = null;
+                workflowWatch.Stop();
                 if (visualizerWindows != null)
                 {
                     visualizerSettings.Update(visualizerWindows);
@@ -1323,6 +1326,7 @@ namespace Bonsai.Editor
                         var runtimeWorkflow = workflowBuilder.Workflow.BuildObservable();
                         Invoke(() =>
                         {
+                            if (debug) workflowWatch.Start(workflowBuilder.Workflow);
                             statusTextLabel.Text = Resources.RunningStatus;
                             statusImageLabel.Image = statusRunningImage;
                             visualizerWindows.Show(visualizerSettings, editorSite, this);
@@ -2618,6 +2622,11 @@ namespace Bonsai.Editor
                 if (serviceType == typeof(SvgRendererFactory))
                 {
                     return siteForm.iconRenderer;
+                }
+
+                if (serviceType == typeof(WorkflowWatch))
+                {
+                    return siteForm.workflowWatch;
                 }
 
                 if (serviceType == typeof(DialogTypeVisualizer))

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1286,6 +1286,7 @@ namespace Bonsai.Editor
                 groupToolStripMenuItem.Enabled = true;
                 cutToolStripMenuItem.Enabled = true;
                 pasteToolStripMenuItem.Enabled = true;
+                watchToolStripMenuItem.Enabled = true;
                 startToolStripSplitButton.Enabled = startToolStripMenuItem.Enabled = startWithoutDebuggingToolStripMenuItem.Enabled = true;
                 stopToolStripButton.Visible = stopToolStripMenuItem.Visible = stopToolStripButton.Enabled = stopToolStripMenuItem.Enabled = false;
                 restartToolStripButton.Visible = restartToolStripMenuItem.Visible = restartToolStripButton.Enabled = restartToolStripMenuItem.Enabled = false;
@@ -1326,7 +1327,8 @@ namespace Bonsai.Editor
                         var runtimeWorkflow = workflowBuilder.Workflow.BuildObservable();
                         Invoke(() =>
                         {
-                            if (debug) workflowWatch.Start(workflowBuilder.Workflow);
+                            if (watchToolStripMenuItem.Checked)
+                                workflowWatch.Start(workflowBuilder.Workflow);
                             statusTextLabel.Text = Resources.RunningStatus;
                             statusImageLabel.Image = statusRunningImage;
                             visualizerWindows.Show(visualizerSettings, editorSite, this);
@@ -1353,6 +1355,7 @@ namespace Bonsai.Editor
             groupToolStripMenuItem.Enabled = false;
             cutToolStripMenuItem.Enabled = false;
             pasteToolStripMenuItem.Enabled = false;
+            watchToolStripMenuItem.Enabled = false;
             startToolStripSplitButton.Enabled = startToolStripMenuItem.Enabled = startWithoutDebuggingToolStripMenuItem.Enabled = false;
             stopToolStripButton.Visible = stopToolStripMenuItem.Visible = stopToolStripButton.Enabled = stopToolStripMenuItem.Enabled = true;
             restartToolStripButton.Visible = restartToolStripMenuItem.Visible = restartToolStripButton.Enabled = restartToolStripMenuItem.Enabled = true;
@@ -2284,6 +2287,15 @@ namespace Bonsai.Editor
             {
                 model.Editor.DisableGraphNodes(selectionModel.SelectedNodes);
             }
+        }
+
+        #endregion
+
+        #region Watch
+
+        private void watchToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            workflowWatch.Enabled = watchToolStripMenuItem.Checked;
         }
 
         #endregion

--- a/Bonsai.Editor/GraphModel/GraphNode.cs
+++ b/Bonsai.Editor/GraphModel/GraphNode.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using Bonsai.Editor.Diagnostics;
 using Bonsai.Expressions;
 
 namespace Bonsai.Editor.GraphModel
@@ -163,6 +164,10 @@ namespace Bonsai.Editor.GraphModel
                 else Flags &= ~NodeFlags.Highlight;
             }
         }
+
+        public WorkflowElementStatus? Status { get; set; }
+
+        public int NotifyingCounter { get; set; }
 
 
         /// <summary>

--- a/Bonsai.Editor/GraphModel/GraphNode.cs
+++ b/Bonsai.Editor/GraphModel/GraphNode.cs
@@ -167,8 +167,7 @@ namespace Bonsai.Editor.GraphModel
 
         public WorkflowElementStatus? Status { get; set; }
 
-        public int NotifyingCounter { get; set; }
-
+        public int NotifyingCounter { get; set; } = -1;
 
         /// <summary>
         /// Returns a string that represents the value of this <see cref="GraphNode"/> instance.

--- a/Bonsai.Editor/GraphModel/WorkflowQuery.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowQuery.cs
@@ -91,9 +91,10 @@ namespace Bonsai.Editor.GraphModel
             this WorkflowBuilder source,
             Func<ExpressionBuilder, bool> predicate,
             ExpressionBuilder current,
-            bool findPrevious)
+            bool findPrevious,
+            bool unwrap = true)
         {
-            var matches = FindAll(source, predicate);
+            var matches = FindAll(source, predicate, unwrap);
             if (current != null)
             {
                 if (findPrevious)
@@ -106,9 +107,10 @@ namespace Bonsai.Editor.GraphModel
 
         public static IEnumerable<WorkflowQueryResult> FindAll(
             this WorkflowBuilder source,
-            Func<ExpressionBuilder, bool> predicate)
+            Func<ExpressionBuilder, bool> predicate,
+            bool unwrap = true)
         {
-            return Query(source.Workflow, predicate);
+            return Query(source.Workflow, predicate, unwrap);
         }
 
         public static WorkflowQueryResult FindReference(
@@ -164,6 +166,7 @@ namespace Bonsai.Editor.GraphModel
         static IEnumerable<WorkflowQueryResult> Query(
             ExpressionBuilderGraph workflow,
             Func<ExpressionBuilder, bool> predicate,
+            bool unwrap = true,
             WorkflowEditorPath parent = null)
         {
             for (int i = 0; i < workflow.Count; i++)
@@ -171,13 +174,13 @@ namespace Bonsai.Editor.GraphModel
                 var node = workflow[i];
                 WorkflowEditorPath path = null;
                 var builder = ExpressionBuilder.Unwrap(node.Value);
-                if (predicate(builder))
+                if (predicate(unwrap ? builder : node.Value))
                     yield return new WorkflowQueryResult(node.Value, path = new WorkflowEditorPath(i, parent));
 
                 if (builder is IWorkflowExpressionBuilder workflowBuilder && workflowBuilder.Workflow is not null)
                 {
                     path ??= new WorkflowEditorPath(i, parent);
-                    foreach (var result in Query(workflowBuilder.Workflow, predicate, path))
+                    foreach (var result in Query(workflowBuilder.Workflow, predicate, unwrap, path))
                     {
                         yield return result;
                     }

--- a/Bonsai.Editor/GraphView/GraphViewControl.cs
+++ b/Bonsai.Editor/GraphView/GraphViewControl.cs
@@ -233,15 +233,15 @@ namespace Bonsai.Editor.GraphView
             remove { Events.RemoveHandler(EventSelectedNodeChanged, value); }
         }
 
-        public Color FocusedSelectionColor { get; set; }
+        public Color FocusedSelectionColor { get; private set; }
 
-        public Color ContrastSelectionColor { get; set; }
+        public Color ContrastSelectionColor { get; private set; }
 
-        public Color UnfocusedSelectionColor { get; set; }
+        public Color UnfocusedSelectionColor { get; private set; }
 
-        public Color CursorColor { get; set; }
+        public Color CursorColor { get; private set; }
 
-        [DefaultValue(null)]
+        [DefaultValue(WorkflowPathFlags.None)]
         public WorkflowPathFlags PathFlags { get; set; }
 
         [DefaultValue(null)]

--- a/Bonsai.Editor/GraphView/GraphViewControl.cs
+++ b/Bonsai.Editor/GraphView/GraphViewControl.cs
@@ -413,7 +413,7 @@ namespace Bonsai.Editor.GraphView
             EntryOffset = new SizeF(-2 * PenWidth, HalfSize);
             ExitOffset = new SizeF(NodeSize + 2 * PenWidth, HalfSize);
             InputPortOffset = new SizeF(-PortSize / 2, EntryOffset.Height - PortSize / 2);
-            OutputPortOffset = new SizeF(NodeSize - PortSize / 2, ExitOffset.Height - PortSize / 2);
+            OutputPortOffset = new SizeF(ExitOffset.Width - PortSize / 2, ExitOffset.Height - PortSize / 2);
             SolidPen = new Pen(NodeEdgeColor, drawScale);
             DashPen = new Pen(NodeEdgeColor, drawScale) { DashPattern = new[] { 4f, 2f } };
             DefaultIconFont = new Font(Font, FontStyle.Bold);

--- a/Bonsai.Editor/GraphView/GraphViewControl.cs
+++ b/Bonsai.Editor/GraphView/GraphViewControl.cs
@@ -1172,8 +1172,9 @@ namespace Bonsai.Editor.GraphView
                 var outputPortRectangle = layout.OutputPortRectangle;
                 var outputPortBrush = nodeStatus switch
                 {
-                    Diagnostics.WorkflowElementStatus.Completed => Brushes.Green,
+                    Diagnostics.WorkflowElementStatus.Completed => Brushes.LimeGreen,
                     Diagnostics.WorkflowElementStatus.Error => Brushes.Red,
+                    Diagnostics.WorkflowElementStatus.Canceled => Brushes.Orange,
                     _ => Brushes.White
                 };
                 outputPortRectangle.Offset(offset.Width, offset.Height);
@@ -1181,7 +1182,8 @@ namespace Bonsai.Editor.GraphView
                 var active = nodeStatus == Diagnostics.WorkflowElementStatus.Active ||
                              nodeStatus == Diagnostics.WorkflowElementStatus.Notifying;
                 var terminated = nodeStatus == Diagnostics.WorkflowElementStatus.Completed ||
-                                 nodeStatus == Diagnostics.WorkflowElementStatus.Error;
+                                 nodeStatus == Diagnostics.WorkflowElementStatus.Error ||
+                                 nodeStatus == Diagnostics.WorkflowElementStatus.Canceled;
                 var edgeColor = active || terminated ? CursorColor : NodeEdgeColor;
 
                 graphics.DrawEllipse(iconRendererState.StrokeStyle(edgeColor, PenWidth), outputPortRectangle);

--- a/Bonsai.Editor/GraphView/GraphViewControl.cs
+++ b/Bonsai.Editor/GraphView/GraphViewControl.cs
@@ -20,7 +20,7 @@ namespace Bonsai.Editor.GraphView
         const float DefaultPenWidth = 2;
         const float DefaultNodeSize = 30;
         const float DefaultNodeAirspace = 80;
-        const float DefaultConnectorSize = 6;
+        const float DefaultPortSize = 6;
         const float DefaultLabelTextOffset = 5;
         static readonly Color CursorLight = Color.White;
         static readonly Color CursorDark = Color.Black;
@@ -34,36 +34,36 @@ namespace Bonsai.Editor.GraphView
         static readonly Color RubberBandPenColor = Color.FromArgb(51, 153, 255);
         static readonly Color RubberBandBrushColor = Color.FromArgb(128, 170, 204, 238);
         static readonly Color HotBrushColor = Color.FromArgb(128, 229, 243, 251);
-        static readonly StringFormat TextFormat = new StringFormat(StringFormatFlags.NoWrap);
-        static readonly StringFormat CenteredTextFormat = new StringFormat(StringFormat.GenericTypographic)
+        static readonly StringFormat TextFormat = new(StringFormatFlags.NoWrap);
+        static readonly StringFormat CenteredTextFormat = new(StringFormat.GenericTypographic)
         {
             Alignment = StringAlignment.Center,
             LineAlignment = StringAlignment.Center
         };
-        static readonly StringFormat VectorTextFormat = new StringFormat(StringFormat.GenericTypographic)
+        static readonly StringFormat VectorTextFormat = new(StringFormat.GenericTypographic)
         {
             FormatFlags = StringFormatFlags.NoWrap,
             Trimming = StringTrimming.Character
         };
 
-        static readonly object EventItemDrag = new object();
-        static readonly object EventNodeMouseClick = new object();
-        static readonly object EventNodeMouseDoubleClick = new object();
-        static readonly object EventNodeMouseEnter = new object();
-        static readonly object EventNodeMouseLeave = new object();
-        static readonly object EventNodeMouseHover = new object();
-        static readonly object EventSelectedNodeChanged = new object();
+        static readonly object EventItemDrag = new();
+        static readonly object EventNodeMouseClick = new();
+        static readonly object EventNodeMouseDoubleClick = new();
+        static readonly object EventNodeMouseEnter = new();
+        static readonly object EventNodeMouseLeave = new();
+        static readonly object EventNodeMouseHover = new();
+        static readonly object EventSelectedNodeChanged = new();
 
         float PenWidth;
         float NodeAirspace;
         float NodeSize;
         float HalfSize;
-        float ConnectorSize;
+        float PortSize;
         float LabelTextOffset;
         SizeF VectorTextOffset;
         SizeF EntryOffset;
         SizeF ExitOffset;
-        SizeF ConnectorOffset;
+        SizeF InputPortOffset;
         Pen SolidPen;
         Pen DashPen;
         Font DefaultIconFont;
@@ -75,9 +75,9 @@ namespace Bonsai.Editor.GraphView
         RectangleF previousRectangle;
         Point? previousScrollOffset;
         GraphNode[] selectionBeforeDrag;
-        readonly LayoutNodeCollection layoutNodes = new LayoutNodeCollection();
-        readonly HashSet<GraphNode> selectedNodes = new HashSet<GraphNode>();
-        readonly SvgRendererState iconRendererState = new SvgRendererState();
+        readonly LayoutNodeCollection layoutNodes = new();
+        readonly HashSet<GraphNode> selectedNodes = new();
+        readonly SvgRendererState iconRendererState = new();
         IReadOnlyList<GraphNodeGrouping> nodes;
         GraphNode pivot;
         GraphNode hot;
@@ -406,12 +406,12 @@ namespace Bonsai.Editor.GraphView
             NodeAirspace = DefaultNodeAirspace * drawScale;
             NodeSize = DefaultNodeSize * drawScale;
             HalfSize = NodeSize / 2;
-            ConnectorSize = DefaultConnectorSize * drawScale;
+            PortSize = DefaultPortSize * drawScale;
             LabelTextOffset = DefaultLabelTextOffset * drawScale;
             VectorTextOffset = new SizeF(0, 1.375f * drawScale);
-            EntryOffset = new SizeF(-2 * DefaultPenWidth * drawScale, DefaultNodeSize * drawScale / 2);
-            ExitOffset = new SizeF(NodeSize + 2 * DefaultPenWidth * drawScale, DefaultNodeSize * drawScale / 2);
-            ConnectorOffset = new SizeF(-ConnectorSize / 2, EntryOffset.Height - ConnectorSize / 2);
+            EntryOffset = new SizeF(-2 * PenWidth, HalfSize);
+            ExitOffset = new SizeF(NodeSize + 2 * PenWidth, HalfSize);
+            InputPortOffset = new SizeF(-PortSize / 2, EntryOffset.Height - PortSize / 2);
             SolidPen = new Pen(NodeEdgeColor, drawScale);
             DashPen = new Pen(NodeEdgeColor, drawScale) { DashPattern = new[] { 4f, 2f } };
             DefaultIconFont = new Font(Font, FontStyle.Bold);
@@ -431,11 +431,9 @@ namespace Bonsai.Editor.GraphView
             var labelRectangle = nodeLayout.LabelRectangle;
             if (nodeText != nodeLayout.Text)
             {
-                using (var graphics = CreateVectorGraphics())
-                {
-                    nodeLayout.SetNodeLabel(nodeText, Font, graphics);
-                    labelRectangle = RectangleF.Union(labelRectangle, nodeLayout.LabelRectangle);
-                }
+                using var graphics = CreateVectorGraphics();
+                nodeLayout.SetNodeLabel(nodeText, Font, graphics);
+                labelRectangle = RectangleF.Union(labelRectangle, nodeLayout.LabelRectangle);
             }
 
             labelRectangle.Offset(offset);
@@ -600,11 +598,11 @@ namespace Bonsai.Editor.GraphView
             if (rect.HasValue)
             {
                 var selection = new HashSet<GraphNode>(GetRubberBandSelection(rect.Value));
-                if (Control.ModifierKeys.HasFlag(Keys.Control))
+                if (ModifierKeys.HasFlag(Keys.Control))
                 {
                     selection.SymmetricExceptWith(selectionBeforeDrag);
                 }
-                else if (Control.ModifierKeys.HasFlag(Keys.Shift))
+                else if (ModifierKeys.HasFlag(Keys.Shift))
                 {
                     selection.UnionWith(selectionBeforeDrag);
                 }
@@ -651,7 +649,7 @@ namespace Bonsai.Editor.GraphView
             return point;
         }
 
-        Rectangle GetNormalizedRectangle(Point p1, Point p2)
+        static Rectangle GetNormalizedRectangle(Point p1, Point p2)
         {
             return new Rectangle(
                 Math.Min(p1.X, p2.X),
@@ -660,19 +658,19 @@ namespace Bonsai.Editor.GraphView
                 Math.Abs(p2.Y - p1.Y));
         }
 
-        float SquaredDistance(ref PointF point, ref PointF center)
+        static float SquaredDistance(ref PointF point, ref PointF center)
         {
             var xdiff = point.X - center.X;
             var ydiff = point.Y - center.Y;
             return xdiff * xdiff + ydiff * ydiff;
         }
 
-        bool CircleIntersect(PointF center, float radius, PointF point)
+        static bool CircleIntersect(PointF center, float radius, PointF point)
         {
             return SquaredDistance(ref point, ref center) <= radius * radius;
         }
 
-        bool CircleIntersect(PointF center, float radius, RectangleF rect)
+        static bool CircleIntersect(PointF center, float radius, RectangleF rect)
         {
             float closestX = Math.Max(rect.Left, Math.Min(center.X, rect.Right));
             float closestY = Math.Max(rect.Top, Math.Min(center.Y, rect.Bottom));
@@ -764,7 +762,7 @@ namespace Bonsai.Editor.GraphView
             return source;
         }
 
-        GraphNode ResolveDummySuccessor(GraphNode source)
+        static GraphNode ResolveDummySuccessor(GraphNode source)
         {
             while (source.Value == null)
             {
@@ -774,7 +772,7 @@ namespace Bonsai.Editor.GraphView
             return source;
         }
 
-        GraphNode GetDefaultSuccessor(GraphNode node)
+        static GraphNode GetDefaultSuccessor(GraphNode node)
         {
             return (from successor in node.Successors
                     orderby successor.Node.LayerIndex ascending
@@ -941,7 +939,7 @@ namespace Bonsai.Editor.GraphView
             if (!any) foreach (var xs in second) yield return xs;
         }
 
-        private IEnumerable<GraphNode> GetSelectionRange(GraphNode from, GraphNode to)
+        static private IEnumerable<GraphNode> GetSelectionRange(GraphNode from, GraphNode to)
         {
             return ConcatEmpty(
                 ConcatEmpty(GetAllPaths(from, to), GetAllPaths(to, from)),
@@ -1140,12 +1138,12 @@ namespace Bonsai.Editor.GraphView
             if (hot) graphics.FillEllipse(iconRendererState.FillStyle(HotBrushColor), nodeRectangle);
             if (layout.Node.ArgumentCount < layout.Node.ArgumentRange.UpperBound)
             {
-                var connectorRectangle = layout.ConnectorRectangle;
+                var inputPortRectangle = layout.InputPortRectangle;
                 var argumentRequired = layout.Node.ArgumentCount < layout.Node.ArgumentRange.LowerBound;
-                var connectorBrush = argumentRequired ? Brushes.Black : Brushes.White;
-                connectorRectangle.Offset(offset.Width, offset.Height);
-                graphics.DrawEllipse(iconRendererState.StrokeStyle(NodeEdgeColor, PenWidth), connectorRectangle);
-                graphics.FillEllipse(connectorBrush, connectorRectangle);
+                var inputPortBrush = argumentRequired ? Brushes.Black : Brushes.White;
+                inputPortRectangle.Offset(offset.Width, offset.Height);
+                graphics.DrawEllipse(iconRendererState.StrokeStyle(NodeEdgeColor, PenWidth), inputPortRectangle);
+                graphics.FillEllipse(inputPortBrush, inputPortRectangle);
             }
         }
 
@@ -1180,36 +1178,31 @@ namespace Bonsai.Editor.GraphView
             graphics.SmoothingMode = SmoothingMode.AntiAlias;
             graphics.Clear(Color.White);
 
-            using (var measureGraphics = CreateVectorGraphics())
+            var font = Font;
+            using var measureGraphics = CreateVectorGraphics();
+            using var fill = new SolidBrush(Color.White);
+            using var stroke = new Pen(NodeEdgeColor, PenWidth);
+            DrawEdges(graphics, Size.Empty);
+            foreach (var layout in layoutNodes)
             {
-                var font = Font;
-                using (var fill = new SolidBrush(Color.White))
-                using (var stroke = new Pen(NodeEdgeColor, PenWidth))
+                if (layout.Node.Value != null)
                 {
-                    DrawEdges(graphics, Size.Empty);
-                    foreach (var layout in layoutNodes)
+                    DrawNode(graphics, layout, Size.Empty, null, fill, stroke, Color.White, vectorFont: font);
+                    var labelRect = layout.LabelRectangle;
+                    foreach (var line in layout.Label.Split(Environment.NewLine.ToArray(),
+                                                            StringSplitOptions.RemoveEmptyEntries))
                     {
-                        if (layout.Node.Value != null)
-                        {
-                            DrawNode(graphics, layout, Size.Empty, null, fill, stroke, Color.White, vectorFont: font);
-                            var labelRect = layout.LabelRectangle;
-                            foreach (var line in layout.Label.Split(Environment.NewLine.ToArray(),
-                                                                    StringSplitOptions.RemoveEmptyEntries))
-                            {
-                                int charactersFitted, linesFilled;
-                                var size = measureGraphics.MeasureString(
-                                    line, font,
-                                    labelRect.Size,
-                                    VectorTextFormat,
-                                    out charactersFitted, out linesFilled);
-                                var lineLabel = line.Length > charactersFitted ? line.Substring(0, charactersFitted) : line;
-                                graphics.DrawString(lineLabel, font, Brushes.Black, labelRect);
-                                labelRect.Y += size.Height;
-                            }
-                        }
-                        else DrawDummyNode(graphics, layout, Size.Empty);
+                        var size = measureGraphics.MeasureString(
+                            line, font,
+                            labelRect.Size,
+                            VectorTextFormat,
+                            out int charactersFitted, out _);
+                        var lineLabel = line.Length > charactersFitted ? line.Substring(0, charactersFitted) : line;
+                        graphics.DrawString(lineLabel, font, Brushes.Black, labelRect);
+                        labelRect.Y += size.Height;
                     }
                 }
+                else DrawDummyNode(graphics, layout, Size.Empty);
             }
         }
 
@@ -1262,12 +1255,10 @@ namespace Bonsai.Editor.GraphView
 
             if (rubberBand.Width > 0 && rubberBand.Height > 0)
             {
-                using (var rubberBandPen = new Pen(RubberBandPenColor))
-                using (var rubberBandBrush = new SolidBrush(RubberBandBrushColor))
-                {
-                    e.Graphics.FillRectangle(rubberBandBrush, rubberBand);
-                    e.Graphics.DrawRectangle(rubberBandPen, rubberBand.X, rubberBand.Y, rubberBand.Width, rubberBand.Height);
-                }
+                using var rubberBandPen = new Pen(RubberBandPenColor);
+                using var rubberBandBrush = new SolidBrush(RubberBandBrushColor);
+                e.Graphics.FillRectangle(rubberBandBrush, rubberBand);
+                e.Graphics.DrawRectangle(rubberBandPen, rubberBand.X, rubberBand.Y, rubberBand.Width, rubberBand.Height);
             }
         }
 
@@ -1399,9 +1390,9 @@ namespace Bonsai.Editor.GraphView
                 get { return PointF.Add(Location, View.ExitOffset); }
             }
 
-            public PointF ConnectorLocation
+            public PointF InputPortLocation
             {
-                get { return PointF.Add(Location, View.ConnectorOffset); }
+                get { return PointF.Add(Location, View.InputPortOffset); }
             }
 
             public RectangleF BoundingRectangle
@@ -1409,18 +1400,18 @@ namespace Bonsai.Editor.GraphView
                 get
                 {
                     return new RectangleF(
-                        ConnectorLocation.X - View.PenWidth, Location.Y - View.PenWidth,
-                        View.ConnectorSize / 2 + View.NodeSize + 2 * View.PenWidth, View.NodeSize + 2 * View.PenWidth);
+                        InputPortLocation.X - View.PenWidth, Location.Y - View.PenWidth,
+                        View.PortSize / 2 + View.NodeSize + 2 * View.PenWidth, View.NodeSize + 2 * View.PenWidth);
                 }
             }
 
-            public RectangleF ConnectorRectangle
+            public RectangleF InputPortRectangle
             {
                 get
                 {
                     return new RectangleF(
-                        ConnectorLocation,
-                        new SizeF(View.ConnectorSize, View.ConnectorSize));
+                        InputPortLocation,
+                        new SizeF(View.PortSize, View.PortSize));
                 }
             }
 

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -215,11 +215,16 @@ namespace Bonsai.Editor.GraphView
             }
         }
 
+        public void ShowFindResults()
+        {
+            ActivateToolWindow(findToolWindow);
+        }
+
         public void ShowFindResults(string text, IEnumerable<WorkflowQueryResult> query)
         {
             findToolWindow.Query = query;
             findToolWindow.Text = text;
-            ActivateToolWindow(findToolWindow);
+            ShowFindResults();
         }
 
         public void UpdateWatchTool()

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -203,7 +203,7 @@ namespace Bonsai.Editor.GraphView
             }
         }
 
-        public void SelectTab(WorkflowGraphView workflowGraphView)
+        public void SelectDockContent(WorkflowGraphView workflowGraphView)
         {
             foreach (var content in dockPanel.Contents)
             {

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -227,14 +227,14 @@ namespace Bonsai.Editor.GraphView
             ShowFindResults();
         }
 
-        public void UpdateWatchTool()
+        public void UpdateWatchTool(IEnumerable<InspectBuilder> selectedItems = default)
         {
-            watchToolWindow.UpdateWatchList();
+            watchToolWindow.UpdateWatchList(selectedItems);
         }
 
-        public void ShowWatchTool()
+        public void ShowWatchTool(IEnumerable<InspectBuilder> selectedItems = default)
         {
-            UpdateWatchTool();
+            UpdateWatchTool(selectedItems);
             ActivateToolWindow(watchToolWindow);
         }
 

--- a/Bonsai.Editor/GraphView/WorkflowEditorSettings.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorSettings.cs
@@ -1,0 +1,31 @@
+﻿using System.Xml.Linq;
+using System.Xml.Serialization;
+
+namespace Bonsai.Editor.GraphView
+{
+    [XmlRoot("EditorSettings")]
+    public sealed class WorkflowEditorSettings
+    {
+        [XmlAttribute]
+        public string Version { get; set; }
+
+        [XmlAnyElement]
+        public XElement DockPanel { get; set; }
+
+        public WorkflowWatchSettings WatchSettings { get; set; }
+
+        public static XmlSerializer Serializer
+        {
+            get { return SerializerFactory.instance; }
+        }
+
+        #region SerializerFactory
+
+        static class SerializerFactory
+        {
+            internal static readonly XmlSerializer instance = new(typeof(WorkflowEditorSettings));
+        }
+
+        #endregion
+    }
+}

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
@@ -38,8 +38,13 @@
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.visualizerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.defaultEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
+            this.addWatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.deleteWatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.docsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.goToDefinitionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.findAllReferencesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openNewTabToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openNewWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
@@ -58,7 +63,6 @@
             this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this.enableToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.disableToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.findAllReferencesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.graphView = new Bonsai.Editor.GraphView.GraphViewControl();
             this.contextMenuStrip.SuspendLayout();
             this.SuspendLayout();
@@ -74,6 +78,10 @@
             this.toolStripSeparator3,
             this.visualizerToolStripMenuItem,
             this.defaultEditorToolStripMenuItem,
+            this.toolStripSeparator8,
+            this.addWatchToolStripMenuItem,
+            this.deleteWatchToolStripMenuItem,
+            this.toolStripSeparator4,
             this.docsToolStripMenuItem,
             this.goToDefinitionToolStripMenuItem,
             this.findAllReferencesToolStripMenuItem,
@@ -96,7 +104,7 @@
             this.enableToolStripMenuItem,
             this.disableToolStripMenuItem});
             this.contextMenuStrip.Name = "contextMenuStrip";
-            this.contextMenuStrip.Size = new System.Drawing.Size(250, 568);
+            this.contextMenuStrip.Size = new System.Drawing.Size(250, 624);
             this.contextMenuStrip.Closed += new System.Windows.Forms.ToolStripDropDownClosedEventHandler(this.contextMenuStrip_Closed);
             this.contextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStrip_Opening);
             // 
@@ -155,6 +163,36 @@
             this.defaultEditorToolStripMenuItem.Text = "Show Default Editor...";
             this.defaultEditorToolStripMenuItem.Click += new System.EventHandler(this.defaultEditorToolStripMenuItem_Click);
             // 
+            // toolStripSeparator8
+            // 
+            this.toolStripSeparator8.Name = "toolStripSeparator8";
+            this.toolStripSeparator8.Size = new System.Drawing.Size(246, 6);
+            // 
+            // addWatchToolStripMenuItem
+            // 
+            this.addWatchToolStripMenuItem.Enabled = false;
+            this.addWatchToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.WatchMenuImage;
+            this.addWatchToolStripMenuItem.Name = "addWatchToolStripMenuItem";
+            this.addWatchToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F9;
+            this.addWatchToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
+            this.addWatchToolStripMenuItem.Text = "Add Watch";
+            this.addWatchToolStripMenuItem.Click += new System.EventHandler(this.addWatchToolStripMenuItem_Click);
+            // 
+            // deleteWatchToolStripMenuItem
+            // 
+            this.deleteWatchToolStripMenuItem.Enabled = false;
+            this.deleteWatchToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.DeleteWatchMenuImage;
+            this.deleteWatchToolStripMenuItem.Name = "deleteWatchToolStripMenuItem";
+            this.deleteWatchToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F9)));
+            this.deleteWatchToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
+            this.deleteWatchToolStripMenuItem.Text = "Delete Watch";
+            this.deleteWatchToolStripMenuItem.Click += new System.EventHandler(this.deleteWatchToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator4
+            // 
+            this.toolStripSeparator4.Name = "toolStripSeparator4";
+            this.toolStripSeparator4.Size = new System.Drawing.Size(246, 6);
+            // 
             // docsToolStripMenuItem
             // 
             this.docsToolStripMenuItem.Enabled = false;
@@ -173,6 +211,15 @@
             this.goToDefinitionToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
             this.goToDefinitionToolStripMenuItem.Text = "Go To Definition";
             this.goToDefinitionToolStripMenuItem.Click += new System.EventHandler(this.goToDefinitionToolStripMenuItem_Click);
+            // 
+            // findAllReferencesToolStripMenuItem
+            // 
+            this.findAllReferencesToolStripMenuItem.Enabled = false;
+            this.findAllReferencesToolStripMenuItem.Name = "findAllReferencesToolStripMenuItem";
+            this.findAllReferencesToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F12)));
+            this.findAllReferencesToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
+            this.findAllReferencesToolStripMenuItem.Text = "Find All References";
+            this.findAllReferencesToolStripMenuItem.Click += new System.EventHandler(this.findAllReferencesToolStripMenuItem_Click);
             // 
             // openNewTabToolStripMenuItem
             // 
@@ -333,15 +380,6 @@
             this.disableToolStripMenuItem.Text = "Disable";
             this.disableToolStripMenuItem.Click += new System.EventHandler(this.disableToolStripMenuItem_Click);
             // 
-            // findAllReferencesToolStripMenuItem
-            // 
-            this.findAllReferencesToolStripMenuItem.Enabled = false;
-            this.findAllReferencesToolStripMenuItem.Name = "findAllReferencesToolStripMenuItem";
-            this.findAllReferencesToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F12)));
-            this.findAllReferencesToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
-            this.findAllReferencesToolStripMenuItem.Text = "Find All References";
-            this.findAllReferencesToolStripMenuItem.Click += new System.EventHandler(this.findAllReferencesToolStripMenuItem_Click);
-            // 
             // graphView
             // 
             this.graphView.AllowDrop = true;
@@ -414,5 +452,9 @@
         private System.Windows.Forms.ToolStripMenuItem openNewTabToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openNewWindowToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem findAllReferencesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+        private System.Windows.Forms.ToolStripMenuItem addWatchToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
+        private System.Windows.Forms.ToolStripMenuItem deleteWatchToolStripMenuItem;
     }
 }

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
@@ -39,8 +39,7 @@
             this.visualizerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.defaultEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
-            this.addWatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.deleteWatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toggleWatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.docsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.goToDefinitionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -79,8 +78,7 @@
             this.visualizerToolStripMenuItem,
             this.defaultEditorToolStripMenuItem,
             this.toolStripSeparator8,
-            this.addWatchToolStripMenuItem,
-            this.deleteWatchToolStripMenuItem,
+            this.toggleWatchToolStripMenuItem,
             this.toolStripSeparator4,
             this.docsToolStripMenuItem,
             this.goToDefinitionToolStripMenuItem,
@@ -104,7 +102,7 @@
             this.enableToolStripMenuItem,
             this.disableToolStripMenuItem});
             this.contextMenuStrip.Name = "contextMenuStrip";
-            this.contextMenuStrip.Size = new System.Drawing.Size(250, 624);
+            this.contextMenuStrip.Size = new System.Drawing.Size(250, 602);
             this.contextMenuStrip.Closed += new System.Windows.Forms.ToolStripDropDownClosedEventHandler(this.contextMenuStrip_Closed);
             this.contextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStrip_Opening);
             // 
@@ -168,25 +166,15 @@
             this.toolStripSeparator8.Name = "toolStripSeparator8";
             this.toolStripSeparator8.Size = new System.Drawing.Size(246, 6);
             // 
-            // addWatchToolStripMenuItem
+            // toggleWatchToolStripMenuItem
             // 
-            this.addWatchToolStripMenuItem.Enabled = false;
-            this.addWatchToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.WatchMenuImage;
-            this.addWatchToolStripMenuItem.Name = "addWatchToolStripMenuItem";
-            this.addWatchToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F9;
-            this.addWatchToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
-            this.addWatchToolStripMenuItem.Text = "Add Watch";
-            this.addWatchToolStripMenuItem.Click += new System.EventHandler(this.addWatchToolStripMenuItem_Click);
-            // 
-            // deleteWatchToolStripMenuItem
-            // 
-            this.deleteWatchToolStripMenuItem.Enabled = false;
-            this.deleteWatchToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.DeleteWatchMenuImage;
-            this.deleteWatchToolStripMenuItem.Name = "deleteWatchToolStripMenuItem";
-            this.deleteWatchToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F9)));
-            this.deleteWatchToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
-            this.deleteWatchToolStripMenuItem.Text = "Delete Watch";
-            this.deleteWatchToolStripMenuItem.Click += new System.EventHandler(this.deleteWatchToolStripMenuItem_Click);
+            this.toggleWatchToolStripMenuItem.Enabled = false;
+            this.toggleWatchToolStripMenuItem.Image = global::Bonsai.Editor.Properties.Resources.WatchMenuImage;
+            this.toggleWatchToolStripMenuItem.Name = "toggleWatchToolStripMenuItem";
+            this.toggleWatchToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F9)));
+            this.toggleWatchToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
+            this.toggleWatchToolStripMenuItem.Text = "Toggle Watch";
+            this.toggleWatchToolStripMenuItem.Click += new System.EventHandler(this.toggleWatchToolStripMenuItem_Click);
             // 
             // toolStripSeparator4
             // 
@@ -453,8 +441,7 @@
         private System.Windows.Forms.ToolStripMenuItem openNewWindowToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem findAllReferencesToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
-        private System.Windows.Forms.ToolStripMenuItem addWatchToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem toggleWatchToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
-        private System.Windows.Forms.ToolStripMenuItem deleteWatchToolStripMenuItem;
     }
 }

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -91,7 +91,12 @@ namespace Bonsai.Editor.GraphView
                         if (node.Value is null)
                             continue;
 
-                        if (workflowWatch.Counters?.TryGetValue(node.Value, out var counter) is true)
+                        if (!workflowWatch.Enabled)
+                        {
+                            node.Status = null;
+                            node.NotifyingCounter = -1;
+                        }
+                        else if (workflowWatch.Counters?.TryGetValue(node.Value, out var counter) is true)
                         {
                             node.Status = counter.GetStatus();
                             if (node.Status == WorkflowElementStatus.Notifying)
@@ -102,11 +107,6 @@ namespace Bonsai.Editor.GraphView
                             {
                                 node.NotifyingCounter = -1;
                             }
-                        }
-                        else
-                        {
-                            node.Status = null;
-                            node.NotifyingCounter = -1;
                         }
                     }
                 }

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -47,6 +47,7 @@ namespace Bonsai.Editor.GraphView
         readonly IWorkflowEditorService editorService;
         readonly TypeVisualizerMap typeVisualizerMap;
         readonly VisualizerLayoutMap visualizerSettings;
+        readonly WorkflowWatchMap watchMap;
         readonly IServiceProvider serviceProvider;
         readonly IUIService uiService;
         readonly ThemeRenderer themeRenderer;
@@ -69,6 +70,7 @@ namespace Bonsai.Editor.GraphView
             typeVisualizerMap = (TypeVisualizerMap)provider.GetService(typeof(TypeVisualizerMap));
             visualizerSettings = (VisualizerLayoutMap)provider.GetService(typeof(VisualizerLayoutMap));
             editorState = (IWorkflowEditorState)provider.GetService(typeof(IWorkflowEditorState));
+            watchMap = (WorkflowWatchMap)provider.GetService(typeof(WorkflowWatchMap));
             workflowWatch = (WorkflowWatch)provider.GetService(typeof(WorkflowWatch));
 
             workflowWatch.Update += WorkflowWatch_Tick;
@@ -588,6 +590,7 @@ namespace Bonsai.Editor.GraphView
         internal void UpdateGraphLayout(bool validateWorkflow, bool updateSelection)
         {
             graphView.Nodes = Workflow.ConnectedComponentLayering();
+            watchMap.InitializeWatchState(Editor);
             graphView.Invalidate();
             if (validateWorkflow)
             {
@@ -608,6 +611,12 @@ namespace Bonsai.Editor.GraphView
                 UpdateSelection();
                 editorService.RefreshEditor();
             }
+        }
+
+        internal void UpdateWatchLayout()
+        {
+            watchMap.InitializeWatchState(Editor);
+            graphView.Invalidate();
         }
 
         internal void InvalidateGraphLayout(bool validateWorkflow)

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -226,6 +226,34 @@ namespace Bonsai.Editor.GraphView
             uiService.ShowError(errorMessage);
         }
 
+        public void AddWatch(IEnumerable<GraphNode> nodes)
+        {
+            var selectedNodes = nodes.Where(node => !watchMap.Contains(node.Value)).ToArray();
+            if (selectedNodes.Length > 0)
+            {
+                foreach (var node in selectedNodes)
+                {
+                    watchMap.Add((InspectBuilder)node.Value);
+                }
+            }
+            EditorControl.UpdateWatchLayout(WorkflowPath);
+            EditorControl.ShowWatchTool();
+        }
+
+        public void DeleteWatch(IEnumerable<GraphNode> nodes)
+        {
+            var selectedNodes = nodes.Where(node => watchMap.Contains(node.Value)).ToArray();
+            if (selectedNodes.Length > 0)
+            {
+                foreach (var node in selectedNodes)
+                {
+                    watchMap.Remove((InspectBuilder)node.Value);
+                }
+            }
+            EditorControl.UpdateWatchLayout(WorkflowPath);
+            EditorControl.UpdateWatchTool();
+        }
+
         public void CutToClipboard()
         {
             try
@@ -873,6 +901,16 @@ namespace Bonsai.Editor.GraphView
                 goToDefinitionToolStripMenuItem_Click(sender, e);
             }
 
+            if (e.KeyData == addWatchToolStripMenuItem.ShortcutKeys)
+            {
+                addWatchToolStripMenuItem_Click(sender, e);
+            }
+
+            if (e.KeyData == deleteWatchToolStripMenuItem.ShortcutKeys)
+            {
+                deleteWatchToolStripMenuItem_Click(sender, e);
+            }
+
             if (e.KeyCode == Keys.Return && !CanEdit)
             {
                 LaunchDefaultAction(graphView.SelectedNode);
@@ -1075,6 +1113,16 @@ namespace Bonsai.Editor.GraphView
         private void defaultEditorToolStripMenuItem_Click(object sender, EventArgs e)
         {
             LaunchDefaultEditor(graphView.SelectedNode);
+        }
+
+        private void addWatchToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            AddWatch(graphView.SelectedNodes);
+        }
+
+        private void deleteWatchToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            DeleteWatch(graphView.SelectedNodes);
         }
 
         private void docsToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1628,6 +1676,8 @@ namespace Bonsai.Editor.GraphView
             if (selectedNodes.Length > 0)
             {
                 copyToolStripMenuItem.Enabled = true;
+                addWatchToolStripMenuItem.Enabled = true;
+                deleteWatchToolStripMenuItem.Enabled = true;
                 saveAsWorkflowToolStripMenuItem.Enabled = true;
                 if (Array.Exists(selectedNodes, node => node.NestedCategory != null))
                 {

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -228,26 +228,32 @@ namespace Bonsai.Editor.GraphView
 
         public void AddWatch(IEnumerable<GraphNode> nodes)
         {
-            var selectedNodes = nodes.Where(node => !watchMap.Contains(node.Value)).ToArray();
-            if (selectedNodes.Length > 0)
+            var selectedItems = nodes
+                .Where(node => !watchMap.Contains(node.Value))
+                .Select(node => (InspectBuilder)node.Value)
+                .ToHashSet();
+            if (selectedItems.Count > 0)
             {
-                foreach (var node in selectedNodes)
+                foreach (var watch in selectedItems)
                 {
-                    watchMap.Add((InspectBuilder)node.Value);
+                    watchMap.Add(watch);
                 }
             }
             EditorControl.UpdateWatchLayout(WorkflowPath);
-            EditorControl.ShowWatchTool();
+            EditorControl.ShowWatchTool(selectedItems);
         }
 
         public void DeleteWatch(IEnumerable<GraphNode> nodes)
         {
-            var selectedNodes = nodes.Where(node => watchMap.Contains(node.Value)).ToArray();
-            if (selectedNodes.Length > 0)
+            var selectedItems = nodes
+                .Where(node => watchMap.Contains(node.Value))
+                .Select(node => (InspectBuilder)node.Value)
+                .ToHashSet();
+            if (selectedItems.Count > 0)
             {
-                foreach (var node in selectedNodes)
+                foreach (var watch in selectedItems)
                 {
-                    watchMap.Remove((InspectBuilder)node.Value);
+                    watchMap.Remove(watch);
                 }
             }
             EditorControl.UpdateWatchLayout(WorkflowPath);

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -93,17 +93,17 @@ namespace Bonsai.Editor.GraphView
                             node.Status = counter.GetStatus();
                             if (node.Status == WorkflowElementStatus.Notifying)
                             {
-                                node.NotifyingCounter = (node.NotifyingCounter + 1) % 2;
+                                node.NotifyingCounter++;
                             }
                             else if (node.Status != WorkflowElementStatus.Active)
                             {
-                                node.NotifyingCounter = 0;
+                                node.NotifyingCounter = -1;
                             }
                         }
                         else
                         {
                             node.Status = null;
-                            node.NotifyingCounter = 0;
+                            node.NotifyingCounter = -1;
                         }
                     }
                 }

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -254,6 +254,7 @@ namespace Bonsai.Editor.GraphView
             }
             EditorControl.UpdateWatchLayout(WorkflowPath);
             EditorControl.ShowWatchTool(selectedItems);
+            EditorControl.SelectDockContent(this);
         }
 
         void DeleteWatch(IEnumerable<GraphNode> nodes)
@@ -373,7 +374,7 @@ namespace Bonsai.Editor.GraphView
         internal void SelectGraphNode(GraphNode node)
         {
             GraphView.SelectedNode = node;
-            EditorControl.SelectTab(this);
+            EditorControl.SelectDockContent(this);
             GraphView.Select();
             UpdateSelection();
         }
@@ -642,7 +643,7 @@ namespace Bonsai.Editor.GraphView
             if (validateWorkflow)
             {
                 editorService.ValidateWorkflow();
-                EditorControl.SelectTab(this);
+                EditorControl.SelectDockContent(this);
                 if (EditorControl.AnnotationPanel.Tag is ExpressionBuilder builder)
                 {
                     var workflowBuilder = (WorkflowBuilder)serviceProvider.GetService(typeof(WorkflowBuilder));

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -81,6 +81,7 @@ namespace Bonsai.Editor.GraphView
 
         private void WorkflowWatch_Tick(object sender, EventArgs e)
         {
+            var hasActiveCounter = false;
             var layers = graphView.Nodes;
             if (layers != null)
             {
@@ -91,13 +92,9 @@ namespace Bonsai.Editor.GraphView
                         if (node.Value is null)
                             continue;
 
-                        if (!workflowWatch.Enabled)
+                        if (workflowWatch.Counters?.TryGetValue(node.Value, out var counter) is true)
                         {
-                            node.Status = null;
-                            node.NotifyingCounter = -1;
-                        }
-                        else if (workflowWatch.Counters?.TryGetValue(node.Value, out var counter) is true)
-                        {
+                            hasActiveCounter = true;
                             node.Status = counter.GetStatus();
                             if (node.Status == WorkflowElementStatus.Notifying)
                             {
@@ -108,11 +105,18 @@ namespace Bonsai.Editor.GraphView
                                 node.NotifyingCounter = -1;
                             }
                         }
+                        else
+                        {
+                            hasActiveCounter |= node.Status is not null;
+                            node.Status = null;
+                            node.NotifyingCounter = -1;
+                        }
                     }
                 }
             }
 
-            graphView.Invalidate();
+            if (hasActiveCounter)
+                graphView.Invalidate();
         }
 
         internal WorkflowEditor Editor { get; }

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -88,6 +88,9 @@ namespace Bonsai.Editor.GraphView
                 {
                     foreach (var node in layers[i])
                     {
+                        if (node.Value is null)
+                            continue;
+
                         if (workflowWatch.Counters?.TryGetValue(node.Value, out var counter) is true)
                         {
                             node.Status = counter.GetStatus();

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -226,7 +226,20 @@ namespace Bonsai.Editor.GraphView
             uiService.ShowError(errorMessage);
         }
 
-        public void AddWatch(IEnumerable<GraphNode> nodes)
+        public void ToggleWatch(IEnumerable<GraphNode> nodes)
+        {
+            if (!HasWatch(nodes))
+                AddWatch(nodes);
+            else
+                DeleteWatch(nodes);
+        }
+
+        bool HasWatch(IEnumerable<GraphNode> nodes)
+        {
+            return nodes.All(node => watchMap.Contains(node.Value));
+        }
+
+        void AddWatch(IEnumerable<GraphNode> nodes)
         {
             var selectedItems = nodes
                 .Where(node => !watchMap.Contains(node.Value))
@@ -243,7 +256,7 @@ namespace Bonsai.Editor.GraphView
             EditorControl.ShowWatchTool(selectedItems);
         }
 
-        public void DeleteWatch(IEnumerable<GraphNode> nodes)
+        void DeleteWatch(IEnumerable<GraphNode> nodes)
         {
             var selectedItems = nodes
                 .Where(node => watchMap.Contains(node.Value))
@@ -1111,14 +1124,9 @@ namespace Bonsai.Editor.GraphView
             LaunchDefaultEditor(graphView.SelectedNode);
         }
 
-        private void addWatchToolStripMenuItem_Click(object sender, EventArgs e)
+        private void toggleWatchToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            editorService.OnKeyDown(new KeyEventArgs(addWatchToolStripMenuItem.ShortcutKeys));
-        }
-
-        private void deleteWatchToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            editorService.OnKeyDown(new KeyEventArgs(deleteWatchToolStripMenuItem.ShortcutKeys));
+            editorService.OnKeyDown(new KeyEventArgs(toggleWatchToolStripMenuItem.ShortcutKeys));
         }
 
         private void docsToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1672,8 +1680,7 @@ namespace Bonsai.Editor.GraphView
             if (selectedNodes.Length > 0)
             {
                 copyToolStripMenuItem.Enabled = true;
-                addWatchToolStripMenuItem.Enabled = true;
-                deleteWatchToolStripMenuItem.Enabled = true;
+                toggleWatchToolStripMenuItem.Enabled = true;
                 saveAsWorkflowToolStripMenuItem.Enabled = true;
                 if (Array.Exists(selectedNodes, node => node.NestedCategory != null))
                 {

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -901,16 +901,6 @@ namespace Bonsai.Editor.GraphView
                 goToDefinitionToolStripMenuItem_Click(sender, e);
             }
 
-            if (e.KeyData == addWatchToolStripMenuItem.ShortcutKeys)
-            {
-                addWatchToolStripMenuItem_Click(sender, e);
-            }
-
-            if (e.KeyData == deleteWatchToolStripMenuItem.ShortcutKeys)
-            {
-                deleteWatchToolStripMenuItem_Click(sender, e);
-            }
-
             if (e.KeyCode == Keys.Return && !CanEdit)
             {
                 LaunchDefaultAction(graphView.SelectedNode);
@@ -1117,12 +1107,12 @@ namespace Bonsai.Editor.GraphView
 
         private void addWatchToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            AddWatch(graphView.SelectedNodes);
+            editorService.OnKeyDown(new KeyEventArgs(addWatchToolStripMenuItem.ShortcutKeys));
         }
 
         private void deleteWatchToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            DeleteWatch(graphView.SelectedNodes);
+            editorService.OnKeyDown(new KeyEventArgs(deleteWatchToolStripMenuItem.ShortcutKeys));
         }
 
         private void docsToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Bonsai.Editor/GraphView/WorkflowWatchSettings.cs
+++ b/Bonsai.Editor/GraphView/WorkflowWatchSettings.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.ObjectModel;
+using System.Xml;
+using System.Xml.Serialization;
+using Bonsai.Editor.GraphModel;
+
+namespace Bonsai.Editor.GraphView
+{
+    public sealed class WorkflowWatchSettings
+    {
+        [XmlElement("Watch")]
+        public Collection<WorkflowElementWatchSettings> WatchList { get; } = new();
+    }
+
+    public sealed class WorkflowElementWatchSettings
+    {
+        [XmlIgnore]
+        internal WorkflowEditorPath Path { get; set; }
+
+        [XmlAttribute(nameof(Path))]
+        public string PathXml
+        {
+            get => Path.ToString();
+            set => Path = WorkflowEditorPath.Parse(value);
+        }
+    }
+}

--- a/Bonsai.Editor/Properties/Resources.Designer.cs
+++ b/Bonsai.Editor/Properties/Resources.Designer.cs
@@ -112,6 +112,16 @@ namespace Bonsai.Editor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap ClearAllMenuImage {
+            get {
+                object obj = ResourceManager.GetObject("ClearAllMenuImage", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to None.
         /// </summary>
         internal static string ContextMenu_NoneMenuItemLabel {
@@ -220,6 +230,16 @@ namespace Bonsai.Editor.Properties {
         internal static System.Drawing.Bitmap DeleteMenuImage {
             get {
                 object obj = ResourceManager.GetObject("DeleteMenuImage", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap DeleteWatchMenuImage {
+            get {
+                object obj = ResourceManager.GetObject("DeleteWatchMenuImage", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -986,7 +1006,7 @@ namespace Bonsai.Editor.Properties {
                 return ResourceManager.GetString("VisualizerLayoutOnNullWorkflow_Error", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>

--- a/Bonsai.Editor/Properties/Resources.Designer.cs
+++ b/Bonsai.Editor/Properties/Resources.Designer.cs
@@ -986,6 +986,16 @@ namespace Bonsai.Editor.Properties {
                 return ResourceManager.GetString("VisualizerLayoutOnNullWorkflow_Error", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap WatchMenuImage {
+            get {
+                object obj = ResourceManager.GetObject("WatchMenuImage", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.

--- a/Bonsai.Editor/Properties/Resources.resx
+++ b/Bonsai.Editor/Properties/Resources.resx
@@ -674,11 +674,31 @@ Do you want to continue assigning any remaining properties and/or running the wo
   <data name="WatchMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
-        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAA7CAAAOwgEVKEqAAAAAv0lE
-        QVQ4T2MYRkBRUTEJiPeDMFQIBcDkQOqgQgggIyMjpKCgsElKSkoYKoQV4FQnLy+fBcJQLl6AoZZY22EA
-        Qz0ptsMAih6gaY+AAfMfC34AkgfRaOJgDNIHNgDI+SsnJyeJjpEV45D/BzYAaNILoHMMkCWB/ACg+FWo
-        BRdAfGR5ZWVlI6D4c5gB24A4HlkBkL8aqKkAakAOiI8sD5RLBIptgRmQB3ImMgaKvQKFNkgeqEEQxMei
-        Jg9swFAHDAwAKi9WPOw18+QAAAAASUVORK5CYII=
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAA7AAAAOwAFq1okJAAAAvklE
+        QVQ4T92QSwrCQBBEcwV1ZQjTVeQC4km8gehSJHgvdyJuvYIb9+Im4h000mEGJvMBt1rQDD2vuuZTFP8j
+        kmuSZ62QqRxTX8iKqqrGAA5lWU5C5ivrE5GN1mAzo8ibTc0o8keJX2gwA+BOskvUTbmuCdbpXB9A8mWM
+        mYblm0Nm+dvd4CEiMx+KyALA1R5w0d7ndV3PSbYu4ARg6RsA7EVkZwO22gcHrAAcXUCTeN9Tf1u5MWak
+        fcLT9AG/rw8qL1Y83UltdgAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="DeleteWatchMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAA7BAAAOwQG4kWvtAAAA/klE
+        QVQ4T2M4wiVeephb3IEBCkBskBiMTxAc5hG1OcIl9vIot7gTMhtdHV4AsVXsJQgju4ZoQJEBR3hEbIn1
+        gqKi4n4oToILwgJRRkZGSEFBwZ1QIILUKSoqbgTRKBKKiorZ8vLyWSiCOABIHYpaqO2bpKSkhFFU4gAY
+        6jFMJAKg6FFQUHikqKj4Hwt+AJIH0Vjk/oP0gQ1QVFT8KycnJ4mOkRWjy0Hl/8Fc8EJeXt4AWVJeXj5A
+        QUHhKtSCCyA+sryysrKRoqLic5gB2xQUFOKRFSgoKKyWl5cvgBqQA+KjWZCooKCwBWZAHhb/vYLFtZyc
+        nCCIj0VNHtiAAQUAuIl4kpXmGr0AAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="ClearAllMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAA7CAAAOwgEVKEqAAAAAaklE
+        QVQ4T2NgoAY4wiVeephb3AHGB7FBYiC2oqLif1wYbsBhHlGbI1xiL49yizshs+EKiAEQW8VegjCya4gG
+        uAxAdzZWLxzhEbGlyAv4ApFigO5srF4YeIDuNGIxujkDCNCdRixGN2dgAADmiWng2iRjRwAAAABJRU5E
+        rkJggg==
 </value>
   </data>
 </root>

--- a/Bonsai.Editor/Properties/Resources.resx
+++ b/Bonsai.Editor/Properties/Resources.resx
@@ -671,4 +671,14 @@ Do you want to continue assigning any remaining properties and/or running the wo
   <data name="ExportWorkflowWithUnknownTypes_Error" xml:space="preserve">
     <value>The workflow contains unknown types. Please ensure any missing dependencies are installed before exporting the workflow.</value>
   </data>
+  <data name="WatchMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAA7CAAAOwgEVKEqAAAAAv0lE
+        QVQ4T2MYRkBRUTEJiPeDMFQIBcDkQOqgQgggIyMjpKCgsElKSkoYKoQV4FQnLy+fBcJQLl6AoZZY22EA
+        Qz0ptsMAih6gaY+AAfMfC34AkgfRaOJgDNIHNgDI+SsnJyeJjpEV45D/BzYAaNILoHMMkCWB/ACg+FWo
+        BRdAfGR5ZWVlI6D4c5gB24A4HlkBkL8aqKkAakAOiI8sD5RLBIptgRmQB3ImMgaKvQKFNkgeqEEQxMei
+        Jg9swFAHDAwAKi9WPOw18+QAAAAASUVORK5CYII=
+</value>
+  </data>
 </root>

--- a/Bonsai.Editor/ToolboxTreeView.cs
+++ b/Bonsai.Editor/ToolboxTreeView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
 using Bonsai.Editor.Themes;
@@ -9,6 +10,7 @@ namespace Bonsai.Editor
     {
         private ToolStripExtendedRenderer renderer;
 
+        [DefaultValue(null)]
         public ToolStripExtendedRenderer Renderer
         {
             get => renderer;

--- a/Bonsai.Editor/WorkflowWatch.cs
+++ b/Bonsai.Editor/WorkflowWatch.cs
@@ -11,10 +11,22 @@ namespace Bonsai.Editor
         const int WatchPeriod = 100;
         readonly Timer watchTimer = new() { Interval = WatchPeriod };
         WorkflowMeter workflowMeter;
+        bool enabled;
 
         public WorkflowWatch()
         {
             watchTimer.Tick += (_, e) => OnUpdate(e);
+            enabled = true;
+        }
+
+        public bool Enabled
+        {
+            get => enabled;
+            set
+            {
+                enabled = value;
+                OnUpdate(EventArgs.Empty);
+            }
         }
 
         public event EventHandler Update;
@@ -45,10 +57,10 @@ namespace Bonsai.Editor
             watchTimer.Stop();
             if (workflowMeter is not null)
             {
+                OnUpdate(EventArgs.Empty);
                 workflowMeter.Dispose();
                 workflowMeter = null;
             }
-            OnUpdate(EventArgs.Empty);
         }
     }
 }

--- a/Bonsai.Editor/WorkflowWatch.cs
+++ b/Bonsai.Editor/WorkflowWatch.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using Bonsai.Editor.Diagnostics;
+using Bonsai.Expressions;
+
+namespace Bonsai.Editor
+{
+    internal class WorkflowWatch
+    {
+        const int WatchPeriod = 100;
+        readonly Timer watchTimer = new() { Interval = WatchPeriod };
+        WorkflowMeter workflowMeter;
+
+        public WorkflowWatch()
+        {
+            watchTimer.Tick += (_, e) => OnUpdate(e);
+        }
+
+        public event EventHandler Update;
+
+        private void OnUpdate(EventArgs e)
+        {
+            Update?.Invoke(this, e);
+        }
+
+        public void Start(ExpressionBuilderGraph workflow)
+        {
+            if (workflowMeter is not null)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(Stop)} must be called before starting a new watch.");
+            }
+
+            workflowMeter = new WorkflowMeter(workflow);
+            OnUpdate(EventArgs.Empty);
+            watchTimer.Start();
+        }
+
+        public IReadOnlyDictionary<ExpressionBuilder, WorkflowElementCounter> Counters =>
+            workflowMeter?.Counters;
+
+        public void Stop()
+        {
+            watchTimer.Stop();
+            if (workflowMeter is not null)
+            {
+                workflowMeter.Dispose();
+                workflowMeter = null;
+            }
+            OnUpdate(EventArgs.Empty);
+        }
+    }
+}

--- a/Bonsai.Editor/WorkflowWatch.cs
+++ b/Bonsai.Editor/WorkflowWatch.cs
@@ -36,7 +36,7 @@ namespace Bonsai.Editor
             Update?.Invoke(this, e);
         }
 
-        public void Start(ExpressionBuilderGraph workflow)
+        public void Start(ExpressionBuilderGraph workflow, WorkflowWatchMap watchMap)
         {
             if (workflowMeter is not null)
             {
@@ -44,7 +44,7 @@ namespace Bonsai.Editor
                     $"{nameof(Stop)} must be called before starting a new watch.");
             }
 
-            workflowMeter = new WorkflowMeter(workflow);
+            workflowMeter = new WorkflowMeter(workflow, watchMap);
             OnUpdate(EventArgs.Empty);
             watchTimer.Start();
         }

--- a/Bonsai.Editor/WorkflowWatchMap.cs
+++ b/Bonsai.Editor/WorkflowWatchMap.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bonsai.Editor.Diagnostics;
+using Bonsai.Editor.GraphModel;
+using Bonsai.Editor.GraphView;
+using Bonsai.Expressions;
+
+namespace Bonsai.Editor
+{
+    internal class WorkflowWatchMap
+    {
+        readonly HashSet<InspectBuilder> watchSet = new();
+
+        public int Count => watchSet.Count;
+
+        public bool Add(InspectBuilder item)
+        {
+            return watchSet.Add(item);
+        }
+
+        public bool Contains(ExpressionBuilder builder)
+        {
+            return builder is InspectBuilder inspectBuilder && Contains(inspectBuilder);
+        }
+
+        public bool Contains(InspectBuilder item)
+        {
+            return watchSet.Contains(item);
+        }
+
+        public bool Remove(InspectBuilder item)
+        {
+            return watchSet.Remove(item);
+        }
+
+        internal void Clear()
+        {
+            watchSet.Clear();
+        }
+
+        internal void InitializeWatchState(WorkflowEditor editor)
+        {
+            foreach (var node in editor.GraphView.Nodes.LayeredNodes())
+            {
+                node.Status = watchSet.Contains(node.Value)
+                    ? WorkflowElementStatus.Ready
+                    : null;
+            }
+        }
+
+        internal void SetWatchNotifications(WorkflowBuilder source)
+        {
+            foreach (var watch in watchSet)
+            {
+                watch.PublishNotifications = true;
+            }
+        }
+
+        public WorkflowWatchSettings GetWatchSettings(WorkflowBuilder workflowBuilder)
+        {
+            var settings = new WorkflowWatchSettings();
+            foreach (var watch in workflowBuilder.FindAll(Contains, unwrap: false))
+                settings.WatchList.Add(new WorkflowElementWatchSettings { Path = watch.Path });
+            return settings;
+        }
+
+        public void SetWatchSettings(WorkflowBuilder workflowBuilder, WorkflowWatchSettings settings)
+        {
+            watchSet.Clear();
+            foreach (var watch in settings.WatchList)
+            {
+                try
+                {
+                    var inspectBuilder = (InspectBuilder)watch.Path.Resolve(workflowBuilder);
+                    watchSet.Add(inspectBuilder);
+                }
+                catch { continue; } // best effort, drop any unresolved watch
+            }
+        }
+    }
+}


### PR DESCRIPTION
Understanding the runtime state of each operator in the workflow can be one of the most confusing aspects of learning visual reactive programming. Here we aim to assist this learning and debugging process by introducing a "watch" feature to the editor debug mode.

There are two main components to the feature:

- New `Diagnostics` namespace introducing components and types for counting the number of notifications, subscriptions and cancellations to each operator.
- Rendering pipeline for periodically overlaying the live watch state on the workflow, currently refreshing at 10 Hz.

### Watch infrastructure

There are five main stages in the life of a subscription to an observable sequence:

- `Subscribe`: the observable receives a subscription from a downstream operator
- `OnNext`: the observable emits a new value notification
- `OnCompleted`: the observable terminates successfully
- `OnError`: the observable terminates exceptionally
- `Unsubscribe`: the subscription is disposed, either following termination or cancellation

These stages can all run in parallel for each observable. The new diagnostics infrastructure introduces components to count all these events in a thread-safe manner using the `InspectBuilder` output streams.

A new `Watch` stream had to be introduced to reliably materialize cancellation. In general cancellation is not part of the Rx grammar and should not be relied upon for operator composition, but it can be invaluable to materialize these events for tracing and runtime monitoring.

Since each operator can have an arbitrary number of parallel subscriptions, we adopt a strategy for combining or aggregating the state of each sequence into a single value using the following rules:

```c#
  enum WorkflowElementStatus
  {
      Ready, // no subscriptions have yet been made
      Active, // at least one active subscription but no values have been emitted yet
      Notifying, // at least one active subscription and emitted at least one value in the last period
      Completed, // no active subscriptions and at least one subscription terminated successfully
      Error, // no active subscriptions and at least one subscription terminated exceptionally
      Canceled // no active subscriptions and at least one subscription was canceled without termination
  }
```

The `Error` status has precedence over `Completed`, and both have precedence over `Canceled`. Each of the status values is mapped into a visual annotation which is updated and overlaid periodically on top of each operator. The `Notifying` status will actively spin as long as values continue to be emitted.

| Status | Annotation |
| ------- | ------------ |
| Ready | <img alt="ready" src="https://github.com/user-attachments/assets/721901be-b260-40a2-b049-accbb0b31622" height ="38px" /> |
| Active | <img alt="ready" src="https://github.com/user-attachments/assets/c6720204-75e9-4e34-919f-e0df33b70d05" height ="35px" /> |
| Notifying | <img alt="ready" src="https://github.com/user-attachments/assets/8bb003f6-59dd-4aea-bae2-41eb6fde6bc5" height ="35px" /> |
| Completed | <img alt="ready" src="https://github.com/user-attachments/assets/16420eda-d8ab-4e32-b6d9-b5f3971c211d" height ="35px" /> |
| Error | <img alt="ready" src="https://github.com/user-attachments/assets/2ac3a3f5-e068-4891-86f6-84940ebaf884" height ="35px" /> |
| Canceled | <img alt="ready" src="https://github.com/user-attachments/assets/7245e852-750a-4a44-a4f1-0f5deb7fb161" height ="35px" /> |

### Watch Example

<img alt="watch-example" src="https://github.com/user-attachments/assets/eac1ee62-8c6b-4325-a816-6075d647e8c7" height="75px" />

### Caveats and limitations

- Since the live watch refreshes at a maximum rate of 10 Hz this feature should not be relied upon for debugging race conditions, high-frequency streams, or any other aspects of the workflow behavior depending on precise timing.
- When overlaying multiple parallel subscriptions some of the indicators may be misleading as to the true state, as there is currently no way of visually tracking the state of individual subscriptions and there are precedence rules for the visual annotations.
- This feature should not be relied upon if knowing how many subscriptions are running over each operator is important.

Fixes #1859 