### PR TITLE
Avoid multiple shutdown paths out of StartWorkflow

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1381,9 +1381,11 @@ namespace Bonsai.Editor
 
         void HandleWorkflowError(Exception e)
         {
-            using var shutdown = building;
-            Action selectExceptionNode = () =>
+            if (InvokeRequired)
+                BeginInvoke(HandleWorkflowError, e);
+            else
             {
+                using var shutdown = building;
                 var workflowException = e as WorkflowException;
                 if (workflowException != null && workflowException.Builder != null || exceptionCache.TryGetValue(e, out workflowException))
                 {
@@ -1392,9 +1394,6 @@ namespace Bonsai.Editor
                 }
                 else editorSite.ShowError(e.Message, Name);
             };
-
-            if (InvokeRequired) Invoke(selectExceptionNode);
-            else selectExceptionNode();
         }
 
         void HandleWorkflowCompleted()

--- a/Bonsai.Editor/WorkflowDisposable.cs
+++ b/Bonsai.Editor/WorkflowDisposable.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Threading;
 
 namespace Bonsai.Editor
@@ -9,10 +10,10 @@ namespace Bonsai.Editor
         int disposed;
         readonly IDisposable disposable;
 
-        public WorkflowDisposable(IObservable<Unit> workflow, IDisposable disposable)
+        public WorkflowDisposable(IObservable<Unit> workflow, Action dispose)
         {
             Workflow = workflow;
-            this.disposable = disposable;
+            disposable = Disposable.Create(dispose);
         }
 
         public IObservable<Unit> Workflow { get; private set; }


### PR DESCRIPTION
Here we improve the consistency of the workflow shutdown sequence. Following a call to `StartWorkflow`, all errors are routed via the created observable sequence, whether they are errors thrown by the workflow build process itself or by any operator following successful subscription.

When any errors are raised, or when successfully completing the sequence, the editor running state must be cleared. Previously we tried distinguishing between different error exit paths, but this proved problematic since complex edge cases could cause multiple error handlers to be called simultaneously.

Here we aim to have a common final path to shutdown by tracking a single shared variable which is disposed when exiting the workflow sequence via any of the exceptional or successful termination routes.

Fixes #1796 