### PR TITLE
Ensure any workflow errors are cleared on open

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -832,6 +832,7 @@ namespace Bonsai.Editor
             }
 
             workflowBuilder = PrepareWorkflow(workflowBuilder, workflowVersion, out bool upgraded);
+            ClearWorkflowError();
             FileName = fileName;
 
             var settingsDirectory = Project.GetWorkflowSettingsDirectory(fileName);


### PR DESCRIPTION
Changes to the editor navigation model introduced in #1870 created a regression where initializing the editor layout will check for pending exceptions to highlight. If a previous workflow had been left with errors this would cause an unhandled exception since the old nodes are no longer present following successful opening of a new file.

Here we ensure workflow errors are cleared as soon as the workflow builder is set to the newly open file.

Fixes #2202 