### PR TITLE
Improve navigation behavior when no tabs are open

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -830,7 +830,7 @@ namespace Bonsai.Editor
             }
 
             workflowBuilder = PrepareWorkflow(workflowBuilder, workflowVersion, out bool upgraded);
-            saveWorkflowDialog.FileName = fileName;
+            FileName = fileName;
 
             var settingsDirectory = Project.GetWorkflowSettingsDirectory(fileName);
             var editorPath = Project.GetEditorSettingsPath(settingsDirectory, fileName);
@@ -858,7 +858,7 @@ namespace Bonsai.Editor
                     Resources.UpgradeWorkflow_Warning_Caption,
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Warning);
-                saveWorkflowDialog.FileName = null;
+                FileName = null;
                 version++;
             }
 
@@ -1002,10 +1002,10 @@ namespace Bonsai.Editor
             if (setWorkingDirectory && directoryToolStripItem.Text != workflowDirectory)
             {
                 Environment.CurrentDirectory = workflowDirectory;
-                saveWorkflowDialog.FileName = fileName;
                 EditorResult = EditorResult.ReloadEditor;
                 ResetProjectStatus();
                 Close();
+                FileName = fileName;
             }
             else
             {
@@ -1537,8 +1537,8 @@ namespace Bonsai.Editor
 
         private string GetProjectDisplayName()
         {
-            return !string.IsNullOrEmpty(saveWorkflowDialog.FileName)
-                ? Path.GetFileNameWithoutExtension(saveWorkflowDialog.FileName)
+            return !string.IsNullOrEmpty(FileName)
+                ? Path.GetFileNameWithoutExtension(FileName)
                 : "Workflow";
         }
 

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -489,7 +489,7 @@ namespace Bonsai.Editor
             var selectedViewChanged = Observable.FromEventPattern<EventHandler, EventArgs>(
                 handler => selectionModel.SelectionChanged += handler,
                 handler => selectionModel.SelectionChanged -= handler)
-                .Select(evt => selectionModel.SelectedView.WorkflowPath)
+                .Select(evt => selectionModel.SelectedView?.WorkflowPath)
                 .DistinctUntilChanged()
                 .Do(explorerTreeView.SelectNode)
                 .IgnoreElements()
@@ -936,10 +936,14 @@ namespace Bonsai.Editor
             SaveElement(VisualizerLayout.Serializer, fileName, layout, Resources.SaveLayout_Error);
         }
 
-        void SaveWorkflowExtension(string fileName, GraphNode node)
+        void SaveWorkflowExtension(WorkflowGraphView model, string fileName, GraphNode node)
         {
+            if (model is null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
             var groupNode = node;
-            var model = selectionModel.SelectedView;
             if (groupNode == null)
             {
                 model.Editor.GroupGraphNodes(selectionModel.SelectedNodes);
@@ -1021,6 +1025,11 @@ namespace Bonsai.Editor
 
         void ExportImage(WorkflowGraphView model, string fileName)
         {
+            if (model is null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
             var workflow = model.Workflow;
             if (model.GraphView.SelectedNodes.Count() > 0)
             {
@@ -1098,6 +1107,9 @@ namespace Bonsai.Editor
             editorSite.EnsureExtensionsDirectory();
             if (!extensionsPath.Exists) return;
 
+            var model = selectionModel.SelectedView;
+            if (model is null) return;
+
             string fileName = null;
             GraphNode groupNode = null;
             var selectedNodes = selectionModel.SelectedNodes;
@@ -1125,13 +1137,13 @@ namespace Bonsai.Editor
                 saveWorkflowDialog.InitialDirectory = openWorkflowDialog.InitialDirectory;
             }
 
-            SaveWorkflowExtension(fileName, groupNode);
+            SaveWorkflowExtension(model, fileName, groupNode);
         }
 
         private void exportImageToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var model = selectionModel.SelectedView;
-            if (model.Workflow.Count > 0)
+            if (model?.Workflow.Count > 0)
             {
                 if (exportImageDialog.ShowDialog() == DialogResult.OK)
                 {
@@ -1393,9 +1405,9 @@ namespace Bonsai.Editor
             var builderPath = WorkflowEditorPath.GetBuilderPath(workflowBuilder, builder);
             if (builderPath != null)
             {
-                var selectedView = selectionModel.SelectedView;
-                selectedView.WorkflowPath = builderPath.Parent;
+                editorSite.NavigateTo(builderPath.Parent, NavigationPreference.Current);
 
+                var selectedView = selectionModel.SelectedView;
                 var graphNode = selectedView.FindGraphNode(builderPath.Resolve(workflowBuilder));
                 if (graphNode == null)
                 {
@@ -1442,7 +1454,7 @@ namespace Bonsai.Editor
         private void DeleteSelectedNode()
         {
             var model = selectionModel.SelectedView;
-            if (model.GraphView.Focused)
+            if (model?.GraphView.Focused is true)
             {
                 model.Editor.DeleteGraphNodes(selectionModel.SelectedNodes);
             }
@@ -1554,10 +1566,14 @@ namespace Bonsai.Editor
 
             var selectedView = selectionModel.SelectedView;
             var canEdit = selectedView != null && selectedView.CanEdit;
+            var hasSelectableObjects = selectedView?.Workflow.Count > 0;
             var hasSelectedObjects = selectedObjects.Length > 0;
             saveAsWorkflowToolStripMenuItem.Enabled = hasSelectedObjects;
             pasteToolStripMenuItem.Enabled = canEdit;
             copyToolStripMenuItem.Enabled = hasSelectedObjects;
+            copyAsImageToolStripMenuItem.Enabled = hasSelectableObjects;
+            selectAllToolStripMenuItem.Enabled = hasSelectableObjects;
+            exportImageToolStripMenuItem.Enabled = hasSelectableObjects;
             cutToolStripMenuItem.Enabled = canEdit && hasSelectedObjects;
             deleteToolStripMenuItem.Enabled = canEdit && hasSelectedObjects;
             groupToolStripMenuItem.Enabled = canEdit && hasSelectedObjects;
@@ -1707,11 +1723,10 @@ namespace Bonsai.Editor
                         break;
                     case Keys.Return:
                         toolboxTreeView_KeyDown(sender, e);
-                        searchTextBox.Clear();
-                        var selectedView = selectionModel.SelectedView;
-                        if (selectedView != null)
+                        if (e.Handled)
                         {
-                            selectedView.Focus();
+                            searchTextBox.Clear();
+                            selectionModel.SelectedView?.Focus();
                         }
                         break;
                 }
@@ -1729,11 +1744,8 @@ namespace Bonsai.Editor
             return arguments.Length == 2 ? arguments[1] : string.Empty;
         }
 
-        void CreateGraphNode(TreeNode typeNode, Keys modifiers)
+        void CreateGraphNode(WorkflowGraphView model, TreeNode typeNode, Keys modifiers)
         {
-            var model = selectionModel.SelectedView;
-            if (!model.CanEdit) return;
-
             var group = modifiers.HasFlag(WorkflowGraphView.GroupModifier);
             var branch = modifiers.HasFlag(WorkflowGraphView.BranchModifier);
             var predecessor = modifiers.HasFlag(WorkflowGraphView.PredecessorModifier) ? CreateGraphNodeType.Predecessor : CreateGraphNodeType.Successor;
@@ -1801,7 +1813,7 @@ namespace Bonsai.Editor
         void FindNextGraphNode(bool findPrevious)
         {
             var model = selectionModel.SelectedView;
-            if (!model.GraphView.Focused) return;
+            if (model?.GraphView.Focused is not true) return;
 
             var selection = selectionModel.SelectedNodes.ToArray();
             if (selection.Length == 0) return;
@@ -1849,7 +1861,10 @@ namespace Bonsai.Editor
             var selectedNode = toolboxTreeView.SelectedNode;
             if (e.KeyCode == Keys.Return && selectedNode?.Tag != null)
             {
-                CreateGraphNode(selectedNode, e.Modifiers);
+                var model = selectionModel.SelectedView;
+                if (model?.CanEdit is not true) return;
+
+                CreateGraphNode(model, selectedNode, e.Modifiers);
                 e.Handled = true;
                 e.SuppressKeyPress = true;
             }
@@ -1868,8 +1883,8 @@ namespace Bonsai.Editor
                 if (!selectedNode.IsEditing && elementCategory == ~ElementCategory.Source)
                 {
                     var currentName = selectedNode.Name;
-                    var selectedView = selectionModel.SelectedView;
-                    var definition = workflowBuilder.GetSubjectDefinition(selectedView.Workflow, currentName);
+                    var targetWorkflow = selectionModel.SelectedView?.Workflow ?? workflowBuilder.Workflow;
+                    var definition = workflowBuilder.GetSubjectDefinition(targetWorkflow, currentName);
                     if (definition == null || rename && definition.IsReadOnly)
                     {
                         var message = definition == null
@@ -2013,7 +2028,7 @@ namespace Bonsai.Editor
             if (!toolboxTreeView.Focused)
             {
                 var model = selectionModel.SelectedView;
-                if (!model.GraphView.Focused) return;
+                if (model?.GraphView.Focused is not true) return;
 
                 var selection = selectionModel.SelectedNodes.ToArray();
                 var selectedBuilder = selection.Length == 1 && selection[0].Value is InspectBuilder inspectBuilder ? inspectBuilder.Builder : null;
@@ -2065,7 +2080,7 @@ namespace Bonsai.Editor
         private void cutToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var model = selectionModel.SelectedView;
-            if (model.GraphView.Focused)
+            if (model?.GraphView.Focused is true)
             {
                 model.CutToClipboard();
             }
@@ -2080,7 +2095,7 @@ namespace Bonsai.Editor
             else
             {
                 var model = selectionModel.SelectedView;
-                if (model.GraphView.Focused)
+                if (model?.GraphView.Focused is true)
                 {
                     model.CopyToClipboard();
                 }
@@ -2089,13 +2104,17 @@ namespace Bonsai.Editor
 
         private void copyAsImageToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            ExportImage(selectionModel.SelectedView);
+            var model = selectionModel.SelectedView;
+            if (model?.Workflow.Count > 0)
+            {
+                ExportImage(model);
+            }
         }
 
         private void pasteToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var model = selectionModel.SelectedView;
-            if (model.GraphView.Focused)
+            if (model?.GraphView.Focused is true)
             {
                 model.PasteFromClipboard();
             }
@@ -2104,7 +2123,7 @@ namespace Bonsai.Editor
         private void selectAllToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var model = selectionModel.SelectedView;
-            if (model.GraphView.Focused)
+            if (model?.GraphView.Focused is true)
             {
                 model.SelectAllGraphNodes();
             }
@@ -2113,7 +2132,7 @@ namespace Bonsai.Editor
         private void groupToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var model = selectionModel.SelectedView;
-            if (model.GraphView.Focused)
+            if (model?.GraphView.Focused is true)
             {
                 model.Editor.GroupGraphNodes(selectionModel.SelectedNodes);
             }
@@ -2122,7 +2141,7 @@ namespace Bonsai.Editor
         private void ungroupToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var model = selectionModel.SelectedView;
-            if (model.GraphView.Focused)
+            if (model?.GraphView.Focused is true)
             {
                 model.Editor.UngroupGraphNodes(selectionModel.SelectedNodes);
             }
@@ -2131,7 +2150,7 @@ namespace Bonsai.Editor
         private void enableToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var model = selectionModel.SelectedView;
-            if (model.GraphView.Focused)
+            if (model?.GraphView.Focused is true)
             {
                 model.Editor.EnableGraphNodes(selectionModel.SelectedNodes);
             }
@@ -2140,7 +2159,7 @@ namespace Bonsai.Editor
         private void disableToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var model = selectionModel.SelectedView;
-            if (model.GraphView.Focused)
+            if (model?.GraphView.Focused is true)
             {
                 model.Editor.DisableGraphNodes(selectionModel.SelectedNodes);
             }
@@ -2283,7 +2302,6 @@ namespace Bonsai.Editor
             try
             {
                 var showExternal = ModifierKeys.HasFlag(Keys.Control);
-                var editorControl = selectionModel.SelectedView.EditorControl;
                 var url = await documentationProvider.GetDocumentationAsync(assemblyName, uid);
                 if (!showExternal && editorControl.AnnotationPanel.HasWebView)
                 {
@@ -2350,7 +2368,7 @@ namespace Bonsai.Editor
             }
 
             var model = selectionModel.SelectedView;
-            if (model.GraphView.Focused)
+            if (model?.GraphView.Focused is true)
             {
                 var selectedNode = selectionModel.SelectedNodes.FirstOrDefault();
                 if (selectedNode != null)
@@ -2441,7 +2459,8 @@ namespace Bonsai.Editor
             {
                 if (serviceType == typeof(ExpressionBuilderGraph))
                 {
-                    return siteForm.selectionModel.SelectedView.Workflow;
+                    return siteForm.selectionModel.SelectedView?.Workflow
+                        ?? siteForm.workflowBuilder.Workflow;
                 }
 
                 if (serviceType == typeof(WorkflowBuilder))
@@ -2628,7 +2647,10 @@ namespace Bonsai.Editor
                 switch (navigationPreference)
                 {
                     case NavigationPreference.Current:
-                        siteForm.selectionModel.SelectedView.WorkflowPath = workflowPath;
+                        var model = siteForm.selectionModel.SelectedView;
+                        if (model is null)
+                            goto case NavigationPreference.NewTab;
+                        model.WorkflowPath = workflowPath;
                         break;
                     case NavigationPreference.NewTab:
                         siteForm.editorControl.CreateDockContent(workflowPath, WeifenLuo.WinFormsUI.Docking.DockState.Document);
@@ -2898,8 +2920,8 @@ namespace Bonsai.Editor
             var selectedObjects = propertyGrid.SelectedObjects;
             if (selectedObjects != null && selectedObjects.Length > 0)
             {
-                var selectedView = selectionModel.SelectedView;
-                if (selectedObjects.Length > 1 || selectedObjects[0] != selectedView.Workflow)
+                var model = selectionModel.SelectedView;
+                if (selectedObjects.Length > 1 || model != null && selectedObjects[0] != model.Workflow)
                 {
                     GetSelectionDescription(selectedObjects, out string displayName, out string description);
                     UpdateDescriptionTextBox(displayName, description, propertiesDescriptionTextBox);

--- a/Bonsai.Editor/GraphModel/WorkflowEditorPath.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditorPath.cs
@@ -109,16 +109,22 @@ namespace Bonsai.Editor.GraphModel
 
         static WorkflowEditorPath GetBuilderPath(ExpressionBuilderGraph workflow, ExpressionBuilder target, List<int> pathElements)
         {
+            if (workflow is null)
+            {
+                throw new ArgumentNullException(nameof(workflow));
+            }
+
             for (int i = 0; i < workflow.Count; i++)
             {
-                var builder = ExpressionBuilder.GetWorkflowElement(workflow[i].Value);
+                var builder = ExpressionBuilder.Unwrap(workflow[i].Value);
                 if (builder == target)
                 {
                     pathElements.Add(i);
                     return GetBuilderPath(pathElements);
                 }
 
-                if (builder is IWorkflowExpressionBuilder workflowBuilder)
+                if (builder is IWorkflowExpressionBuilder workflowBuilder &&
+                    workflowBuilder.Workflow is not null)
                 {
                     pathElements.Add(i);
                     var path = GetBuilderPath(workflowBuilder.Workflow, target, pathElements);

--- a/Bonsai.Editor/GraphModel/WorkflowEditorPath.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditorPath.cs
@@ -48,7 +48,7 @@ namespace Bonsai.Editor.GraphModel
         public ExpressionBuilder Resolve(WorkflowBuilder workflowBuilder, out WorkflowPathFlags pathFlags)
         {
             pathFlags = WorkflowPathFlags.None;
-            var builder = default(ExpressionBuilder);
+            var result = default(ExpressionBuilder);
             var workflow = workflowBuilder.Workflow;
             foreach (var pathElement in GetPathElements())
             {
@@ -57,7 +57,8 @@ namespace Bonsai.Editor.GraphModel
                     throw new ArgumentException($"Unable to resolve workflow editor path.", nameof(workflowBuilder));
                 }
 
-                builder = ExpressionBuilder.Unwrap(workflow[pathElement.Index].Value);
+                result = workflow[pathElement.Index].Value;
+                var builder = ExpressionBuilder.Unwrap(result);
                 if (builder is DisableBuilder disableBuilder)
                 {
                     builder = disableBuilder.Builder;
@@ -73,7 +74,7 @@ namespace Bonsai.Editor.GraphModel
                 else workflow = null;
             }
 
-            return builder;
+            return result;
         }
 
         public static WorkflowEditorPath GetExceptionPath(WorkflowBuilder workflowBuilder, WorkflowException ex)

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -240,7 +240,8 @@ namespace Bonsai.Editor.GraphView
 
         internal void HighlightGraphNode(WorkflowGraphView selectedView, WorkflowEditorPath path, bool selectNode)
         {
-            UpdateGraphView(graphView => graphView.HighlightGraphNode(path, selectNode && graphView == selectedView));
+            UpdateGraphView(selectedView, graphView => graphView.HighlightGraphNode(path, selectNode: false));
+            selectedView?.HighlightGraphNode(path, selectNode);
         }
 
         internal void RefreshSelection(WorkflowGraphView selectedView)

--- a/Bonsai.Editor/GraphView/WorkflowSelectionModel.cs
+++ b/Bonsai.Editor/GraphView/WorkflowSelectionModel.cs
@@ -25,8 +25,8 @@ namespace Bonsai.Editor.GraphView
 
         public void UpdateSelection(WorkflowGraphView selectedView)
         {
-            SelectedView = selectedView ?? throw new ArgumentNullException(nameof(selectedView));
-            SelectedNodes = selectedView.GraphView.SelectedNodes;
+            SelectedView = selectedView;
+            SelectedNodes = selectedView?.GraphView.SelectedNodes ?? Enumerable.Empty<GraphNode>();
             OnSelectionChanged(EventArgs.Empty);
         }
     }


### PR DESCRIPTION
Closing all tabs would leave the selected view as a disposed control. These changes allow the selected view to be fully optional:
  - safeguards are added where necessary, e.g. by using the null-coalescing operator
  - default navigation behavior will create a tab when none is available
  - fixed a number of outstanding issues with the Find command left from the editor refactoring
  - fixed an outstanding issue where newly created tabs would not correctly highlight existing errors
  - fixed an outstanding issue with saving workflow settings where the wrong path would be used when changing working directory

Where possible, reasonable default behavior was implemented to avoid propagation of null-handling concerns. For example, asking for the `ExpressionBuilderGraph` service will typically return the currently selected workflow. If no view is selected, it will now return the top-level graph. Similarly, accessing the `SelectedNodes` property when no view is selected will return an empty collection.

Finally, dock contents now automatically select the next content when they are closed, to prevent possibly confusing states.

Fixes #2162 