### PR TITLE
Add obsolete message to operator descriptions

### DIFF
--- a/Bonsai.Editor/GraphModel/ElementHelper.cs
+++ b/Bonsai.Editor/GraphModel/ElementHelper.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
+using System.Text;
 using Bonsai.Expressions;
 
 namespace Bonsai.Editor.GraphModel
@@ -44,14 +46,30 @@ namespace Bonsai.Editor.GraphModel
 
         public static string GetElementDescription(object component)
         {
+            string description;
             if (component is WorkflowExpressionBuilder workflowExpressionBuilder)
             {
-                var description = workflowExpressionBuilder.Description;
+                description = workflowExpressionBuilder.Description;
                 if (!string.IsNullOrEmpty(description)) return description;
             }
 
-            var descriptionAttribute = (DescriptionAttribute)TypeDescriptor.GetAttributes(component)[typeof(DescriptionAttribute)];
-            return descriptionAttribute.Description;
+            var attributes = TypeDescriptor.GetAttributes(component);
+            var descriptionAttribute = (DescriptionAttribute)attributes[typeof(DescriptionAttribute)];
+            description = descriptionAttribute.Description;
+
+            if (attributes[typeof(ObsoleteAttribute)] is ObsoleteAttribute obsoleteAttribute)
+            {
+                var messageBuilder = new StringBuilder();
+                messageBuilder.Append("This operator is obsolete");
+                if (!string.IsNullOrEmpty(obsoleteAttribute.Message))
+                    messageBuilder.AppendFormat(": {0}", obsoleteAttribute.Message);
+                messageBuilder.AppendLine();
+                messageBuilder.AppendLine();
+                messageBuilder.Append(description);
+                description = messageBuilder.ToString();
+            }
+
+            return description;
         }
     }
 }


### PR DESCRIPTION
Deprecated operators are hidden from the toolbox, but remain visible in workflows containing them.

While clearly distinguished by a visual hash, here we include any deprecation message embedded in the type metadata onto the operator description displayed by the property grid when the operator is selected.

This allows more information to be conveyed on how to deal with the obsolete operator going forward.

Fixes #2207 