### PR TITLE
Use workflow filename as default export image name

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1148,6 +1148,7 @@ namespace Bonsai.Editor
             var model = selectionModel.SelectedView;
             if (model?.Workflow.Count > 0)
             {
+                exportImageDialog.FileName = Path.GetFileNameWithoutExtension(FileName);
                 if (exportImageDialog.ShowDialog() == DialogResult.OK)
                 {
                     ExportImage(model, exportImageDialog.FileName);


### PR DESCRIPTION
To make it easier to generate documentation images from existing workflow files, here we set the default export image name to match the workflow filename. If no file has been saved yet, the dialog will retain its current behavior of leaving the filename empty.

Fixes #1536 