### PR TITLE
Prune all fully disabled branches during build

### DIFF
--- a/Bonsai.Core.Tests/TestWorkflow.cs
+++ b/Bonsai.Core.Tests/TestWorkflow.cs
@@ -36,6 +36,11 @@ namespace Bonsai.Core.Tests
                 return this;
         }
 
+        public TestWorkflow ResetCursor(Node<ExpressionBuilder, ExpressionBuilderArgument> cursor)
+        {
+            return new TestWorkflow(Workflow, cursor);
+        }
+
         public TestWorkflow Capture(out ExpressionBuilder builder)
         {
             builder = Cursor?.Value;


### PR DESCRIPTION
To avoid complicated edge cases with disabled branch logic we introduce new semantics where all fully disabled branches are removed from the build sequence.

A fully disabled branch is defined as any path ending in a disabled terminal node (i.e. a node with no outgoing edges) where all branches leaving from the path are also themselves fully disabled.

Fixes #2007 