### PR TITLE
Ensure visualizer mapping build state is cleared

### DIFF
--- a/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
+++ b/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
@@ -140,6 +140,22 @@ namespace Bonsai.Core.Tests
         }
 
         [TestMethod]
+        public void Build_WithBuildTargetBeforeVisualizerMapping_ReturnsExpression()
+        {
+            // related to https://github.com/bonsai-rx/bonsai/issues/1591
+            var workflow = new TestWorkflow()
+                .AppendBranch(root => root
+                    .AppendValue(0)
+                    .Append(new VisualizerMappingBuilder())
+                    .AppendValue(1)
+                    .AddArguments(root.AppendUnit()))
+                .ToInspectableGraph();
+            var buildTarget = workflow[workflow.Count - 1].Value;
+            var partialBuild = workflow.Build(buildTarget);
+            Assert.IsNotNull(workflow.Build());
+        }
+
+        [TestMethod]
         public void Build_ActiveBranch_HasMulticastExpression()
         {
             var workflow = new ExpressionBuilderGraph();

--- a/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
@@ -677,7 +677,7 @@ namespace Bonsai.Expressions
             }
 
             try { return source.Build(buildContext); }
-            catch
+            finally
             {
                 foreach (var node in source)
                 {
@@ -686,10 +686,7 @@ namespace Bonsai.Expressions
                         builder.ResetVisualizerMappings();
                     }
                 }
-                throw;
-            }
-            finally
-            {
+
                 foreach (var parameter in parameters)
                 {
                     parameter.Source = null;

--- a/Bonsai.Core/Expressions/InspectBuilder.cs
+++ b/Bonsai.Core/Expressions/InspectBuilder.cs
@@ -54,6 +54,11 @@ namespace Bonsai.Expressions
             return visualizerElement;
         }
 
+        private void BuildVisualizerMappings()
+        {
+            MappingList?.BuildVisualizerMappings();
+        }
+
         internal void ResetVisualizerMappings()
         {
             MappingList?.ResetVisualizerMappings();
@@ -128,7 +133,7 @@ namespace Bonsai.Expressions
         public override Expression Build(IEnumerable<Expression> arguments)
         {
             ObservableType = null;
-            ResetVisualizerMappings();
+            BuildVisualizerMappings();
             var source = Builder.Build(arguments);
             if (source == EmptyExpression.Instance) return source;
             if (IsReducible(source))
@@ -296,9 +301,13 @@ namespace Bonsai.Expressions
                 ((List<VisualizerMapping>)VisualizerMappings).AddRange(mappings);
             }
 
-            public void ResetVisualizerMappings()
+            public void BuildVisualizerMappings()
             {
                 VisualizerMappings = localMappings.Values.ToList();
+            }
+
+            public void ResetVisualizerMappings()
+            {
                 localMappings.Clear();
             }
 


### PR DESCRIPTION
Partial workflow builds are not required to traverse the entire build tree, and will stop as soon as their build target is reached.

This meant that build state left pending for evaluation by downstream nodes, such as visualizer mappings, might never be evaluated (and cleared) in cases where the mapping target was downstream of the build target.

To avoid subtle implications of such temporary state (which might even become irrelevant with future implementation changes, but extremely subtle to debug now), we will enforce any such build states to be fully cleared on all workflow builds, rather than conditionally on throw or depending on evaluation of specific nodes.

Fixes #1591 