### PR TITLE
Ensure topological sort before deletion

### DIFF
--- a/Bonsai.Core.Tests/TestWorkflow.cs
+++ b/Bonsai.Core.Tests/TestWorkflow.cs
@@ -87,6 +87,11 @@ namespace Bonsai.Core.Tests
             return Append(new WorkflowOutputBuilder());
         }
 
+        public TestWorkflow AppendNamed(string name)
+        {
+            return Append(new GroupWorkflowBuilder { Name = name });
+        }
+
         public TestWorkflow AppendPropertyMapping(params string[] propertyNames)
         {
             var mappingBuilder = new PropertyMappingBuilder();

--- a/Bonsai.Editor.Tests/EditorHelper.cs
+++ b/Bonsai.Editor.Tests/EditorHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Bonsai.Editor.GraphModel;
 using Bonsai.Expressions;
@@ -43,6 +44,11 @@ namespace Bonsai.Editor.Tests
         {
             var node = editor.Workflow.First(n => ExpressionBuilder.Unwrap(n.Value) == builder);
             return editor.FindGraphNode(node.Value);
+        }
+
+        internal static IEnumerable<GraphNode> FindNodes(this WorkflowEditor editor, params string[] names)
+        {
+            return Array.ConvertAll(names, name => editor.FindNode(name));
         }
 
         internal static void ConnectNodes(this WorkflowEditor editor, string source, string target)

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -231,6 +231,30 @@ namespace Bonsai.Editor.Tests
         }
 
         [TestMethod]
+        public void DeleteGraphNodes_SinglePathWithMultipleMergePoints_KeepConnectedPath()
+        {
+            var workflow = new TestWorkflow()
+                .AppendNamed("A")
+                .AppendNamed("B")
+                .AppendBranch(source => source.AddArguments(source.AppendInput(index: 0)))
+                .AppendNamed("C")
+                .AppendBranch(source => source.AddArguments(source.AppendInput(index: 1)))
+                .AppendNamed("D")
+                .TopologicalSort()
+                .ToInspectableGraph();
+
+            var (editor, assertIsReversible) = CreateMockEditor(workflow);
+            var nodesToDelete = editor.FindNodes("B", "Source1", "C", "Source2");
+            editor.DeleteGraphNodes(nodesToDelete);
+
+            var sourceNode = editor.FindNode("A");
+            var targetNode = editor.FindNode("D");
+            Assert.AreEqual(expected: 1, sourceNode.Successors.Count());
+            Assert.IsTrue(sourceNode.Successors.Any(edge => edge.Node == targetNode));
+            assertIsReversible();
+        }
+
+        [TestMethod]
         public void CreateAnnotation_EmptySelection_InsertAfterClosestRoot()
         {
             var workflow = EditorHelper.CreateEditorGraph("A");

--- a/Bonsai.Editor/GraphModel/WorkflowEditor.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditor.cs
@@ -1502,7 +1502,7 @@ namespace Bonsai.Editor.GraphModel
             var updateGraphLayout = CreateUpdateGraphLayoutDelegate();
             commandExecutor.BeginCompositeCommand();
             commandExecutor.Execute(EmptyAction, reorder.Undo + updateGraphLayout);
-            foreach (var node in nodes)
+            foreach (var node in nodes.SortSelection(Workflow).ToList())
             {
                 DeleteGraphNode(node);
             }


### PR DESCRIPTION
The semantics of the node deletion action allow preserving connected paths whenever possible. Still, when a node receives multiple input arguments, it becomes ambiguous to decide which path should be continued.

However, this problem becomes again decidable if we also delete all the multiple input arguments in the same operation. To leverage this, we need to ensure the set of deleted nodes is topologically sorted, such that we delete all upstream nodes before downstream merge nodes.

Fixes #1523 