### PR TITLE
Ensure property mapping and member selector operators prefer derived properties

### DIFF
--- a/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
+++ b/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
@@ -300,6 +300,17 @@ namespace Bonsai.Core.Tests
         }
 
         [TestMethod]
+        [ExpectedException(typeof(WorkflowBuildException))]
+        public void Build_PropertyMappingToMissingProperty_ThrowsWorkflowBuildException()
+        {
+            new TestWorkflow()
+                .AppendValue(1)
+                .AppendPropertyMapping(nameof(DerivedNewProperty.AnotherValue))
+                .AppendCombinator(new DerivedValueProperty())
+                .BuildObservable<Unit>();
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
         public void BuildObservable_InvalidWorkflowType_ThrowsArgumentException()
         {

--- a/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
+++ b/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
@@ -290,6 +290,16 @@ namespace Bonsai.Core.Tests
         }
 
         [TestMethod]
+        public void Build_PropertyMappingToInheritedHiddenProperty_PreferDerivedProperty()
+        {
+            new TestWorkflow()
+                .AppendValue(1)
+                .AppendPropertyMapping(nameof(DerivedValueProperty.Value))
+                .AppendCombinator(new DerivedNewProperty())
+                .BuildObservable<Unit>();
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
         public void BuildObservable_InvalidWorkflowType_ThrowsArgumentException()
         {
@@ -323,6 +333,11 @@ namespace Bonsai.Core.Tests
         {
             [Range(0, 100)]
             public new int Value { get; set; }
+        }
+
+        class DerivedNewProperty : DerivedValueProperty
+        {
+            public int AnotherValue { get; set; }
         }
 
         class MergeBranchVisitor : ExpressionVisitor

--- a/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
+++ b/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
@@ -312,7 +312,7 @@ namespace Bonsai.Core.Tests
 
         [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
-        public void BuildObservable_InvalidWorkflowType_ThrowsArgumentException()
+        public void BuildObservable_InvalidWorkflowType_ThrowsInvalidOperationException()
         {
             new TestWorkflow()
                 .AppendValue(0)

--- a/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
+++ b/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
@@ -280,6 +280,16 @@ namespace Bonsai.Core.Tests
         }
 
         [TestMethod]
+        public void Build_PropertyMappingToHiddenProperty_PreferDerivedProperty()
+        {
+            new TestWorkflow()
+                .AppendValue(1)
+                .AppendPropertyMapping(nameof(DerivedValueProperty.Value))
+                .AppendCombinator(new DerivedValueProperty())
+                .BuildObservable<Unit>();
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
         public void BuildObservable_InvalidWorkflowType_ThrowsArgumentException()
         {
@@ -307,6 +317,12 @@ namespace Bonsai.Core.Tests
                 .AppendOutput()
                 .BuildObservable<double>();
             Assert.IsNotNull(workflow);
+        }
+
+        class DerivedValueProperty : WorkflowProperty<int>
+        {
+            [Range(0, 100)]
+            public new int Value { get; set; }
         }
 
         class MergeBranchVisitor : ExpressionVisitor

--- a/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
+++ b/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
@@ -340,17 +340,6 @@ namespace Bonsai.Core.Tests
             Assert.IsNotNull(workflow);
         }
 
-        class DerivedValueProperty : WorkflowProperty<int>
-        {
-            [Range(0, 100)]
-            public new int Value { get; set; }
-        }
-
-        class DerivedNewProperty : DerivedValueProperty
-        {
-            public int AnotherValue { get; set; }
-        }
-
         class MergeBranchVisitor : ExpressionVisitor
         {
             public int BranchCount { get; private set; }

--- a/Bonsai.Core.Tests/ExpressionHelperTests.cs
+++ b/Bonsai.Core.Tests/ExpressionHelperTests.cs
@@ -73,5 +73,12 @@ namespace Bonsai.Core.Tests
             var derivedValue = Expression.Constant(new DerivedValueProperty());
             ExpressionHelper.MemberAccess(derivedValue, nameof(DerivedValueProperty.Value));
         }
+
+        [TestMethod]
+        public void MemberAccess_SameNameInternalFieldInDerivedType_PreferDerivedField()
+        {
+            var derivedValue = Expression.Constant(new DerivedNewProperty());
+            ExpressionHelper.MemberAccess(derivedValue, nameof(DerivedNewProperty.InternalField));
+        }
     }
 }

--- a/Bonsai.Core.Tests/ExpressionHelperTests.cs
+++ b/Bonsai.Core.Tests/ExpressionHelperTests.cs
@@ -7,7 +7,6 @@ namespace Bonsai.Core.Tests
     [TestClass]
     public class ExpressionHelperTests
     {
-        static readonly Expression NullConstant = Expression.Constant(null);
         static readonly Expression PrimitiveConstant = Expression.Constant(string.Empty);
         static readonly Type PrimitiveAccessMemberType = typeof(int);
         const string PrimitiveAccess = "Length";
@@ -66,6 +65,13 @@ namespace Bonsai.Core.Tests
         public void MemberAccess_MethodName_ThrowsArgumentException()
         {
             ExpressionHelper.MemberAccess(PrimitiveConstant, "ToString");
+        }
+
+        [TestMethod]
+        public void MemberAccess_HiddenPropertyInDerivedType_PreferDerivedProperty()
+        {
+            var derivedValue = Expression.Constant(new DerivedValueProperty());
+            ExpressionHelper.MemberAccess(derivedValue, nameof(DerivedValueProperty.Value));
         }
     }
 }

--- a/Bonsai.Core.Tests/TestTypes.cs
+++ b/Bonsai.Core.Tests/TestTypes.cs
@@ -1,4 +1,5 @@
 ﻿using System.Xml.Serialization;
+using Bonsai.Expressions;
 
 namespace Bonsai.Core.Tests
 {
@@ -29,5 +30,16 @@ namespace Bonsai.Core.Tests
         public class ExtraType : PolymorphicType
         {
         }
+    }
+
+    class DerivedValueProperty : WorkflowProperty<int>
+    {
+        [Range(0, 100)]
+        public new int Value { get; set; }
+    }
+
+    class DerivedNewProperty : DerivedValueProperty
+    {
+        public int AnotherValue { get; set; }
     }
 }

--- a/Bonsai.Core.Tests/TestTypes.cs
+++ b/Bonsai.Core.Tests/TestTypes.cs
@@ -36,10 +36,14 @@ namespace Bonsai.Core.Tests
     {
         [Range(0, 100)]
         public new int Value { get; set; }
+
+        internal int InternalField;
     }
 
     class DerivedNewProperty : DerivedValueProperty
     {
         public int AnotherValue { get; set; }
+
+        internal new int InternalField;
     }
 }

--- a/Bonsai.Core/ExpressionHelper.cs
+++ b/Bonsai.Core/ExpressionHelper.cs
@@ -257,6 +257,23 @@ namespace Bonsai
             return instance;
         }
 
+        internal static MemberExpression Property(Expression expression, string propertyName)
+        {
+            var type = expression.Type;
+            while (type is not null)
+            {
+                var bindingFlags = BindingFlags.Instance | BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly;
+                var property = type.GetProperty(propertyName, bindingFlags | BindingFlags.Public);
+                property ??= type.GetProperty(propertyName, bindingFlags | BindingFlags.NonPublic);
+                if (property is not null)
+                    return Expression.Property(expression, property);
+
+                type = type.BaseType;
+            }
+
+            throw new ArgumentException($"Instance property '{propertyName}' is not defined for type '{expression.Type}'");
+        }
+
         static Expression PropertyOrField(Expression instance, string propertyOrFieldName)
         {
             if (instance.Type.IsInterface)

--- a/Bonsai.Core/Expressions/BinaryOperatorBuilder.cs
+++ b/Bonsai.Core/Expressions/BinaryOperatorBuilder.cs
@@ -133,7 +133,7 @@ namespace Bonsai.Expressions
                 var accumulator = Expression.Variable(elementType);
                 var loopLabel = Expression.Label(elementType);
                 var moveNext = Expression.Call(enumerator, MoveNextMethod);
-                var current = Expression.Property(enumerator, "Current");
+                var current = Expression.Property(enumerator, nameof(IEnumerator.Current));
                 return Expression.Block(new[] { enumerator, accumulator },
                     Expression.Assign(enumerator, enumeratorCall),
                     Expression.IfThen(
@@ -166,7 +166,7 @@ namespace Bonsai.Expressions
 
                 left = expression;
                 var operandExpression = Expression.Constant(operand);
-                right = Expression.Property(operandExpression, "Value");
+                right = ExpressionHelper.Property(operandExpression, "Value");
             }
 
             return ConvertAndBuildSelector(left, right);

--- a/Bonsai.Core/Expressions/ExpressionBuilder.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilder.cs
@@ -1101,7 +1101,7 @@ namespace Bonsai.Expressions
                 else property = Expression.Property(instance, propertyInfo);
             }
 
-            property ??= Expression.Property(instance, propertyName);
+            property ??= ExpressionHelper.Property(instance, propertyName);
             if (source == EmptyExpression.Instance) return source;
             var sourceType = source.Type.GetGenericArguments()[0];
             var parameter = Expression.Parameter(sourceType);

--- a/Bonsai.Core/Expressions/GetValueOrDefaultBuilder.cs
+++ b/Bonsai.Core/Expressions/GetValueOrDefaultBuilder.cs
@@ -53,7 +53,7 @@ namespace Bonsai.Expressions
 
             var left = expression;
             var operandExpression = Expression.Constant(operand);
-            var right = Expression.Property(operandExpression, "Value");
+            var right = ExpressionHelper.Property(operandExpression, "Value");
             return BuildSelector(left, right);
         }
     }

--- a/Bonsai.Core/Expressions/HasFlagBuilder.cs
+++ b/Bonsai.Core/Expressions/HasFlagBuilder.cs
@@ -64,7 +64,7 @@ namespace Bonsai.Expressions
 
                 left = expression;
                 var operandExpression = Expression.Constant(operand);
-                right = Expression.Property(operandExpression, "Value");
+                right = ExpressionHelper.Property(operandExpression, "Value");
             }
 
             return BuildSelector(left, right);

--- a/Bonsai.Core/Expressions/IndexBuilder.cs
+++ b/Bonsai.Core/Expressions/IndexBuilder.cs
@@ -67,7 +67,7 @@ namespace Bonsai.Expressions
 
                 left = expression;
                 var operandExpression = Expression.Constant(operand);
-                right = Expression.Property(operandExpression, "Value");
+                right = ExpressionHelper.Property(operandExpression, "Value");
             }
 
             return BuildSelector(left, right);

--- a/Bonsai.Core/Expressions/WorkflowPropertyDescriptor.cs
+++ b/Bonsai.Core/Expressions/WorkflowPropertyDescriptor.cs
@@ -15,7 +15,7 @@ namespace Bonsai.Expressions
             : base(name, attrs)
         {
             var propertyExpression = Expression.Constant(property);
-            var valueProperty = Expression.Property(propertyExpression, "Value");
+            var valueProperty = ExpressionHelper.Property(propertyExpression, "Value");
             var getterBody = Expression.Convert(valueProperty, typeof(object));
             getValue = Expression.Lambda<Func<object>>(getterBody).Compile();
 

--- a/Bonsai.Design.Visualizers/GraphHelper.cs
+++ b/Bonsai.Design.Visualizers/GraphHelper.cs
@@ -97,11 +97,11 @@ namespace Bonsai.Design.Visualizers
                 indexLabel = "Time";
             }
 
-            if (selectedIndex.Type == typeof(DateTimeOffset)) selectedIndex = Expression.Property(selectedIndex, nameof(DateTimeOffset.DateTime));
+            if (selectedIndex.Type == typeof(DateTimeOffset))
+                selectedIndex = Expression.Property(selectedIndex, nameof(DateTimeOffset.DateTime));
+
             if (selectedIndex.Type == typeof(DateTime))
-            {
                 selectedIndex = Expression.Convert(selectedIndex, typeof(XDate));
-            }
 
             return selectedIndex;
         }


### PR DESCRIPTION
By default, the named overload to the [`Expression.Property`](https://learn.microsoft.com/en-us/dotnet/api/system.linq.expressions.expression.property?view=net-9.0#system-linq-expressions-expression-property(system-linq-expressions-expression-system-string)) and [`Expression.PropertyOrField`](https://learn.microsoft.com/en-us/dotnet/api/system.linq.expressions.expression.propertyorfield?view=net-9.0) methods may throw an exception when accessing a property or field that hides an inherited member with the same name, due to the default rules used by the underlying [`System.Type.GetProperty`](https://learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-type-getproperty) method where an `AmbiguousMatchException` is thrown.

Here we rewrite several uses of these named accessors to ensure the most derived members with the same name are always preferred by searching incrementally through the type hierarchy.

Fixes #2200 