### PR TITLE
Make TextureSequence a public class

### DIFF
--- a/Bonsai.Shaders/TextureSequence.cs
+++ b/Bonsai.Shaders/TextureSequence.cs
@@ -3,16 +3,33 @@ using System.Collections.Generic;
 
 namespace Bonsai.Shaders
 {
-    class TextureSequence : Texture, ITextureSequence
+    /// <summary>
+    /// Represents a sequence of texture objects with an enumerator.
+    /// </summary>
+    public class TextureSequence : Texture, ITextureSequence
     {
         readonly TextureArray textures;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextureSequence"/> class
+        /// with the specified number of texture objects in the internal <see cref="TextureArray"/>.
+        /// </summary>
+        /// <param name="length">
+        /// The total number of texture objects in the <see cref="TextureArray"/>.
+        /// </param>
         public TextureSequence(int length)
             : base(0)
         {
             textures = new TextureArray(length);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextureSequence"/> class
+        /// with existing texture handles.
+        /// </summary>
+        /// <param name="textures">
+        /// The texture handles.
+        /// </param> 
         public TextureSequence(int[] textures)
         {
             this.textures = new TextureArray(textures);
@@ -23,8 +40,22 @@ namespace Bonsai.Shaders
             get { return textures; }
         }
 
+        /// <summary>
+        /// The target playback rate of the texture sequence.
+        /// </summary>
         public double PlaybackRate { get; set; }
 
+        /// <summary>
+        /// Returns an enumerator that iterates through all texture objects in
+        /// the sequence.
+        /// </summary>
+        /// <param name="loop">
+        /// Boolean specifying whether the sequence should loop.
+        /// </param> 
+        /// <returns>
+        /// An enumerator that can be used to iterate through the texture objects
+        /// in the sequence.
+        /// </returns>
         public IEnumerator<ElementIndex<Texture>> GetEnumerator(bool loop)
         {
             var index = 0;

--- a/Bonsai.Shaders/TextureSequence.cs
+++ b/Bonsai.Shaders/TextureSequence.cs
@@ -35,6 +35,9 @@ namespace Bonsai.Shaders
             this.textures = new TextureArray(textures);
         }
 
+        /// <summary>
+        /// Gets the <see cref="TextureArray"/> associated with this texture sequence.
+        /// </summary>
         public TextureArray Textures
         {
             get { return textures; }


### PR DESCRIPTION
Relates to issue #1968 

This PR makes TextureSequence in Bonsai.Shaders a public class, which allows for using extensions to determine the length of the texture array inside TextureSequence, Also adds the docstrings required for the class.