### PR TITLE
Save workflow settings when closing the editor

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -269,6 +269,9 @@ namespace Bonsai.Editor
 
         void CloseEditorForm()
         {
+            if (!string.IsNullOrEmpty(FileName))
+                SaveWorkflowSettings(FileName);
+
             Application.RemoveMessageFilter(hotKeys);
             EditorSettings.Instance.AnnotationPanelSize = (int)Math.Round(
                 editorControl.AnnotationPanelSize * inverseScaleFactor.Width);
@@ -894,6 +897,19 @@ namespace Bonsai.Editor
             if (!SaveWorkflowBuilder(fileName, serializerWorkflowBuilder)) return false;
             saveVersion = version;
 
+            SaveWorkflowSettings(fileName);
+            UpdateWorkflowDirectory(fileName);
+            UpdateTitle();
+            return true;
+        }
+
+        bool SaveWorkflowBuilder(string fileName, WorkflowBuilder workflowBuilder)
+        {
+            return SaveElement(WorkflowBuilder.Serializer, fileName, workflowBuilder, Resources.SaveWorkflow_Error);
+        }
+
+        void SaveWorkflowSettings(string fileName)
+        {
             var settingsDirectory = Project.GetWorkflowSettingsDirectory(fileName);
             Directory.CreateDirectory(settingsDirectory);
 
@@ -913,15 +929,6 @@ namespace Bonsai.Editor
                 }
 #pragma warning restore CS0612 // Support for deprecated layout config files
             }
-
-            UpdateWorkflowDirectory(fileName);
-            UpdateTitle();
-            return true;
-        }
-
-        bool SaveWorkflowBuilder(string fileName, WorkflowBuilder workflowBuilder)
-        {
-            return SaveElement(WorkflowBuilder.Serializer, fileName, workflowBuilder, Resources.SaveWorkflow_Error);
         }
 
         void SaveVisualizerLayout(string fileName, VisualizerLayout layout)


### PR DESCRIPTION
Similar to other IDE software, we should preserve the current editing environment even if no changes have been made to the underlying workflow. To do this we factor out the workflow settings serialization logic and run it on a clean editor shutdown, similar to persistence of global editor settings.

Fixes #2153 