### PR TITLE
Improve editor experience when manipulating visualizer mappings

### DIFF
--- a/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
@@ -141,7 +141,7 @@
             this.visualizerToolStripMenuItem.Enabled = false;
             this.visualizerToolStripMenuItem.Name = "visualizerToolStripMenuItem";
             this.visualizerToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
-            this.visualizerToolStripMenuItem.Text = "Show Visualizer";
+            this.visualizerToolStripMenuItem.Text = global::Bonsai.Editor.Properties.Resources.ShowVisualizerMenuItem;
             // 
             // defaultEditorToolStripMenuItem
             // 

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -433,7 +433,7 @@ namespace Bonsai.Editor.GraphView
 
             var builder = (InspectBuilder)Workflow[node.Index].Value;
             var visualizerDialogs = (VisualizerDialogMap)serviceProvider.GetService(typeof(VisualizerDialogMap));
-            if (visualizerDialogs != null)
+            if (visualizerDialogs != null && builder.TryGetRuntimeVisualizerSource(out var _))
             {
                 if (!visualizerDialogs.TryGetValue(builder, out VisualizerDialogLauncher visualizerLauncher))
                 {

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1424,12 +1424,15 @@ namespace Bonsai.Editor.GraphView
 
         private void CreateVisualizerMenuItems(
             string activeVisualizerTypeName,
-            InspectBuilder visualizerElement,
+            InspectBuilder inspectBuilder,
             ToolStripMenuItem ownerItem,
             GraphNode selectedNode)
         {
-            if (visualizerElement.ObservableType != null &&
-                (!editorState.WorkflowRunning || visualizerElement.PublishNotifications))
+            var visualizerElement = ExpressionBuilder.GetVisualizerElement(inspectBuilder);
+            if (visualizerElement.ObservableType is not null &&
+                (!editorState.WorkflowRunning ||
+                visualizerElement.PublishNotifications &&
+                inspectBuilder.Builder is not VisualizerMappingBuilder))
             {
                 var visualizerTypes = Enumerable.Repeat<Type>(null, 1);
                 visualizerTypes = visualizerTypes.Concat(typeVisualizerMap.GetTypeVisualizers(visualizerElement));
@@ -1618,8 +1621,7 @@ namespace Bonsai.Editor.GraphView
                 }
 
                 var activeVisualizer = GetActiveVisualizerTypeName(workflowElement, inspectBuilder);
-                var visualizerElement = ExpressionBuilder.GetVisualizerElement(inspectBuilder);
-                CreateVisualizerMenuItems(activeVisualizer, visualizerElement, visualizerToolStripMenuItem, selectedNode);
+                CreateVisualizerMenuItems(activeVisualizer, inspectBuilder, visualizerToolStripMenuItem, selectedNode);
             }
         }
 

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1429,10 +1429,12 @@ namespace Bonsai.Editor.GraphView
             GraphNode selectedNode)
         {
             var visualizerElement = ExpressionBuilder.GetVisualizerElement(inspectBuilder);
+            var canShowVisualizer = inspectBuilder.Builder is not VisualizerMappingBuilder;
+            ownerItem.Text = canShowVisualizer ? Resources.ShowVisualizerMenuItem : Resources.SelectVisualizerMenuItem;
             if (visualizerElement.ObservableType is not null &&
                 (!editorState.WorkflowRunning ||
                 visualizerElement.PublishNotifications &&
-                inspectBuilder.Builder is not VisualizerMappingBuilder))
+                canShowVisualizer))
             {
                 var visualizerTypes = Enumerable.Repeat<Type>(null, 1);
                 visualizerTypes = visualizerTypes.Concat(typeVisualizerMap.GetTypeVisualizers(visualizerElement));
@@ -1640,6 +1642,7 @@ namespace Bonsai.Editor.GraphView
 
             outputToolStripMenuItem.Text = Resources.OutputMenuItemLabel;
             subjectTypeToolStripMenuItem.Text = Resources.CreateSourceMenuItemLabel;
+            visualizerToolStripMenuItem.Text = Resources.ShowVisualizerMenuItem;
             outputToolStripMenuItem.DropDownItems.Clear();
             subjectTypeToolStripMenuItem.DropDownItems.Clear();
             externalizeToolStripMenuItem.DropDownItems.Clear();

--- a/Bonsai.Editor/Layout/VisualizerLayoutMap.cs
+++ b/Bonsai.Editor/Layout/VisualizerLayoutMap.cs
@@ -31,6 +31,8 @@ namespace Bonsai.Design
             for (int i = 0; i < workflow.Count; i++)
             {
                 var builder = (InspectBuilder)workflow[i].Value;
+                if (builder.ObservableType is null) continue;
+
                 if (lookup.TryGetValue(builder, out VisualizerDialogSettings dialogSettings))
                 {
                     visualizerDialogs.Add(builder, workflow, dialogSettings);

--- a/Bonsai.Editor/Properties/Resources.Designer.cs
+++ b/Bonsai.Editor/Properties/Resources.Designer.cs
@@ -418,6 +418,15 @@ namespace Bonsai.Editor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The specified workflow path does not resolve to a workflow expression builder node..
+        /// </summary>
+        internal static string InvalidWorkflowPath_Error {
+            get {
+                return ResourceManager.GetString("InvalidWorkflowPath_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap NewMenuImage {
@@ -434,14 +443,6 @@ namespace Bonsai.Editor.Properties {
             get {
                 object obj = ResourceManager.GetObject("OpenMenuImage", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
-            }
-        }
-        
-        ///   Looks up a localized string similar to The specified workflow path does not resolve to a workflow expression builder node..
-        /// </summary>
-        internal static string InvalidWorkflowPath_Error {
-            get {
-                return ResourceManager.GetString("InvalidWorkflowPath_Error", resourceCulture);
             }
         }
         
@@ -680,6 +681,24 @@ namespace Bonsai.Editor.Properties {
             get {
                 object obj = ResourceManager.GetObject("SelectAllMenuImage", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select Visualizer.
+        /// </summary>
+        internal static string SelectVisualizerMenuItem {
+            get {
+                return ResourceManager.GetString("SelectVisualizerMenuItem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show Visualizer.
+        /// </summary>
+        internal static string ShowVisualizerMenuItem {
+            get {
+                return ResourceManager.GetString("ShowVisualizerMenuItem", resourceCulture);
             }
         }
         

--- a/Bonsai.Editor/Properties/Resources.resx
+++ b/Bonsai.Editor/Properties/Resources.resx
@@ -342,6 +342,12 @@ NOTE: You will have to restart Bonsai for any changes to take effect.</value>
   <data name="Editor_HelpLabel" xml:space="preserve">
     <value>Help</value>
   </data>
+  <data name="ShowVisualizerMenuItem" xml:space="preserve">
+    <value>Show Visualizer</value>
+  </data>
+  <data name="SelectVisualizerMenuItem" xml:space="preserve">
+    <value>Select Visualizer</value>
+  </data>
   <data name="BrowseDirectoryMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO


### PR DESCRIPTION
Visualizer mapping operators are handled by the editor in potentially surprising ways as they should not be visualized directly as other nodes, and changing their target visualizer also does not cause a dialog to appear. Instead, all these effects are targeted at visualizer composition happening in the downstream operator.

To make this more clear, here we change the label of visualizer mapping context menu to display "Select Visualizer" rather than "Show Visualizer" and also prevent any runtime changes (as they would never take effect until the next build anyway).

Finally, we fix a few issues with states which were left unguarded when launching or restoring visualizer dialogs.

Fixes #1791 
Fixes #2177 