### PR TITLE
Add multiline string editor for string properties

### DIFF
--- a/Bonsai.Core/Expressions/Properties/StringProperty.cs
+++ b/Bonsai.Core/Expressions/Properties/StringProperty.cs
@@ -11,5 +11,14 @@ namespace Bonsai.Expressions
     [Description("Represents a workflow property containing Unicode text.")]
     public class StringProperty : WorkflowProperty<string>
     {
+        /// <summary>
+        /// Gets or sets the value of the property.
+        /// </summary>
+        [Editor(DesignTypes.MultilineStringEditor, DesignTypes.UITypeEditor)]
+        public new string Value
+        {
+            get => base.Value;
+            set => base.Value = value;
+        }
     }
 }


### PR DESCRIPTION
Here we add a new `Value` property to the `StringProperty` class, and attach an `EditorAttribute` to the property declaration for the purposes of allowing editing of multi-line strings.

Fixes #2190 