### PR TITLE
Improve consistency of visualizer context menu

### DIFF
--- a/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
@@ -1365,6 +1365,18 @@ namespace Bonsai.Expressions
         /// <returns>An enumerable sequence of all the descendant elements in this workflow.</returns>
         public static IEnumerable<ExpressionBuilder> Descendants(this ExpressionBuilderGraph source)
         {
+            return Descendants(source, unwrap: true);
+        }
+
+        /// <summary>
+        /// Returns a filtered collection of the descendant elements for this workflow, including elements
+        /// nested inside grouped workflows. Any descendants of disabled groups will not be included in the result.
+        /// </summary>
+        /// <param name="source">The expression builder workflow to search.</param>
+        /// <param name="unwrap">A value indicating whether to unwrap descendant elements.</param>
+        /// <returns>An enumerable sequence of all the descendant elements in this workflow.</returns>
+        public static IEnumerable<ExpressionBuilder> Descendants(this ExpressionBuilderGraph source, bool unwrap)
+        {
             var stack = new Stack<IEnumerator<Node<ExpressionBuilder, ExpressionBuilderArgument>>>();
             stack.Push(source.GetEnumerator());
 
@@ -1379,8 +1391,9 @@ namespace Bonsai.Expressions
                         break;
                     }
 
-                    var builder = ExpressionBuilder.Unwrap(nodeEnumerator.Current.Value);
-                    yield return builder;
+                    var nodeValue = nodeEnumerator.Current.Value;
+                    var builder = ExpressionBuilder.Unwrap(nodeValue);
+                    yield return unwrap ? builder : nodeValue;
 
                     if (builder is IWorkflowExpressionBuilder workflowBuilder && workflowBuilder.Workflow != null)
                     {

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1499,6 +1499,10 @@ namespace Bonsai.Editor.GraphView
                             visualizerSettings[inspectBuilder] = dialogSettings;
                     }
                 }
+                else if (editorState.WorkflowRunning)
+                {
+                    LaunchVisualizer(selectedNode);
+                }
             });
             return menuItem;
         }

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1404,13 +1404,22 @@ namespace Bonsai.Editor.GraphView
 
         private string GetActiveVisualizerTypeName(object workflowElement, InspectBuilder inspectBuilder)
         {
-            if (workflowElement is VisualizerMappingBuilder mappingBuilder &&
-                mappingBuilder.VisualizerType is not null)
-                return mappingBuilder.VisualizerType.GetType().GetGenericArguments()[0].FullName;
+            if (editorState.WorkflowRunning)
+            {
+                var visualizerDialogs = (VisualizerDialogMap)serviceProvider.GetService(typeof(VisualizerDialogMap));
+                visualizerDialogs.TryGetValue(inspectBuilder, out VisualizerDialogLauncher visualizerDialog);
+                return visualizerDialog?.VisualizerFactory.VisualizerType.FullName;
+            }
             else
-                return visualizerSettings.TryGetValue(inspectBuilder, out var dialogSettings)
-                        ? dialogSettings.VisualizerTypeName
-                        : null;
+            {
+                if (workflowElement is VisualizerMappingBuilder mappingBuilder &&
+                    mappingBuilder.VisualizerType is not null)
+                    return mappingBuilder.VisualizerType.GetType().GetGenericArguments()[0].FullName;
+                else
+                    return visualizerSettings.TryGetValue(inspectBuilder, out var dialogSettings)
+                            ? dialogSettings.VisualizerTypeName
+                            : null;
+            }
         }
 
         private void CreateVisualizerMenuItems(

--- a/Bonsai.Editor/Layout/LayoutHelper.cs
+++ b/Bonsai.Editor/Layout/LayoutHelper.cs
@@ -46,7 +46,7 @@ namespace Bonsai.Design
 
         public static void SetLayoutNotifications(ExpressionBuilderGraph source, VisualizerDialogMap lookup)
         {
-            foreach (var builder in source.Descendants())
+            foreach (var builder in source.Descendants(unwrap: false))
             {
                 var inspectBuilder = (InspectBuilder)builder;
                 if (lookup.TryGetValue((InspectBuilder)builder, out VisualizerDialogLauncher _))

--- a/Bonsai.Editor/Layout/VisualizerDialogLauncher.cs
+++ b/Bonsai.Editor/Layout/VisualizerDialogLauncher.cs
@@ -34,7 +34,7 @@ namespace Bonsai.Design
 
         public Lazy<DialogTypeVisualizer> Visualizer { get; }
 
-        private VisualizerFactory VisualizerFactory { get; }
+        public VisualizerFactory VisualizerFactory { get; }
 
         static IDisposable SubscribeDialog<TSource>(IObservable<TSource> source, TypeVisualizerDialog visualizerDialog)
         {


### PR DESCRIPTION
A few visualizer assignment behaviors were broken by the changes in #1870. Specifically the way the active visualizer is obtained at runtime is no longer valid and needs to change to use the visualizer dialog map.

We also took this opportunity to correct the startup behavior of visualizer layouts described in #2071 and also the behavior of the show visualizer context menu, to ensure that if the selected visualizer is not visible but the drop down menu item is clicked, the dialog is shown or activated.

Fixes #2071 
Fixes #1841 