### PR TITLE
Fix various issues with `Extensions.csproj` handling and add unit testing for it

### DIFF
--- a/Bonsai.Configuration.Tests/AssemblyInfo.cs
+++ b/Bonsai.Configuration.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[assembly: Parallelize]

--- a/Bonsai.Configuration.Tests/Bonsai.Configuration.Tests.csproj
+++ b/Bonsai.Configuration.Tests/Bonsai.Configuration.Tests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="**\*.bonsai" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Bonsai.Configuration\Bonsai.Configuration.csproj" />
+  </ItemGroup>
+</Project>

--- a/Bonsai.Configuration.Tests/ScriptExtensionsProjectMetadataTests.cs
+++ b/Bonsai.Configuration.Tests/ScriptExtensionsProjectMetadataTests.cs
@@ -1,0 +1,380 @@
+﻿using System.Linq;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Configuration.Tests;
+
+[TestClass]
+public sealed class ScriptExtensionsProjectMetadataTests
+{
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void DefaultValueStateIsValid(bool useNullXDocument)
+    {
+        ScriptExtensionsProjectMetadata metadata = useNullXDocument ? new((XDocument)null) : default;
+        Assert.IsFalse(metadata.Exists);
+        Assert.IsFalse(metadata.AllowUnsafeBlocks);
+        CollectionAssert.DoesNotContain(metadata.GetAssemblyReferences().ToArray(), "System.Windows.Forms.dll"); // Winforms is not enabled by default
+        Assert.AreEqual(0, metadata.GetPackageReferences().Count());
+        Assert.AreEqual
+        (
+            """
+            <Project Sdk="Microsoft.NET.Sdk">            
+
+              <PropertyGroup>
+                <TargetFramework>net472</TargetFramework>
+              </PropertyGroup>
+
+            </Project>
+            """.NormalizeNewlines(),
+            metadata.GetProjectXml()
+        );
+    }
+
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void AllowUnsafeBlocks(bool enabled)
+    {
+        var document = XDocument.Parse
+        ($"""
+        <Project Sdk="Microsoft.NET.Sdk">            
+          <PropertyGroup>
+            <TargetFramework>net472</TargetFramework>
+            <AllowUnsafeBlocks>{enabled}</AllowUnsafeBlocks>
+          </PropertyGroup> 
+        </Project>
+        """, LoadOptions.PreserveWhitespace);
+        var metadata = new ScriptExtensionsProjectMetadata(document);
+        Assert.AreEqual(enabled, metadata.AllowUnsafeBlocks);
+    }
+
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void EnablingWinformsReferencesWinforms(bool enabled)
+    {
+        var document = XDocument.Parse
+        ($"""
+        <Project Sdk="Microsoft.NET.Sdk">            
+          <PropertyGroup>
+            <TargetFramework>net472</TargetFramework>
+            <UseWindowsForms>{enabled}</UseWindowsForms>
+          </PropertyGroup> 
+        </Project>
+        """, LoadOptions.PreserveWhitespace);
+        var metadata = new ScriptExtensionsProjectMetadata(document);
+
+        if (enabled)
+            CollectionAssert.Contains(metadata.GetAssemblyReferences().ToArray(), "System.Windows.Forms.dll");
+        else
+            CollectionAssert.DoesNotContain(metadata.GetAssemblyReferences().ToArray(), "System.Windows.Forms.dll");
+    }
+
+    [TestMethod]
+    public void GetPackageReferences()
+    {
+        var document = XDocument.Parse
+        ($"""
+        <Project Sdk="Microsoft.NET.Sdk">            
+          <PropertyGroup>
+            <TargetFramework>net472</TargetFramework>
+          </PropertyGroup> 
+          <ItemGroup>
+            <PackageReference Include="FakePackageA" Version="3226.42.1337" />
+            <PackageReference Include="FakePackageB" Version="126.484.30" />
+          </ItemGroup>
+        </Project>
+        """, LoadOptions.PreserveWhitespace);
+        var metadata = new ScriptExtensionsProjectMetadata(document);
+        var references = metadata.GetPackageReferences();
+        CollectionAssert.AreEquivalent((string[])["FakePackageA", "FakePackageB"], references.ToArray());
+    }
+
+    [TestMethod]
+    public void GetPackageReferencesTwoItemGroups()
+    {
+        var document = XDocument.Parse
+        ($"""
+        <Project Sdk="Microsoft.NET.Sdk">            
+          <PropertyGroup>
+            <TargetFramework>net472</TargetFramework>
+          </PropertyGroup> 
+          <ItemGroup>
+            <PackageReference Include="FakePackageA" Version="3226.42.1337" />
+          </ItemGroup>
+          <ItemGroup>
+            <PackageReference Include="FakePackageB" Version="126.484.30" />
+          </ItemGroup>
+        </Project>
+        """, LoadOptions.PreserveWhitespace);
+        var metadata = new ScriptExtensionsProjectMetadata(document);
+        var references = metadata.GetPackageReferences();
+        CollectionAssert.AreEquivalent((string[])["FakePackageA", "FakePackageB"], references.ToArray());
+    }
+
+    [TestMethod]
+    public void AddNewPackageReference()
+    {
+        var document = XDocument.Parse
+        ($"""
+        <Project Sdk="Microsoft.NET.Sdk">            
+          <PropertyGroup>
+            <TargetFramework>net472</TargetFramework>
+          </PropertyGroup> 
+          <ItemGroup>
+            <PackageReference Include="FakePackageA" Version="3226.42.1337" />
+          </ItemGroup>
+        </Project>
+        """, LoadOptions.PreserveWhitespace);
+        var metadata = new ScriptExtensionsProjectMetadata(document);
+        var updatedMetadata = metadata.AddPackageReferences([new PackageReference("FakePackageB", "126.484.30")]);
+
+        // Assert the new metadata has the reference but the immutable original does not
+        CollectionAssert.AreEquivalent((string[])["FakePackageA", "FakePackageB"], updatedMetadata.GetPackageReferences().ToArray());
+        CollectionAssert.AreEquivalent((string[])["FakePackageA"], metadata.GetPackageReferences().ToArray());
+
+        var xml = updatedMetadata.GetProjectXml();
+        var xElement = XElement.Parse(xml);
+
+        var itemGroups = xElement.Descendants("ItemGroup").ToArray();
+        Assert.AreEqual(1, itemGroups.Length);
+
+        var packageBs = xElement.XPathSelectElements("/ItemGroup/PackageReference[@Include = 'FakePackageB']").ToArray();
+        Assert.AreEqual(1, packageBs.Length);
+        Assert.AreEqual(itemGroups[0], packageBs[0].Parent);
+        Assert.AreEqual("""<PackageReference Include="FakePackageB" Version="126.484.30" />""", packageBs[0].ToString());
+    }
+
+    [TestMethod]
+    public void AddPackageReferenceToEmptyItemGroup()
+    {
+        var document = XDocument.Parse
+        ($"""
+        <Project Sdk="Microsoft.NET.Sdk">            
+          <PropertyGroup>
+            <TargetFramework>net472</TargetFramework>
+          </PropertyGroup> 
+          <ItemGroup>
+          </ItemGroup>
+        </Project>
+        """, LoadOptions.PreserveWhitespace);
+        var metadata = new ScriptExtensionsProjectMetadata(document);
+        Assert.AreEqual(0, metadata.GetPackageReferences().Count());
+
+        metadata = metadata.AddPackageReferences([new PackageReference("FakePackageA", "3226.42.1337")]);
+        var xml = metadata.GetProjectXml();
+        var xElement = XElement.Parse(xml);
+        var itemGroups = xElement.Descendants("ItemGroup").ToArray();
+        var packageReferences = xElement.Descendants("PackageReference").ToArray();
+
+        CollectionAssert.AreEquivalent((string[])["FakePackageA"], metadata.GetPackageReferences().ToArray());
+        Assert.AreEqual(1, itemGroups.Length);
+        Assert.AreEqual(1, packageReferences.Length);
+        Assert.AreEqual(itemGroups[0], packageReferences[0].Parent);
+        Assert.AreEqual("""<PackageReference Include="FakePackageA" Version="3226.42.1337" />""", packageReferences[0].ToString());
+    }
+
+    [TestMethod]
+    public void AddPackageReferenceToItemGroupWithoutPackageReferences()
+    {
+        var document = XDocument.Parse
+        ($"""
+        <Project Sdk="Microsoft.NET.Sdk">            
+          <PropertyGroup>
+            <TargetFramework>net472</TargetFramework>
+          </PropertyGroup> 
+          <ItemGroup>
+            <None Include="HelloWorld.txt" />
+          </ItemGroup>
+        </Project>
+        """, LoadOptions.PreserveWhitespace);
+        var metadata = new ScriptExtensionsProjectMetadata(document);
+        Assert.AreEqual(0, metadata.GetPackageReferences().Count());
+
+        metadata = metadata.AddPackageReferences([new PackageReference("FakePackageA", "3226.42.1337")]);
+        var xml = metadata.GetProjectXml();
+        var xElement = XElement.Parse(xml);
+        var itemGroups = xElement.Descendants("ItemGroup").ToArray();
+        var packageReferences = xElement.Descendants("PackageReference").ToArray();
+
+        CollectionAssert.AreEquivalent((string[])["FakePackageA"], metadata.GetPackageReferences().ToArray());
+        Assert.AreEqual(1, itemGroups.Length);
+        Assert.AreEqual(1, packageReferences.Length);
+        Assert.AreEqual(itemGroups[0], packageReferences[0].Parent);
+        Assert.AreEqual("""<PackageReference Include="FakePackageA" Version="3226.42.1337" />""", packageReferences[0].ToString());
+    }
+
+    [TestMethod]
+    public void AddPackageReferenceToEmptyItemGroupAndProperties()
+    {
+        var document = XDocument.Parse
+        ($"""
+        <Project Sdk="Microsoft.NET.Sdk">            
+          <PropertyGroup>
+            <TargetFramework>net472</TargetFramework>
+          </PropertyGroup> 
+          <ItemGroup Condition="false">
+          </ItemGroup>
+        </Project>
+        """, LoadOptions.PreserveWhitespace);
+        var metadata = new ScriptExtensionsProjectMetadata(document);
+        Assert.AreEqual(0, metadata.GetPackageReferences().Count());
+
+        metadata = metadata.AddPackageReferences([new PackageReference("FakePackageA", "3226.42.1337")]);
+        var xml = metadata.GetProjectXml();
+        var xElement = XElement.Parse(xml);
+        var itemGroups = xElement.Descendants("ItemGroup").ToArray();
+        var packageReferences = xElement.Descendants("PackageReference").ToArray();
+
+        CollectionAssert.AreEquivalent((string[])["FakePackageA"], metadata.GetPackageReferences().ToArray());
+        Assert.AreEqual(1, packageReferences.Length);
+        Assert.AreEqual("""<PackageReference Include="FakePackageA" Version="3226.42.1337" />""", packageReferences[0].ToString());
+
+        // A fresh item group should've been added for the reference
+        Assert.AreEqual(2, xElement.Descendants("ItemGroup").Count());
+        Assert.AreNotEqual(xElement.XPathSelectElement("/ItemGroup[@Condition='false']"), packageReferences[0].Parent);
+    }
+
+    [TestMethod]
+    public void AddPackageReferenceWithoutItemGroup()
+    {
+        var document = XDocument.Parse
+        ($"""
+        <Project Sdk="Microsoft.NET.Sdk">            
+          <PropertyGroup>
+            <TargetFramework>net472</TargetFramework>
+          </PropertyGroup> 
+        </Project>
+        """, LoadOptions.PreserveWhitespace);
+        var metadata = new ScriptExtensionsProjectMetadata(document);
+        Assert.AreEqual(0, metadata.GetPackageReferences().Count());
+
+        metadata = metadata.AddPackageReferences([new PackageReference("FakePackageA", "3226.42.1337")]);
+        var xml = metadata.GetProjectXml();
+        var xElement = XElement.Parse(xml);
+        var itemGroups = xElement.Descendants("ItemGroup").ToArray();
+        var packageReferences = xElement.Descendants("PackageReference").ToArray();
+
+        CollectionAssert.AreEquivalent((string[])["FakePackageA"], metadata.GetPackageReferences().ToArray());
+        Assert.AreEqual(1, itemGroups.Length);
+        Assert.AreEqual(1, packageReferences.Length);
+        Assert.AreEqual(itemGroups[0], packageReferences[0].Parent);
+        Assert.AreEqual("""<PackageReference Include="FakePackageA" Version="3226.42.1337" />""", packageReferences[0].ToString());
+    }
+
+    [TestMethod]
+    public void AddNewPackageReferenceTwoItemGroups()
+    {
+        var document = XDocument.Parse
+        ($"""
+        <Project Sdk="Microsoft.NET.Sdk">            
+          <PropertyGroup>
+            <TargetFramework>net472</TargetFramework>
+          </PropertyGroup> 
+          <ItemGroup>
+            <PackageReference Include="FakePackageA" Version="3226.42.1337" />
+          </ItemGroup>
+          <ItemGroup>
+            <PackageReference Include="FakePackageB" Version="126.484.30" />
+          </ItemGroup>
+        </Project>
+        """, LoadOptions.PreserveWhitespace);
+        var metadata = new ScriptExtensionsProjectMetadata(document);
+        metadata = metadata.AddPackageReferences([new PackageReference("FakePackageC", "2016.4.14")]);
+        var xml = metadata.GetProjectXml();
+        var xElement = XElement.Parse(xml);
+        var itemGroups = xElement.Descendants("ItemGroup").ToArray();
+        var packageReferences = xElement.Descendants("PackageReference").ToArray();
+
+        CollectionAssert.AreEquivalent((string[])["FakePackageA", "FakePackageB", "FakePackageC"], metadata.GetPackageReferences().ToArray());
+        Assert.AreEqual(2, itemGroups.Length);
+        Assert.AreEqual(3, packageReferences.Length);
+
+        XElement[] packageCs = xElement.XPathSelectElements("/ItemGroup/PackageReference[@Include='FakePackageC']").ToArray();
+        Assert.AreEqual(1, packageCs.Length);
+        CollectionAssert.Contains(itemGroups, packageCs[0].Parent);
+        Assert.AreEqual("""<PackageReference Include="FakePackageC" Version="2016.4.14" />""", packageCs[0].ToString());
+    }
+
+    [TestMethod]
+    public void UpgradeExistingPackageReference()
+    {
+        var document = XDocument.Parse
+        ($"""
+        <Project Sdk="Microsoft.NET.Sdk">            
+          <PropertyGroup>
+            <TargetFramework>net472</TargetFramework>
+          </PropertyGroup> 
+          <ItemGroup>
+            <PackageReference Include="FakePackageA" Version="3226.42.1337" />
+            <PackageReference Include="FakePackageB" Version="126.484.30" />
+          </ItemGroup>
+        </Project>
+        """, LoadOptions.PreserveWhitespace);
+        var metadata = new ScriptExtensionsProjectMetadata(document);
+        metadata = metadata.AddPackageReferences([new PackageReference("FakePackageA", "3226.42.1338")]);
+        var xml = metadata.GetProjectXml();
+        var xElement = XElement.Parse(xml);
+        var itemGroups = xElement.Descendants("ItemGroup").ToArray();
+        var packageReferences = xElement.Descendants("PackageReference").ToArray();
+
+        CollectionAssert.AreEquivalent((string[])["FakePackageA", "FakePackageB"], metadata.GetPackageReferences().ToArray());
+
+        // Package was udpated
+        var packageAs = xElement.XPathSelectElements("/ItemGroup/PackageReference[@Include='FakePackageA']").ToArray();
+        Assert.AreEqual(1, packageAs.Length);
+        Assert.AreEqual("3226.42.1338", packageAs[0].Attribute("Version").Value);
+        Assert.AreEqual(-1, xml.IndexOf("3226.42.1337"));
+
+        // Unrelated package untouched
+        var packageBs = xElement.XPathSelectElements("/ItemGroup/PackageReference[@Include='FakePackageB']").ToArray();
+        Assert.AreEqual(1, packageBs.Length);
+        Assert.AreEqual("126.484.30", packageBs[0].Attribute("Version").Value);
+
+        // Only the two packages are present
+        Assert.AreEqual(2, xElement.Descendants("PackageReference").Count());
+    }
+
+    [TestMethod]
+    public void DowngradeExistingPackageReference()
+    {
+        var document = XDocument.Parse
+        ($"""
+        <Project Sdk="Microsoft.NET.Sdk">            
+          <PropertyGroup>
+            <TargetFramework>net472</TargetFramework>
+          </PropertyGroup> 
+          <ItemGroup>
+            <PackageReference Include="FakePackageA" Version="3226.42.1337" />
+            <PackageReference Include="FakePackageB" Version="126.484.30" />
+          </ItemGroup>
+        </Project>
+        """, LoadOptions.PreserveWhitespace);
+        var metadata = new ScriptExtensionsProjectMetadata(document);
+        metadata = metadata.AddPackageReferences([new PackageReference("FakePackageA", "3226.42.1336")]);
+        var xml = metadata.GetProjectXml();
+        var xElement = XElement.Parse(xml);
+        var itemGroups = xElement.Descendants("ItemGroup").ToArray();
+        var packageReferences = xElement.Descendants("PackageReference").ToArray();
+
+        CollectionAssert.AreEquivalent((string[])["FakePackageA", "FakePackageB"], metadata.GetPackageReferences().ToArray());
+
+        // Package was not updated
+        //TODO: This is how the implementation is written, but is this behavior correct?
+        var packageAs = xElement.XPathSelectElements("/ItemGroup/PackageReference[@Include='FakePackageA']").ToArray();
+        Assert.AreEqual(1, packageAs.Length);
+        Assert.AreEqual("3226.42.1337", packageAs[0].Attribute("Version").Value);
+        Assert.AreEqual(-1, xml.IndexOf("3226.42.1336"));
+
+        // Unrelated package untouched
+        var packageBs = xElement.XPathSelectElements("/ItemGroup/PackageReference[@Include='FakePackageB']").ToArray();
+        Assert.AreEqual(1, packageBs.Length);
+        Assert.AreEqual("126.484.30", packageBs[0].Attribute("Version").Value);
+
+        // Only the two packages are present
+        Assert.AreEqual(2, xElement.Descendants("PackageReference").Count());
+    }
+}

--- a/Bonsai.Configuration.Tests/ScriptExtensionsTests.cs
+++ b/Bonsai.Configuration.Tests/ScriptExtensionsTests.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Configuration.Tests;
+
+[TestClass]
+[DoNotParallelize] // Tests involve filesystem at current working directory and must not be ran concurrently
+public sealed class ScriptExtensionsTests
+{
+    private static void EnsureCleanWorkspace()
+    {
+        if (File.Exists("Extensions.csproj"))
+            File.Delete("Extensions.csproj");
+    }
+
+    private static readonly PackageReference DummyPackageA = new("DummyPackageA", "3226.42.1337");
+    private static readonly PackageReference DummyPackageB = new("DummyPackageB", "126.484.30");
+    private static PackageConfiguration CreateDummyPackageConfiguration()
+    {
+        string dummyBonsaiConfig =
+            $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <Packages>
+                <Package id="{DummyPackageA.Id}" version="{DummyPackageA.Version}" />
+                <Package id="{DummyPackageB.Id}" version="{DummyPackageB.Version}" />
+              </Packages>
+              <AssemblyReferences>
+              </AssemblyReferences>
+              <AssemblyLocations>
+                <AssemblyLocation assemblyName="{DummyPackageA.Id}" processorArchitecture="MSIL" location="Packages/{DummyPackageA.Id}.{DummyPackageA.Version}/{DummyPackageA.Id}.dll" />
+                <AssemblyLocation assemblyName="{DummyPackageB.Id}" processorArchitecture="MSIL" location="Packages/{DummyPackageB.Id}.{DummyPackageB.Version}/{DummyPackageB.Id}.dll" />
+              </AssemblyLocations>
+              <LibraryFolders>
+              </LibraryFolders>
+            </PackageConfiguration>
+            """;
+
+        var serializer = new XmlSerializer(typeof(PackageConfiguration));
+        using XmlReader reader = XmlReader.Create(new StringReader(dummyBonsaiConfig));
+        var configuration = (PackageConfiguration)serializer.Deserialize(reader);
+        configuration.ConfigurationFile = Path.GetFullPath("DummyBonsai.config");
+        return configuration;
+    }
+
+    [TestMethod]
+    public void HasDefaultProjectMetadata()
+    {
+        EnsureCleanWorkspace();
+
+        var packageConfiguration = CreateDummyPackageConfiguration();
+        using var extensions = new ScriptExtensions(packageConfiguration, $"{nameof(HasDefaultProjectMetadata)}Output");
+
+        Assert.IsFalse(File.Exists("Extensions.csproj"));
+        ScriptExtensionsProjectMetadata metadata = extensions.LoadProjectMetadata();
+
+        Assert.IsFalse(metadata.Exists);
+        Assert.AreEqual(default(ScriptExtensionsProjectMetadata).GetProjectXml(), metadata.GetProjectXml());
+        Assert.IsFalse(File.Exists("Extensions.csproj")); // Project file should not be written automatically
+    }
+
+    [TestMethod]
+    public void WillLoadProjectMetadata()
+    {
+        EnsureCleanWorkspace();
+
+        File.WriteAllText
+        (
+            "Extensions.csproj",
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+                <TargetFramework>net472</TargetFramework>
+              </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="FakePackage" Version="1.0.0" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        var packageConfiguration = CreateDummyPackageConfiguration();
+        using var extensions = new ScriptExtensions(packageConfiguration, $"{nameof(WillLoadProjectMetadata)}Output");
+        ScriptExtensionsProjectMetadata metadata = extensions.LoadProjectMetadata();
+        Assert.IsTrue(metadata.Exists);
+        Assert.IsTrue(metadata.AllowUnsafeBlocks);
+        CollectionAssert.Contains(metadata.GetPackageReferences().ToArray(), "FakePackage");
+    }
+
+    [TestMethod]
+    public void UpdateProjectMetadataInitializesProject()
+    {
+        EnsureCleanWorkspace();
+
+        var packageConfiguration = CreateDummyPackageConfiguration();
+        using var extensions = new ScriptExtensions(packageConfiguration, $"{nameof(UpdateProjectMetadataInitializesProject)}Output");
+
+        Assert.IsFalse(File.Exists("Extensions.csproj"));
+        extensions.UpdateProjectMetadata(default);
+
+        Assert.IsTrue(File.Exists("Extensions.csproj"));
+        Assert.AreEqual(default(ScriptExtensionsProjectMetadata).GetProjectXml(), extensions.LoadProjectMetadata().GetProjectXml());
+    }
+
+    [TestMethod]
+    public void AddAssemblyReferencesInitializesProject()
+    {
+        EnsureCleanWorkspace();
+
+        var packageConfiguration = CreateDummyPackageConfiguration();
+        using var extensions = new ScriptExtensions(packageConfiguration, $"{nameof(AddAssemblyReferencesInitializesProject)}Output");
+
+        Assert.IsFalse(File.Exists("Extensions.csproj"));
+        extensions.AddAssemblyReferences([DummyPackageA.Id]);
+
+        Assert.IsTrue(File.Exists("Extensions.csproj"));
+        var metadata = extensions.LoadProjectMetadata();
+        CollectionAssert.Contains(metadata.GetPackageReferences().ToArray(), DummyPackageA.Id);
+    }
+
+    [TestMethod]
+    public void AddAssemblyReferencesUpdatesExistingProject()
+    {
+        EnsureCleanWorkspace();
+
+        File.WriteAllText
+        (
+            "Extensions.csproj",
+            $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+                <TargetFramework>net472</TargetFramework>
+              </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="{DummyPackageA.Id}" Version="{DummyPackageA.Version}" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        var packageConfiguration = CreateDummyPackageConfiguration();
+        using var extensions = new ScriptExtensions(packageConfiguration, $"{nameof(AddAssemblyReferencesUpdatesExistingProject)}Output");
+
+        var before = extensions.LoadProjectMetadata().GetPackageReferences();
+        CollectionAssert.Contains(before.ToArray(), DummyPackageA.Id);
+        CollectionAssert.DoesNotContain(before.ToArray(), DummyPackageB.Id);
+
+        extensions.AddAssemblyReferences([DummyPackageB.Id]);
+
+        var after = extensions.LoadProjectMetadata().GetPackageReferences();
+        CollectionAssert.Contains(after.ToArray(), DummyPackageA.Id);
+        CollectionAssert.Contains(after.ToArray(), DummyPackageB.Id);
+    }
+
+    [TestMethod]
+    // Regression test for https://github.com/bonsai-rx/bonsai/issues/2055
+    public void AddAssemblyReferencesUpdatesAreNonDestructive()
+    {
+        EnsureCleanWorkspace();
+
+        // A few edge cases exist that are not handled due to the way System.Xml.Linq works and therefore intentionally not tested:
+        // * XML declaration / processing instructions are not preserved -- It is legacy/meaningless to include these in a csproj
+        // * Trailing whitespace after the final closing tag
+        // * Mixed newlines or newlines not matching the environment -- They're always normalized.
+        string projectFileStart =
+            $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+                {"\t"}<PropertyGroup>
+            {"\t\t"}<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+                    <TargetFramework>net472</TargetFramework>
+              </PropertyGroup>
+
+
+
+            <ItemGroup>
+                <!-- This is a comment before the first package reference -->
+                <PackageReference Include="{DummyPackageA.Id}" Version="{DummyPackageA.Version}" />
+
+            """.NormalizeNewlines();
+        string projectFileEnd =
+            $"""
+                <!-- This one is last! -->
+              </ItemGroup>
+            </Project>
+            """.NormalizeNewlines();
+
+        File.WriteAllText
+        (
+            "Extensions.csproj",
+            projectFileStart + projectFileEnd,
+            Encoding.UTF8
+        );
+
+        var packageConfiguration = CreateDummyPackageConfiguration();
+        using var extensions = new ScriptExtensions(packageConfiguration, $"{nameof(AddAssemblyReferencesUpdatesExistingProject)}Output");
+
+        extensions.AddAssemblyReferences([DummyPackageB.Id]);
+
+        string after = File.ReadAllText("Extensions.csproj");
+        Assert.AreEqual(projectFileStart + $"""    <PackageReference Include="{DummyPackageB.Id}" Version="{DummyPackageB.Version}" />{Environment.NewLine}""" + projectFileEnd, after);
+    }
+}

--- a/Bonsai.Configuration.Tests/TestHelpers.cs
+++ b/Bonsai.Configuration.Tests/TestHelpers.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace Bonsai.Configuration.Tests;
+
+internal static class TestHelpers
+{
+    /// <summary>Normalizes newlines to <see cref="Environment.NewLine"/>, intended for use with raw strings when newlines matter</summary>
+    internal static string NormalizeNewlines(this string value)
+        => Regex.Replace(value, "\r?\n", Environment.NewLine);
+}

--- a/Bonsai.Configuration/ScriptExtensions.cs
+++ b/Bonsai.Configuration/ScriptExtensions.cs
@@ -1,11 +1,9 @@
-﻿using NuGet.Configuration;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Xml;
-using System.Xml.Linq;
+using NuGet.Configuration;
 
 namespace Bonsai.Configuration
 {
@@ -73,17 +71,8 @@ namespace Bonsai.Configuration
             if (!File.Exists(ProjectFileName))
                 return default;
 
-            var readerSettings = new XmlReaderSettings()
-            {
-                IgnoreWhitespace = true,
-                IgnoreProcessingInstructions = true,
-                DtdProcessing = DtdProcessing.Prohibit
-            };
-
             using var stream = File.OpenRead(ProjectFileName);
-            using var reader = XmlReader.Create(stream, readerSettings);
-            var document = XDocument.Load(reader, LoadOptions.None);
-            return new ScriptExtensionsProjectMetadata(document);
+            return new ScriptExtensionsProjectMetadata(stream);
         }
 
         public void UpdateProjectMetadata(ScriptExtensionsProjectMetadata projectMetadata)

--- a/Bonsai.Editor/Properties/AssemblyInfo.cs
+++ b/Bonsai.Editor/Properties/AssemblyInfo.cs
@@ -1,8 +1,7 @@
 ﻿using System.Runtime.CompilerServices;
 using Bonsai;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: WorkflowNamespaceIcon("Bonsai.Editor.Scripting", "Bonsai:ElementIcon.CSharp")]
-[assembly: InternalsVisibleTo("Bonsai.Editor.Tests")]

--- a/Bonsai.sln
+++ b/Bonsai.sln
@@ -70,12 +70,15 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tooling", "tooling", "{69C99DD4-0616-43BB-82EC-EABE18279BCC}"
 	ProjectSection(SolutionItems) = preProject
 		tooling\Common.csproj.props = tooling\Common.csproj.props
+		tooling\Common.csproj.targets = tooling\Common.csproj.targets
 		tooling\Common.props = tooling\Common.props
 		tooling\Common.targets = tooling\Common.targets
 		tooling\Common.wixproj.props = tooling\Common.wixproj.props
 		tooling\CurrentVersion.props = tooling\CurrentVersion.props
 		tooling\Versioning.props = tooling\Versioning.props
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Configuration.Tests", "Bonsai.Configuration.Tests\Bonsai.Configuration.Tests.csproj", "{024A09F4-7525-4EE3-B07F-4097A9415C89}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -115,10 +118,6 @@ Global
 		{B783D74F-CB2D-4419-B438-266CD15774FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B783D74F-CB2D-4419-B438-266CD15774FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B783D74F-CB2D-4419-B438-266CD15774FB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A341A5A1-45A6-4B35-9AB1-FE42C622F738}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A341A5A1-45A6-4B35-9AB1-FE42C622F738}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A341A5A1-45A6-4B35-9AB1-FE42C622F738}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A341A5A1-45A6-4B35-9AB1-FE42C622F738}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6DAA7012-22BF-4E0B-A7DB-B7A8B2A95F0A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6DAA7012-22BF-4E0B-A7DB-B7A8B2A95F0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6DAA7012-22BF-4E0B-A7DB-B7A8B2A95F0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -127,14 +126,6 @@ Global
 		{B9456E54-9249-4178-951A-166A6F54A206}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B9456E54-9249-4178-951A-166A6F54A206}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B9456E54-9249-4178-951A-166A6F54A206}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D487E501-77E3-4A1C-943E-F4F2534E3BC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D487E501-77E3-4A1C-943E-F4F2534E3BC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D487E501-77E3-4A1C-943E-F4F2534E3BC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D487E501-77E3-4A1C-943E-F4F2534E3BC8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{18A71178-6045-49A6-810B-1F5E50DD621F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{18A71178-6045-49A6-810B-1F5E50DD621F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{18A71178-6045-49A6-810B-1F5E50DD621F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{18A71178-6045-49A6-810B-1F5E50DD621F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{156452CC-3847-4706-AC65-4FA3BECA88EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{156452CC-3847-4706-AC65-4FA3BECA88EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{156452CC-3847-4706-AC65-4FA3BECA88EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -211,6 +202,10 @@ Global
 		{FD09545E-4FB8-4730-B936-FE0BCF43E883}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD09545E-4FB8-4730-B936-FE0BCF43E883}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD09545E-4FB8-4730-B936-FE0BCF43E883}.Release|Any CPU.Build.0 = Release|Any CPU
+		{024A09F4-7525-4EE3-B07F-4097A9415C89}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{024A09F4-7525-4EE3-B07F-4097A9415C89}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{024A09F4-7525-4EE3-B07F-4097A9415C89}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{024A09F4-7525-4EE3-B07F-4097A9415C89}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tooling/Common.csproj.props
+++ b/tooling/Common.csproj.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Common C# Properties -->
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Features>strict</Features>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 

--- a/tooling/Common.csproj.targets
+++ b/tooling/Common.csproj.targets
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Automatically expose internals to tests -->
+  <ItemGroup Condition="'$(IsTestProject)' != 'true'">
+    <InternalsVisibleTo Include="$(MSBuildProjectName).Tests" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Was initially focused on https://github.com/bonsai-rx/bonsai/issues/2055, which was caused by an oversight done when refactoring the several redundant XML parsing entrypoints during https://github.com/bonsai-rx/bonsai/pull/1753 (Prior to the refactor, all of them stripped whitespace *except* for the one that loaded the project for adding package references. That exception was lost in the refactor.)

While I was at it I wrote a suite of unit tests related to the handling of `Extensions.csproj` and fixed some other issues I found along the way.

* Fix whitespace being stripped during automatic updates
* Fix fresh `Extensions.csproj` always being written with CRLF newlines
* Fix `ScriptExtensionsProjectMetadata` not actually being immutable as intended
* Fix adding redundant `ItemGroup` when all `PackageReference`s were removed but the group wasn't
* Added automatic exposing of assembly internals to the relevant test assembly
* Upgraded to C# 12 to get raw strings (our `global.json` already requires the .NET 8 SDK anyway)

Fixes https://github.com/bonsai-rx/bonsai/issues/2055