### PR TITLE
Remove idempotent operations from the undo history

### DIFF
--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -1910,7 +1910,7 @@ namespace Bonsai.Editor.GraphModel
 
         public void UngroupGraphNodes(IEnumerable<GraphNode> nodes)
         {
-            UpdateGraphNodes(nodes, UngroupOrReplaceGraphNode);
+            UpdateGraphNodes(nodes.Where(node => !node.IsDisabled && node.NestedCategory.HasValue), UngroupOrReplaceGraphNode);
         }
 
         private void UngroupOrReplaceGraphNode(GraphNode node)
@@ -2030,12 +2030,12 @@ namespace Bonsai.Editor.GraphModel
 
         public void DisableGraphNodes(IEnumerable<GraphNode> nodes)
         {
-            UpdateGraphNodes(nodes, DisableGraphNode);
+            UpdateGraphNodes(nodes.Where(node => !node.IsDisabled), DisableGraphNode);
         }
 
         public void EnableGraphNodes(IEnumerable<GraphNode> nodes)
         {
-            UpdateGraphNodes(nodes, EnableGraphNode);
+            UpdateGraphNodes(nodes.Where(node => node.IsDisabled), EnableGraphNode);
         }
 
         public void RenameSubject(SubjectDefinition definition, string newName)


### PR DESCRIPTION
Added filters on ungroup, enable and disable operations so that only eligible nodes in a multi-selection will be included in the command. If no nodes are eligible the command will not execute and the command history will remain unchanged.

This has a secondary benefit that when calling undo on the operation, only affected nodes will be highlighted.

Fixes #2150 