### PR TITLE
Avoid launching editor during image export

### DIFF
--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -86,6 +86,9 @@ namespace Bonsai
             });
             parser.Parse(args);
 
+            if (exportImage)
+                launchEditor = false;
+
             var editorAssembly = typeof(Program).Assembly;
             var editorPath = editorAssembly.Location;
             var editorFolder = Path.GetDirectoryName(editorPath);


### PR DESCRIPTION
When the `--export-image` flag was introduced we failed to ensure the editor is not launched during package restore. This PR fixes it by validating the launch editor flag against the state of the export image flag.

Fixes #2096 