### PR TITLE
Add MatrixWriter overload for sequences of unmanaged types

### DIFF
--- a/Bonsai.Dsp/MatrixWriter.cs
+++ b/Bonsai.Dsp/MatrixWriter.cs
@@ -72,6 +72,30 @@ namespace Bonsai.Dsp
         }
 
         /// <summary>
+        /// Writes all of the values in an observable sequence to the specified raw binary output stream.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of the elements in the sequence. This type must be a non-pointer, non-nullable
+        /// unmanaged type.
+        /// </typeparam>
+        /// <param name="source">The sequence of values to write.</param>
+        /// <returns>
+        /// An observable sequence that is identical to the source sequence but where
+        /// there is an additional side effect of writing the values to a binary stream.
+        /// </returns>
+        public unsafe IObservable<TElement> Process<TElement>(IObservable<TElement> source) where TElement : unmanaged
+        {
+            return Process(source, input =>
+            {
+                var valuePtr = &input;
+                var bytes = new byte[sizeof(TElement)];
+                fixed (byte* bytesPtr = bytes)
+                    System.Buffer.MemoryCopy(valuePtr, bytesPtr, bytes.Length, bytes.Length);
+                return new ArraySegment<byte>(bytes);
+            });
+        }
+
+        /// <summary>
         /// Writes all of the <see cref="byte"/> arrays in an observable sequence to the
         /// specified raw binary output stream.
         /// </summary>

--- a/Bonsai.Dsp/MatrixWriter.cs
+++ b/Bonsai.Dsp/MatrixWriter.cs
@@ -52,13 +52,14 @@ namespace Bonsai.Dsp
         /// <summary>
         /// Writes all of the arrays in an observable sequence to the specified raw binary output stream.
         /// </summary>
-        /// <param name="source">
-        /// The sequence of arrays to write. The elements stored in each array must
-        /// be of an unmanaged type.
-        /// </param>
+        /// <typeparam name="TElement">
+        /// The type of the elements in each array. This type must be a non-pointer, non-nullable
+        /// unmanaged type.
+        /// </typeparam>
+        /// <param name="source">The sequence of arrays to write.</param>
         /// <returns>
         /// An observable sequence that is identical to the source sequence but where
-        /// there is an additional side effect of writing the arrays to a stream.
+        /// there is an additional side effect of writing the arrays to a binary stream.
         /// </returns>
         public unsafe IObservable<TElement[]> Process<TElement>(IObservable<TElement[]> source) where TElement : unmanaged
         {


### PR DESCRIPTION
This PR expands the compatibility of `MatrixWriter` to any arbitrary sequence of [unmanaged types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/unmanaged-types) by taking advantage of [`Buffer.MemoryCopy`](https://learn.microsoft.com/en-us/dotnet/api/system.buffer.memorycopy?view=net-9.0) to directly marshal the value type into a binary stream.

The new overload signature is:

```c#
public IObservable<TElement> Process<TElement>(IObservable<TElement> source) where TElement : unmanaged
```

`Buffer.MemoryCopy` is compatible across both .NET Framework and .NET 5+ but we might consider later improving the implementation for .NET 5+ by taking advantage of new memory copy performance primitives.

Fixes #1578 