### PR TITLE
Keep Linux builds on Ubuntu 22.04 for now

### DIFF
--- a/.github/workflows/create-build-matrix.py
+++ b/.github/workflows/create-build-matrix.py
@@ -27,7 +27,7 @@ def add(name: str, runner_os: str, rid: str, configurations: list[str] = ['Debug
     return ret
 
 windows = add('Windows x64', 'windows-latest', 'win-x64')
-linux = add('Linux x64', 'ubuntu-latest', 'linux-x64')
+linux = add('Linux x64', 'ubuntu-22.04', 'linux-x64')
 
 # Collect packages and create installer from Windows Release x64
 windows['Release']['collect-packages'] = True


### PR DESCRIPTION
GitHub [has resumed](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/) the rollout of bringing `ubuntu-latest` up to Ubuntu 24.04.

This breaks our unit tests on Linux due to Mono being dropped from the runner image due to [somewhat unfortunate reasons](https://www.github.com/actions/runner-images/issues/10636#issuecomment-2375010324).

The easiest solution for now is to just stick to Ubuntu 22.04, which still includes Mono. We can expect 22.04 to be supported by GitHub until October 2026 at the very least, most likely until April 2027. By then we will either hopefully A) not care about Mono anymore or B) the [recent migration of Mono to Wine](https://www.github.com/mono/mono/issues/21796) will mean more modern ways of acquiring Mono will have become available.