### PR TITLE
Use deployment key in CI for manipulating Git repository

### DIFF
--- a/.github/workflows/Bonsai.yml
+++ b/.github/workflows/Bonsai.yml
@@ -392,6 +392,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: refs/heads/main
+          ssh-key: ${{secrets.CI_DEPLOYMENT_KEY}}
 
       # ----------------------------------------------------------------------- Update `latest` tag
       - name: Update `latest` tag


### PR DESCRIPTION
This allows CI to bypass the pull request requirement for pushing to `main`

This PR requires some manual repository configuration before merging.