### PR TITLE
Fallback to base url when no docs are found

### DIFF
--- a/Bonsai.Editor/DocumentationHelper.cs
+++ b/Bonsai.Editor/DocumentationHelper.cs
@@ -54,7 +54,7 @@ namespace Bonsai.Editor
             for (int i = 0; i < hrefs.Length; i++)
             {
                 try { return await GetXRefMapAsync($"{baseUrl}{hrefs[i]}"); }
-                catch (WebException ex) when (ex.Response is HttpWebResponse { StatusCode: HttpStatusCode.NotFound })
+                catch (HttpRequestException ex)
                 { lastException ??= ex; } // Always prefer a DocumentationException as it'll be more specific
                 catch (DocumentationException ex)
                 { lastException = ex; }

--- a/Bonsai.Editor/DocumentationHelper.cs
+++ b/Bonsai.Editor/DocumentationHelper.cs
@@ -39,8 +39,15 @@ namespace Bonsai.Editor
 
         static async Task<Uri> GetDocumentationAsync(string baseUrl, string uid)
         {
-            var lookup = await GetXRefMapAsync(baseUrl.TrimEnd('/'), "/docs", string.Empty);
-            return new Uri(lookup[uid]);
+            try
+            {
+                var lookup = await GetXRefMapAsync(baseUrl.TrimEnd('/'), "/docs", string.Empty);
+                return new Uri(lookup[uid]);
+            }
+            catch (Exception ex) when (ex is DocumentationException || ex is HttpRequestException)
+            {
+                return new Uri(baseUrl);
+            }
         }
 
         static async Task<Dictionary<string, string>> GetXRefMapAsync(string baseUrl, params string[] hrefs)


### PR DESCRIPTION
When searching for operator documentation, the editor starts from the project URL specified in the operator package and the UID of the operator fully qualified type. For successful resolution to work, the project URL must currently host a `xrefmap.yml` file containing the specified UID inside.

For various reasons this ends up being impractical behavior for many projects. To begin with, it assumes all projects must be documented using [docfx](https://dotnet.github.io/docfx/), and that all projects went to the trouble of defining a complete reference documentation.

Instead, it is very often the case that documentation has still not been finalized for a project, and the project URL may simply be pointing to a version control repository, or that the developers of a package simply wish to point everyone to a single common entry point. These valid references would still be more useful to display as operator help than the error message saying that the specific UID xref could not be resolved.

Here we introduce a top-level fallback where failure to retrieve the `xrefmap.yml` file and the specific `href` inside it will make the editor display the specified package project URL, if any.

Fixes #2065 