### PR TITLE
Clear annotation panel on new workflow creation

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -784,6 +784,7 @@ namespace Bonsai.Editor
             ClearWorkflowError();
             saveWorkflowDialog.FileName = null;
             workflowBuilder.Workflow.Clear();
+            editorControl.ClearAnnotationPanel();
             editorControl.ResetEditorLayout();
             editorSite.ValidateWorkflow();
             visualizerSettings.Clear();

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -784,7 +784,8 @@ namespace Bonsai.Editor
             ClearWorkflowError();
             saveWorkflowDialog.FileName = null;
             workflowBuilder.Workflow.Clear();
-            editorControl.ClearAnnotationPanel();
+            if (editorControl.AnnotationPanel.Tag is ExpressionBuilder)
+                editorControl.ClearAnnotationPanel();
             editorControl.ResetEditorLayout();
             editorSite.ValidateWorkflow();
             visualizerSettings.Clear();

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -91,6 +91,12 @@ namespace Bonsai.Editor.GraphView
         public void CollapseAnnotationPanel()
         {
             splitContainer.Panel1Collapsed = true;
+            ClearAnnotationPanel();
+        }
+
+        public void ClearAnnotationPanel()
+        {
+            annotationPanel.NavigateToString(string.Empty);
             annotationPanel.Tag = null;
         }
 

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -553,8 +553,7 @@ namespace Bonsai.Editor.GraphView
                     var workflowBuilder = (WorkflowBuilder)serviceProvider.GetService(typeof(WorkflowBuilder));
                     if (!workflowBuilder.Workflow.Descendants().Contains(builder))
                     {
-                        EditorControl.AnnotationPanel.NavigateToString(string.Empty);
-                        EditorControl.AnnotationPanel.Tag = null;
+                        EditorControl.ClearAnnotationPanel();
                     }
                 }
             }


### PR DESCRIPTION
The contents of the annotation panel should be cleared if they relate to the specific workflow which has been cleared by the new action. If contents relate to browsing documentation pages, we leave them, as in this case no explicit link exists between the contents of the browser and the workflow.

Fixes #2067 