### PR TITLE
Expose texture array interface on texture sequence

### DIFF
--- a/Bonsai.Shaders/ITextureArray.cs
+++ b/Bonsai.Shaders/ITextureArray.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+
+namespace Bonsai.Shaders
+{
+    /// <summary>
+    /// Represents a read-only array of texture objects that can be accessed by index.
+    /// </summary>
+    public interface ITextureArray : IEnumerable<int>
+    {
+        /// <summary>
+        /// Gets the total number of texture objects in the array.
+        /// </summary>
+        int Length { get; }
+
+        /// <summary>
+        /// Gets the texture object at the specified index.
+        /// </summary>
+        /// <param name="index">
+        /// The zero-based index of the texture object to get.
+        /// </param>
+        /// <returns>
+        /// The handle to the texture object at the specified index.
+        /// </returns>
+        int this[int index] { get; }
+    }
+}

--- a/Bonsai.Shaders/TextureArray.cs
+++ b/Bonsai.Shaders/TextureArray.cs
@@ -8,7 +8,7 @@ namespace Bonsai.Shaders
     /// <summary>
     /// Represents an array of texture objects.
     /// </summary>
-    public class TextureArray : IDisposable, IEnumerable<int>
+    public class TextureArray : IDisposable, ITextureArray
     {
         readonly int[] textures;
 

--- a/Bonsai.Shaders/TextureSequence.cs
+++ b/Bonsai.Shaders/TextureSequence.cs
@@ -1,9 +1,10 @@
 ﻿using Bonsai.Reactive;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Bonsai.Shaders
 {
-    class TextureSequence : Texture, ITextureSequence
+    class TextureSequence : Texture, ITextureSequence, ITextureArray
     {
         readonly TextureArray textures;
 
@@ -65,5 +66,23 @@ namespace Bonsai.Shaders
             {
             }
         }
+
+        #region ITextureArray Members
+
+        int ITextureArray.Length => textures.Length;
+
+        int ITextureArray.this[int index] => textures[index];
+
+        IEnumerator<int> IEnumerable<int>.GetEnumerator()
+        {
+            return textures.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return textures.GetEnumerator();
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
As discussed in #1968 and #1999, there is often a need to explicitly access the array of textures stored in a texture sequence for custom purposes. Here we provide a new interface `ITextureArray` matching the already public class `TextureArray` and also provide an adapter to this interface via the `TextureSequence` class.

This allows downcasting from a texture sequence into `ITextureArray` for the purposes of accessing the internal texture handles:

```c#
if (window.ResourceManager.Load<Texture>(name) is ITextureArray array)
{
    for (int i = 0; i < array.Length; i++)
        GL.BindTexture(TextureTarget, array[i]);
}
```

Fixes #1968 