### PR TITLE
Add editor find tool for subjects and operator types

### DIFF
--- a/Bonsai.Core.Tests/TestWorkflow.cs
+++ b/Bonsai.Core.Tests/TestWorkflow.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq.Expressions;
 using Bonsai.Dag;
 using Bonsai.Expressions;
 

--- a/Bonsai.Core/Expressions/NestedWorkflowBuilder.cs
+++ b/Bonsai.Core/Expressions/NestedWorkflowBuilder.cs
@@ -1,10 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Xml.Serialization;
-using System.Linq.Expressions;
-using System.Reflection;
-using System.Reactive.Linq;
 using System;
 using Bonsai.Reactive;
 

--- a/Bonsai.Core/Expressions/SubjectNameConverter.cs
+++ b/Bonsai.Core/Expressions/SubjectNameConverter.cs
@@ -42,9 +42,12 @@ namespace Bonsai.Expressions
             foreach (var inspectBuilder in SelectContextElements(source))
             {
                 var element = inspectBuilder.Builder;
-                if (element is IGroupWorkflowBuilder groupBuilder && groupBuilder.Workflow == target) return true;
-
-                if (element is WorkflowExpressionBuilder workflowBuilder)
+                if (element is IGroupWorkflowBuilder groupBuilder)
+                {
+                    if (groupBuilder.Workflow == target)
+                        return true;
+                }
+                else if (element is WorkflowExpressionBuilder workflowBuilder)
                 {
                     if (GetCallContext(workflowBuilder.Workflow, target, context))
                     {

--- a/Bonsai.Editor/AboutBox.cs
+++ b/Bonsai.Editor/AboutBox.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Windows.Forms;
 using System.Diagnostics;
 using Bonsai.Editor.Properties;

--- a/Bonsai.Editor/Docking/DockPanelHelper.cs
+++ b/Bonsai.Editor/Docking/DockPanelHelper.cs
@@ -78,7 +78,7 @@ namespace Bonsai.Editor.Docking
                 if (dockState == DockState.Unknown)
                     return;
 
-                var dockPane = dockPanel.GetPaneFromId(dockPaneId);
+                var dockPane = dockPanel.GetDocumentPaneFromId(dockPaneId);
                 if (dockPane != null && !singletonContent)
                 {
                     dockContent.Show(dockPane, contentIndex);
@@ -87,7 +87,7 @@ namespace Bonsai.Editor.Docking
 
                 contentIndex = -1;
                 singletonContent = default;
-                dockPane = dockPanel.GetPaneFromId(previousPaneId);
+                dockPane = dockPanel.GetDocumentPaneFromId(previousPaneId);
                 if (dockPane is DockPane previousPane)
                 {
                     dockContent.Show(previousPane, dockAlignment.Value, dockProportion);
@@ -128,12 +128,13 @@ namespace Bonsai.Editor.Docking
             pane.DockPanel.ResumeLayout(performLayout: true, allWindows: true);
         }
 
-        static DockPane GetPaneFromId(this DockPanel dockPanel, object paneId)
+        static DockPane GetDocumentPaneFromId(this DockPanel dockPanel, object paneId)
         {
             for (int i = 0; i < dockPanel.Panes.Count; i++)
             {
-                if (ReferenceEquals(paneId, dockPanel.Panes[i].Tag))
-                    return dockPanel.Panes[i];
+                var pane = dockPanel.Panes[i];
+                if (pane.IsDockStateValid(DockState.Document) && ReferenceEquals(paneId, pane.Tag))
+                    return pane;
             }
 
             return null;

--- a/Bonsai.Editor/Docking/DockPanelSerializer.cs
+++ b/Bonsai.Editor/Docking/DockPanelSerializer.cs
@@ -42,6 +42,8 @@ namespace Bonsai.Editor.Docking
                     workflowPath?.Resolve(workflowBuilder);
                     return editorControl.CreateDockContent(workflowPath, DockState.Unknown);
                 default:
+                    if (editorControl.ToolWindows.Contains(contentString))
+                        return editorControl.ToolWindows[contentString];
                     ThrowNotRecognizedException(contentString);
                     return default;
             }

--- a/Bonsai.Editor/Docking/EditorToolWindow.cs
+++ b/Bonsai.Editor/Docking/EditorToolWindow.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Bonsai.Editor.Themes;
+using WeifenLuo.WinFormsUI.Docking;
+
+namespace Bonsai.Editor.Docking
+{
+    internal class EditorToolWindow : DockContent
+    {
+        readonly IServiceProvider serviceProvider;
+        readonly ThemeRenderer themeRenderer;
+
+        private EditorToolWindow()
+        {
+        }
+
+        protected EditorToolWindow(IServiceProvider provider)
+        {
+            serviceProvider = provider ?? throw new ArgumentNullException(nameof(provider));
+            themeRenderer = (ThemeRenderer)provider.GetService(typeof(ThemeRenderer));
+            HideOnClose = true;
+            DockAreas = DockAreas.Float |
+                DockAreas.DockLeft |
+                DockAreas.DockRight |
+                DockAreas.DockTop |
+                DockAreas.DockBottom;
+        }
+
+        protected IServiceProvider ServiceProvider
+        {
+            get { return serviceProvider; }
+        }
+
+        private void themeRenderer_ThemeChanged(object sender, EventArgs e)
+        {
+            InitializeTheme(themeRenderer);
+        }
+
+        protected virtual void InitializeTheme(ThemeRenderer themeRenderer)
+        {
+        }
+
+        protected override string GetPersistString()
+        {
+            return GetType().Name;
+        }
+
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            if (themeRenderer is not null)
+            {
+                themeRenderer.ThemeChanged += themeRenderer_ThemeChanged;
+                InitializeTheme(themeRenderer);
+            }
+            base.OnHandleCreated(e);
+        }
+
+        protected override void OnHandleDestroyed(EventArgs e)
+        {
+            if (themeRenderer is not null)
+                themeRenderer.ThemeChanged -= themeRenderer_ThemeChanged;
+            base.OnHandleDestroyed(e);
+        }
+    }
+}

--- a/Bonsai.Editor/Docking/WorkflowDockContent.cs
+++ b/Bonsai.Editor/Docking/WorkflowDockContent.cs
@@ -108,7 +108,7 @@ namespace Bonsai.Editor.Docking
                 return false;
 
             int contentIndex = -1;
-            DockContent nextContent = null;
+            WorkflowDockContent nextContent = null;
             for (int i = contents.Count - 1; i >= 0; i--)
             {
                 if (contentIndex < 0 && contents[i] == this)
@@ -121,7 +121,7 @@ namespace Bonsai.Editor.Docking
                         continue;
                 }
 
-                if (contents[i] is DockContent dockContent && !dockContent.IsHidden)
+                if (contents[i] is WorkflowDockContent dockContent && !dockContent.IsHidden)
                 {
                     nextContent = dockContent;
                     if (contentIndex >= 0)

--- a/Bonsai.Editor/Docking/WorkflowDockPaneCaption.cs
+++ b/Bonsai.Editor/Docking/WorkflowDockPaneCaption.cs
@@ -1,0 +1,333 @@
+﻿using System;
+using System.ComponentModel;
+using System.Drawing.Drawing2D;
+using System.Drawing;
+using System.Windows.Forms;
+using WeifenLuo.WinFormsUI.Docking;
+using WeifenLuo.WinFormsUI.ThemeVS2012;
+using Bonsai.Editor.Properties;
+
+namespace Bonsai.Editor.Docking
+{
+    internal class WorkflowDockPaneCaption : DockPaneCaptionBase
+    {
+        #region Constants
+
+        private const int TextGapTop = 3;
+        private const int TextGapBottom = 2;
+        private const int TextGapLeft = 2;
+        private const int TextGapRight = 3;
+        private const int ButtonGapTop = 4;
+        private const int ButtonGapBottom = 3;
+        private const int ButtonGapBetween = 1;
+        private const int ButtonGapLeft = 1;
+        private const int ButtonGapRight = 5;
+
+        #endregion
+
+        #region Members
+
+        private InertButtonBase m_buttonClose;
+        private InertButtonBase m_buttonAutoHide;
+        private InertButtonBase m_buttonOptions;
+        private readonly IContainer m_components;
+        private readonly ToolTip m_toolTip;
+
+        #endregion
+
+        #region Properties
+
+        private InertButtonBase ButtonClose
+        {
+            get
+            {
+                if (m_buttonClose == null)
+                {
+                    m_buttonClose = new VS2012DockPaneCaptionInertButton(this,
+                        DockPane.DockPanel.Theme.ImageService.DockPaneHover_Close,
+                        DockPane.DockPanel.Theme.ImageService.DockPane_Close,
+                        DockPane.DockPanel.Theme.ImageService.DockPanePress_Close,
+                        DockPane.DockPanel.Theme.ImageService.DockPaneActiveHover_Close,
+                        DockPane.DockPanel.Theme.ImageService.DockPaneActive_Close);
+                    m_toolTip.SetToolTip(m_buttonClose, Resources.ToolTipClose);
+                    m_buttonClose.Click += new EventHandler(Close_Click);
+                    Controls.Add(m_buttonClose);
+                }
+
+                return m_buttonClose;
+            }
+        }
+
+        private InertButtonBase ButtonAutoHide
+        {
+            get
+            {
+                if (m_buttonAutoHide == null)
+                {
+                    m_buttonAutoHide = new VS2012DockPaneCaptionInertButton(this,
+                        DockPane.DockPanel.Theme.ImageService.DockPaneHover_Dock,
+                        DockPane.DockPanel.Theme.ImageService.DockPane_Dock,
+                        DockPane.DockPanel.Theme.ImageService.DockPanePress_Dock,
+                        DockPane.DockPanel.Theme.ImageService.DockPaneActiveHover_Dock,
+                        DockPane.DockPanel.Theme.ImageService.DockPaneActive_Dock,
+                        DockPane.DockPanel.Theme.ImageService.DockPaneActiveHover_AutoHide,
+                        DockPane.DockPanel.Theme.ImageService.DockPaneActive_AutoHide,
+                        DockPane.DockPanel.Theme.ImageService.DockPanePress_AutoHide);
+                    m_toolTip.SetToolTip(m_buttonAutoHide, Resources.ToolTipAutoHide);
+                    m_buttonAutoHide.Click += new EventHandler(AutoHide_Click);
+                    Controls.Add(m_buttonAutoHide);
+                }
+
+                return m_buttonAutoHide;
+            }
+        }
+
+        private InertButtonBase ButtonOptions
+        {
+            get
+            {
+                if (m_buttonOptions == null)
+                {
+                    m_buttonOptions = new VS2012DockPaneCaptionInertButton(this,
+                        DockPane.DockPanel.Theme.ImageService.DockPaneHover_Option,
+                        DockPane.DockPanel.Theme.ImageService.DockPane_Option,
+                        DockPane.DockPanel.Theme.ImageService.DockPanePress_Option,
+                        DockPane.DockPanel.Theme.ImageService.DockPaneActiveHover_Option,
+                        DockPane.DockPanel.Theme.ImageService.DockPaneActive_Option);
+                    m_toolTip.SetToolTip(m_buttonOptions, Resources.ToolTipOptions);
+                    m_buttonOptions.Click += new EventHandler(Options_Click);
+                    Controls.Add(m_buttonOptions);
+                }
+                return m_buttonOptions;
+            }
+        }
+
+        private IContainer Components
+        {
+            get { return m_components; }
+        }
+
+        #endregion
+
+        public WorkflowDockPaneCaption(DockPane pane)
+            : base(pane)
+        {
+            SuspendLayout();
+
+            m_components = new Container();
+            m_toolTip = new ToolTip(Components);
+
+            ResumeLayout();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                Components.Dispose();
+            base.Dispose(disposing);
+        }
+
+        public Font TextFont
+        {
+            get { return DockPane.DockPanel.Theme.Skin.DockPaneStripSkin.TextFont; }
+        }
+
+        private const TextFormatFlags _defaultTextFormat =
+            TextFormatFlags.SingleLine |
+            TextFormatFlags.EndEllipsis |
+            TextFormatFlags.VerticalCenter;
+        private TextFormatFlags TextFormat
+        {
+            get
+            {
+                if (RightToLeft == RightToLeft.No)
+                    return _defaultTextFormat;
+                else
+                    return _defaultTextFormat | TextFormatFlags.RightToLeft | TextFormatFlags.Right;
+            }
+        }
+
+        protected override int MeasureHeight()
+        {
+            int height = TextFont.Height + TextGapTop + TextGapBottom;
+
+            if (height < ButtonClose.Image.Height + ButtonGapTop + ButtonGapBottom)
+                height = ButtonClose.Image.Height + ButtonGapTop + ButtonGapBottom;
+
+            return height;
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+            DrawCaption(e.Graphics);
+        }
+
+        private void DrawCaption(Graphics g)
+        {
+            if (ClientRectangle.Width == 0 || ClientRectangle.Height == 0)
+                return;
+
+            Rectangle rect = ClientRectangle;
+            var border = DockPane.DockPanel.Theme.ColorPalette.ToolWindowBorder;
+            ToolWindowCaptionPalette palette;
+            if (DockPane.IsActivePane)
+            {
+                palette = DockPane.DockPanel.Theme.ColorPalette.ToolWindowCaptionActive;
+            }
+            else
+            {
+                palette = DockPane.DockPanel.Theme.ColorPalette.ToolWindowCaptionInactive;
+            }
+
+            SolidBrush captionBrush = DockPane.DockPanel.Theme.PaintingService.GetBrush(palette.Background);
+            g.FillRectangle(captionBrush, rect);
+
+            g.DrawLine(DockPane.DockPanel.Theme.PaintingService.GetPen(border), rect.Left, rect.Top,
+                rect.Left, rect.Bottom);
+            g.DrawLine(DockPane.DockPanel.Theme.PaintingService.GetPen(border), rect.Left, rect.Top,
+                rect.Right, rect.Top);
+            g.DrawLine(DockPane.DockPanel.Theme.PaintingService.GetPen(border), rect.Right - 1, rect.Top,
+                rect.Right - 1, rect.Bottom);
+
+            Rectangle rectCaption = rect;
+
+            Rectangle rectCaptionText = rectCaption;
+            rectCaptionText.X += TextGapLeft;
+            rectCaptionText.Width -= TextGapLeft + TextGapRight;
+            rectCaptionText.Width -= ButtonGapLeft + ButtonClose.Width + ButtonGapRight;
+            if (ShouldShowAutoHideButton)
+                rectCaptionText.Width -= ButtonAutoHide.Width + ButtonGapBetween;
+            if (HasTabPageContextMenu)
+                rectCaptionText.Width -= ButtonOptions.Width + ButtonGapBetween;
+            rectCaptionText.Y += TextGapTop;
+            rectCaptionText.Height -= TextGapTop + TextGapBottom;
+
+            TextRenderer.DrawText(g, DockPane.CaptionText, TextFont, DrawHelper.RtlTransform(this, rectCaptionText), palette.Text, TextFormat);
+
+            Rectangle rectDotsStrip = rectCaptionText;
+            int textLength = (int)g.MeasureString(DockPane.CaptionText, TextFont).Width + TextGapLeft;
+            rectDotsStrip.X += textLength;
+            rectDotsStrip.Width -= textLength;
+            rectDotsStrip.Height = ClientRectangle.Height;
+
+            DrawDotsStrip(g, rectDotsStrip, palette.Grip);
+        }
+
+        protected void DrawDotsStrip(Graphics g, Rectangle rectStrip, Color colorDots)
+        {
+            if (rectStrip.Width <= 0 || rectStrip.Height <= 0)
+                return;
+
+            var penDots = DockPane.DockPanel.Theme.PaintingService.GetPen(colorDots, 1);
+            penDots.DashStyle = DashStyle.Custom;
+            penDots.DashPattern = new float[] { 1, 3 };
+            int positionY = rectStrip.Height / 2;
+
+            g.DrawLine(penDots, rectStrip.X + 2, positionY, rectStrip.X + rectStrip.Width - 2, positionY);
+
+            g.DrawLine(penDots, rectStrip.X, positionY - 2, rectStrip.X + rectStrip.Width, positionY - 2);
+            g.DrawLine(penDots, rectStrip.X, positionY + 2, rectStrip.X + rectStrip.Width, positionY + 2);
+        }
+
+        protected override void OnLayout(LayoutEventArgs levent)
+        {
+            SetButtonsPosition();
+            base.OnLayout(levent);
+        }
+
+        protected override void OnRefreshChanges()
+        {
+            SetButtons();
+            Invalidate();
+        }
+
+        private bool CloseButtonEnabled
+        {
+            get { return (DockPane.ActiveContent != null) && DockPane.ActiveContent.DockHandler.CloseButton; }
+        }
+
+        private bool CloseButtonVisible
+        {
+            get { return (DockPane.ActiveContent != null) && DockPane.ActiveContent.DockHandler.CloseButtonVisible; }
+        }
+
+        private bool ShouldShowAutoHideButton
+        {
+            get { return !DockPane.IsFloat; }
+        }
+
+        private void SetButtons()
+        {
+            ButtonClose.Enabled = CloseButtonEnabled;
+            ButtonClose.Visible = CloseButtonVisible;
+            ButtonAutoHide.Visible = ShouldShowAutoHideButton;
+            ButtonOptions.Visible = HasTabPageContextMenu;
+            ButtonClose.RefreshChanges();
+            ButtonAutoHide.RefreshChanges();
+            ButtonOptions.RefreshChanges();
+
+            SetButtonsPosition();
+        }
+
+        private static Size GetButtonSize(Rectangle rectTab)
+        {
+            const int gap = 3;
+            var imageSize = PatchController.EnableHighDpi == true ? rectTab.Height - gap * 2 : 15;
+            return new Size(imageSize, imageSize);
+        }
+
+        private void SetButtonsPosition()
+        {
+            // set the size and location for close and auto-hide buttons
+            Rectangle rectCaption = ClientRectangle;
+            Size buttonSize = GetButtonSize(rectCaption);
+            int x = rectCaption.X + rectCaption.Width - ButtonGapRight - m_buttonClose.Width;
+            int y = rectCaption.Y + ButtonGapTop;
+            Point point = new Point(x, y);
+            ButtonClose.Bounds = DrawHelper.RtlTransform(this, new Rectangle(point, buttonSize));
+
+
+            // If the close button is not visible draw the auto hide button overtop.
+            // Otherwise it is drawn to the left of the close button.
+            if (CloseButtonVisible)
+                point.Offset(-(buttonSize.Width + ButtonGapBetween), 0);
+
+            ButtonAutoHide.Bounds = DrawHelper.RtlTransform(this, new Rectangle(point, buttonSize));
+            if (ShouldShowAutoHideButton)
+                point.Offset(-(buttonSize.Width + ButtonGapBetween), 0);
+            ButtonOptions.Bounds = DrawHelper.RtlTransform(this, new Rectangle(point, buttonSize));
+        }
+
+        private void Close_Click(object sender, EventArgs e)
+        {
+            DockPane.CloseActiveContent();
+        }
+
+        private void AutoHide_Click(object sender, EventArgs e)
+        {
+            DockPane.DockState = DockHelper.ToggleAutoHideState(DockPane.DockState);
+            if (DockHelper.IsDockStateAutoHide(DockPane.DockState))
+            {
+                DockPane.DockPanel.ActiveAutoHideContent = null;
+                DockPane.NestedDockingStatus.NestedPanes.SwitchPaneWithFirstChild(DockPane);
+            }
+        }
+
+        private void Options_Click(object sender, EventArgs e)
+        {
+            ShowTabPageContextMenu(PointToClient(Control.MousePosition));
+        }
+
+        protected override void OnRightToLeftChanged(EventArgs e)
+        {
+            base.OnRightToLeftChanged(e);
+            PerformLayout();
+        }
+
+        protected override bool CanDragAutoHide
+        {
+            get { return true; }
+        }
+    }
+}

--- a/Bonsai.Editor/Docking/WorkflowDockPaneCaptionFactory.cs
+++ b/Bonsai.Editor/Docking/WorkflowDockPaneCaptionFactory.cs
@@ -1,0 +1,12 @@
+﻿using WeifenLuo.WinFormsUI.Docking;
+
+namespace Bonsai.Editor.Docking
+{
+    internal class WorkflowDockPaneCaptionFactory : DockPanelExtender.IDockPaneCaptionFactory
+    {
+        public DockPaneCaptionBase CreateDockPaneCaption(DockPane pane)
+        {
+            return new WorkflowDockPaneCaption(pane);
+        }
+    }
+}

--- a/Bonsai.Editor/Docking/WorkflowDockPaneStrip.cs
+++ b/Bonsai.Editor/Docking/WorkflowDockPaneStrip.cs
@@ -85,6 +85,7 @@ namespace Bonsai.Editor.Docking
         private Rectangle _activeClose;
         private int _selectMenuMargin = 5;
         private bool m_suspendDrag = false;
+
         #endregion
 
         #region Properties

--- a/Bonsai.Editor/Docking/WorkflowFindToolWindow.Designer.cs
+++ b/Bonsai.Editor/Docking/WorkflowFindToolWindow.Designer.cs
@@ -1,0 +1,145 @@
+﻿namespace Bonsai.Editor.Docking
+{
+    partial class WorkflowFindToolWindow
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.findListView = new Bonsai.Editor.ListView();
+            this.nameColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.pathColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.operatorTypeColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.observableTypeColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.openNewTabToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.openNewWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.selectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.contextMenuStrip.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // findListView
+            // 
+            this.findListView.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.findListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.nameColumnHeader,
+            this.pathColumnHeader,
+            this.operatorTypeColumnHeader,
+            this.observableTypeColumnHeader});
+            this.findListView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.findListView.FullRowSelect = true;
+            this.findListView.HideSelection = false;
+            this.findListView.Location = new System.Drawing.Point(0, 0);
+            this.findListView.MultiSelect = false;
+            this.findListView.Name = "findListView";
+            this.findListView.Size = new System.Drawing.Size(568, 261);
+            this.findListView.TabIndex = 0;
+            this.findListView.UseCompatibleStateImageBehavior = false;
+            this.findListView.View = System.Windows.Forms.View.Details;
+            this.findListView.ItemActivate += new System.EventHandler(this.findListView_ItemActivate);
+            this.findListView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.findListView_KeyDown);
+            this.findListView.MouseClick += new System.Windows.Forms.MouseEventHandler(this.findListView_MouseClick);
+            // 
+            // nameColumnHeader
+            // 
+            this.nameColumnHeader.Text = "Name";
+            this.nameColumnHeader.Width = 40;
+            // 
+            // pathColumnHeader
+            // 
+            this.pathColumnHeader.Text = "Workflow Path";
+            this.pathColumnHeader.Width = 82;
+            // 
+            // operatorTypeColumnHeader
+            // 
+            this.operatorTypeColumnHeader.Text = "Operator Type";
+            this.operatorTypeColumnHeader.Width = 80;
+            // 
+            // observableTypeColumnHeader
+            // 
+            this.observableTypeColumnHeader.Text = "Observable Type";
+            this.observableTypeColumnHeader.Width = 362;
+            // 
+            // contextMenuStrip
+            // 
+            this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.selectToolStripMenuItem,
+            this.openNewTabToolStripMenuItem,
+            this.openNewWindowToolStripMenuItem});
+            this.contextMenuStrip.Name = "contextMenuStrip";
+            this.contextMenuStrip.Size = new System.Drawing.Size(236, 92);
+            // 
+            // openNewTabToolStripMenuItem
+            // 
+            this.openNewTabToolStripMenuItem.Name = "openNewTabToolStripMenuItem";
+            this.openNewTabToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.T)));
+            this.openNewTabToolStripMenuItem.Size = new System.Drawing.Size(235, 22);
+            this.openNewTabToolStripMenuItem.Text = "Select in New Tab";
+            this.openNewTabToolStripMenuItem.Click += new System.EventHandler(this.openNewTabToolStripMenuItem_Click);
+            // 
+            // openNewWindowToolStripMenuItem
+            // 
+            this.openNewWindowToolStripMenuItem.Name = "openNewWindowToolStripMenuItem";
+            this.openNewWindowToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
+            this.openNewWindowToolStripMenuItem.Size = new System.Drawing.Size(235, 22);
+            this.openNewWindowToolStripMenuItem.Text = "Select in New Window";
+            this.openNewWindowToolStripMenuItem.Click += new System.EventHandler(this.openNewWindowToolStripMenuItem_Click);
+            // 
+            // selectToolStripMenuItem
+            // 
+            this.selectToolStripMenuItem.Name = "selectToolStripMenuItem";
+            this.selectToolStripMenuItem.ShortcutKeyDisplayString = "Enter";
+            this.selectToolStripMenuItem.Size = new System.Drawing.Size(235, 22);
+            this.selectToolStripMenuItem.Text = "Select";
+            this.selectToolStripMenuItem.Click += new System.EventHandler(this.findListView_ItemActivate);
+            // 
+            // WorkflowFindToolWindow
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(568, 261);
+            this.Controls.Add(this.findListView);
+            this.Icon = global::Bonsai.Editor.Properties.Resources.Icon;
+            this.Name = "WorkflowFindToolWindow";
+            this.Text = "Find";
+            this.contextMenuStrip.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private Bonsai.Editor.ListView findListView;
+        private System.Windows.Forms.ColumnHeader nameColumnHeader;
+        private System.Windows.Forms.ColumnHeader pathColumnHeader;
+        private System.Windows.Forms.ColumnHeader operatorTypeColumnHeader;
+        private System.Windows.Forms.ColumnHeader observableTypeColumnHeader;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStrip;
+        private System.Windows.Forms.ToolStripMenuItem openNewTabToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem openNewWindowToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem selectToolStripMenuItem;
+    }
+}

--- a/Bonsai.Editor/Docking/WorkflowFindToolWindow.cs
+++ b/Bonsai.Editor/Docking/WorkflowFindToolWindow.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Forms;
+using Bonsai.Editor.GraphModel;
+using Bonsai.Editor.Themes;
+using Bonsai.Expressions;
+
+namespace Bonsai.Editor.Docking
+{
+    partial class WorkflowFindToolWindow : EditorToolWindow
+    {
+        static readonly object EventNavigate = new();
+        IEnumerable<WorkflowQueryResult> query;
+
+        public WorkflowFindToolWindow(IServiceProvider provider)
+            : base(provider)
+        {
+            InitializeComponent();
+            findListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+        }
+
+        public event WorkflowNavigateEventHandler Navigate
+        {
+            add { Events.AddHandler(EventNavigate, value); }
+            remove { Events.RemoveHandler(EventNavigate, value); }
+        }
+
+        protected override void InitializeTheme(ThemeRenderer themeRenderer)
+        {
+            var colorTable = themeRenderer.ToolStripRenderer.ColorTable;
+            findListView.BackColor = colorTable.WindowBackColor;
+            findListView.ForeColor = colorTable.ControlForeColor;
+        }
+
+        protected virtual void OnNavigate(WorkflowNavigateEventArgs e)
+        {
+            if (Events[EventNavigate] is WorkflowNavigateEventHandler handler)
+            {
+                handler(this, e);
+            }
+        }
+
+        public IEnumerable<WorkflowQueryResult> Query
+        {
+            get => query;
+            set
+            {
+                query = value;
+                UpdateResults();
+            }
+        }
+
+        public void UpdateResults()
+        {
+            findListView.BeginUpdate();
+            if (findListView.Items.Count > 0)
+                findListView.Items.Clear();
+
+            if (query is not null)
+            {
+                var workflowBuilder = (WorkflowBuilder)ServiceProvider.GetService(typeof(WorkflowBuilder));
+                foreach (var result in query)
+                {
+                    var inspectBuilder = (InspectBuilder)result.Builder;
+                    var name = ExpressionBuilder.GetElementDisplayName(inspectBuilder);
+                    var elementType = ExpressionBuilder.GetWorkflowElement(inspectBuilder).GetType();
+                    var containerPath = GetElementDisplayPath(workflowBuilder, result.Path.Parent);
+                    var item = new ListViewItem(name);
+                    item.Tag = result.Path;
+                    item.SubItems.Add(containerPath);
+                    item.SubItems.Add(TypeHelper.GetTypeName(elementType));
+                    item.SubItems.Add(inspectBuilder.ObservableType is not null
+                        ? TypeHelper.GetTypeName(inspectBuilder.ObservableType)
+                        : string.Empty);
+                    findListView.Items.Add(item);
+                }
+
+                if (findListView.Items.Count > 0)
+                {
+                    findListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
+                    findListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+                }
+            }
+            findListView.EndUpdate();
+        }
+
+        static string GetElementDisplayPath(WorkflowBuilder workflowBuilder, WorkflowEditorPath path)
+        {
+            var sb = new StringBuilder();
+            foreach (var pathElement in WorkflowEditorPath.GetPathDisplayElements(path, workflowBuilder))
+            {
+                if (sb.Length > 0)
+                    sb.Append(" > ");
+                sb.Append(pathElement.Key);
+            }
+
+            return sb.ToString();
+        }
+
+        private void NavigateToSelectedItem(NavigationPreference navigationPreference)
+        {
+            if (findListView.SelectedItems.Count == 0)
+                return;
+
+            var selectedItem = findListView.SelectedItems[0];
+            var workflowPath = (WorkflowEditorPath)selectedItem.Tag;
+            OnNavigate(new WorkflowNavigateEventArgs(workflowPath, navigationPreference));
+        }
+
+        private void findListView_MouseClick(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right)
+            {
+                var focusedItem = findListView.FocusedItem;
+                if (focusedItem is not null && focusedItem.Bounds.Contains(e.Location))
+                {
+                    contextMenuStrip.Show(Cursor.Position);
+                }
+            }
+        }
+
+        private void findListView_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyData == openNewTabToolStripMenuItem.ShortcutKeys)
+                openNewTabToolStripMenuItem_Click(sender, e);
+            if (e.KeyData == openNewWindowToolStripMenuItem.ShortcutKeys)
+                openNewWindowToolStripMenuItem_Click(sender, e);
+        }
+
+        private void findListView_ItemActivate(object sender, EventArgs e)
+        {
+            NavigateToSelectedItem(NavigationPreference.Current);
+        }
+
+        private void openNewTabToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            NavigateToSelectedItem(NavigationPreference.NewTab);
+        }
+
+        private void openNewWindowToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            NavigateToSelectedItem(NavigationPreference.NewWindow);
+        }
+    }
+}

--- a/Bonsai.Editor/Docking/WorkflowFindToolWindow.resx
+++ b/Bonsai.Editor/Docking/WorkflowFindToolWindow.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/Bonsai.Editor/EditorForm.Designer.cs
+++ b/Bonsai.Editor/EditorForm.Designer.cs
@@ -147,6 +147,7 @@
             this.findNextToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.findPreviousToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.goToDefinitionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.findAllReferencesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.commandExecutor = new Bonsai.Design.CommandExecutor();
             this.workflowFileWatcher = new System.IO.FileSystemWatcher();
             this.exportImageDialog = new System.Windows.Forms.SaveFileDialog();
@@ -1212,9 +1213,10 @@
             this.renameSubjectToolStripMenuItem,
             this.findNextToolStripMenuItem,
             this.findPreviousToolStripMenuItem,
-            this.goToDefinitionToolStripMenuItem});
+            this.goToDefinitionToolStripMenuItem,
+            this.findAllReferencesToolStripMenuItem});
             this.toolboxContextMenuStrip.Name = "toolboxContextMenuStrip";
-            this.toolboxContextMenuStrip.Size = new System.Drawing.Size(207, 268);
+            this.toolboxContextMenuStrip.Size = new System.Drawing.Size(232, 312);
             // 
             // toolboxDocsToolStripMenuItem
             // 
@@ -1318,6 +1320,14 @@
             this.goToDefinitionToolStripMenuItem.Text = "Go To Definition";
             this.goToDefinitionToolStripMenuItem.Click += new System.EventHandler(this.goToDefinitionToolStripMenuItem_Click);
             // 
+            // findAllReferencesToolStripMenuItem
+            // 
+            this.findAllReferencesToolStripMenuItem.Name = "findAllReferencesToolStripMenuItem";
+            this.findAllReferencesToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F12)));
+            this.findAllReferencesToolStripMenuItem.Size = new System.Drawing.Size(231, 22);
+            this.findAllReferencesToolStripMenuItem.Text = "Find All References";
+            this.findAllReferencesToolStripMenuItem.Click += new System.EventHandler(this.findAllReferencesToolStripMenuItem_Click);
+            // 
             // commandExecutor
             // 
             this.commandExecutor.StatusChanged += new System.EventHandler(this.commandExecutor_StatusChanged);
@@ -1389,7 +1399,7 @@
             this.explorerTreeView.Name = "explorerTreeView";
             this.explorerTreeView.Size = new System.Drawing.Size(200, 137);
             this.explorerTreeView.TabIndex = 3;
-            this.explorerTreeView.Navigate += new Bonsai.Editor.ExplorerTreeViewEventHandler(explorerTreeView_Navigate);
+            this.explorerTreeView.Navigate += new Bonsai.Editor.WorkflowNavigateEventHandler(explorerTreeView_Navigate);
             // 
             // EditorForm
             // 
@@ -1546,6 +1556,7 @@
         private System.Windows.Forms.ToolStripMenuItem findNextToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem findPreviousToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem goToDefinitionToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem findAllReferencesToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
         private System.Windows.Forms.ToolStripMenuItem reloadExtensionsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem reloadExtensionsDebugToolStripMenuItem;

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -274,9 +274,6 @@ namespace Bonsai.Editor
 
         void CloseEditorForm()
         {
-            if (!string.IsNullOrEmpty(FileName))
-                SaveWorkflowSettings(FileName);
-
             Application.RemoveMessageFilter(hotKeys);
             EditorSettings.Instance.AnnotationPanelSize = (int)Math.Round(
                 editorControl.AnnotationPanelSize * inverseScaleFactor.Width);
@@ -761,9 +758,12 @@ namespace Bonsai.Editor
                     saveToolStripMenuItem_Click(this, EventArgs.Empty);
                     return saveVersion == version;
                 }
-                else return result == DialogResult.No;
+                else if (result == DialogResult.Cancel)
+                    return false;
             }
 
+            if (!string.IsNullOrEmpty(FileName))
+                SaveWorkflowSettings(FileName);
             return true;
         }
 
@@ -1019,6 +1019,7 @@ namespace Bonsai.Editor
             {
                 Environment.CurrentDirectory = workflowDirectory;
                 EditorResult = EditorResult.ReloadEditor;
+                selectionModel.UpdateSelection(null);
                 ResetProjectStatus();
                 Close();
                 FileName = fileName;
@@ -3074,6 +3075,6 @@ namespace Bonsai.Editor
             EditorSettings.Instance.EditorTheme = themeRenderer.ActiveTheme;
         }
 
-#endregion
+        #endregion
     }
 }

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2592,7 +2592,7 @@ namespace Bonsai.Editor
             public void OnKeyPress(KeyPressEventArgs e)
             {
                 var selectedView = siteForm.selectionModel.SelectedView;
-                if (selectedView != null && selectedView.CanEdit && selectedView.GraphView.Focused)
+                if (selectedView != null && selectedView.GraphView.Focused)
                 {
                     if (char.IsLetter(e.KeyChar))
                     {

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -424,12 +424,12 @@ namespace Bonsai.Editor
                 handler => selectionModel.SelectionChanged -= handler)
                 .Select(evt => selectionModel.SelectedView)
                 .DistinctUntilChanged(view => view?.WorkflowPath);
-            var workflowValidating = Observable.FromEventPattern<EventHandler, EventArgs>(
-                handler => Events.AddHandler(WorkflowValidating, handler),
-                handler => Events.RemoveHandler(WorkflowValidating, handler))
+            var workflowValidated = Observable.FromEventPattern<EventHandler, EventArgs>(
+                handler => Events.AddHandler(WorkflowValidated, handler),
+                handler => Events.RemoveHandler(WorkflowValidated, handler))
                 .Select(evt => selectionModel.SelectedView);
             return Observable
-                .Merge(selectedPathChanged, workflowValidating)
+                .Merge(selectedPathChanged, workflowValidated)
                 .Do(view =>
                 {
                     toolboxTreeView.BeginUpdate();

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -420,17 +420,17 @@ namespace Bonsai.Editor
 
         Task InitializeSubjectSourcesAsync(CancellationToken cancellationToken)
         {
-            var selectedViewChanged = Observable.FromEventPattern<EventHandler, EventArgs>(
+            var selectedPathChanged = Observable.FromEventPattern<EventHandler, EventArgs>(
                 handler => selectionModel.SelectionChanged += handler,
                 handler => selectionModel.SelectionChanged -= handler)
                 .Select(evt => selectionModel.SelectedView)
-                .DistinctUntilChanged();
+                .DistinctUntilChanged(view => view?.WorkflowPath);
             var workflowValidating = Observable.FromEventPattern<EventHandler, EventArgs>(
                 handler => Events.AddHandler(WorkflowValidating, handler),
                 handler => Events.RemoveHandler(WorkflowValidating, handler))
                 .Select(evt => selectionModel.SelectedView);
             return Observable
-                .Merge(selectedViewChanged, workflowValidating)
+                .Merge(selectedPathChanged, workflowValidating)
                 .Do(view =>
                 {
                     toolboxTreeView.BeginUpdate();

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -652,16 +652,19 @@ namespace Bonsai.Editor
             }
             else if (matchTarget is IncludeWorkflowBuilder includeBuilder && !string.IsNullOrEmpty(includeBuilder.Path))
             {
-                if (Path.IsPathRooted(includeBuilder.Path))
-                    return includeBuilder.Name;
-
-                string includeNamespace;
+                var includeNamespace = Project.DefaultWorkflowNamespace;
                 if (TryGetAssemblyResource(includeBuilder.Path, out string _, out string resourceName))
                 {
                     var nameSeparator = resourceName.LastIndexOf(ExpressionHelper.MemberSeparator);
                     includeNamespace = nameSeparator >= 0 ? resourceName.Substring(0, nameSeparator) : resourceName;
                 }
-                else includeNamespace = Project.GetFileNamespace(includeBuilder.Path);
+                else
+                {
+                    var fullPath = Path.GetFullPath(includeBuilder.Path);
+                    var relativePath = PathConvert.GetProjectPath(fullPath);
+                    if (relativePath != fullPath)
+                        includeNamespace = Project.GetFileNamespace(relativePath);
+                }
                 return $"{includeBuilder.Name} ({includeNamespace})";
             }
             else

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -33,7 +33,6 @@ namespace Bonsai.Editor
     {
         const float DefaultEditorScale = 1.0f;
         const string EditorUid = "editor";
-        const string BonsaiPackageName = "Bonsai";
         const string WorkflowCategoryName = "Workflow";
         const string SubjectCategoryName = "Subject";
         static readonly AttributeCollection DesignTimeAttributes = new AttributeCollection(BrowsableAttribute.Yes, DesignTimeVisibleAttribute.Yes);
@@ -643,9 +642,14 @@ namespace Bonsai.Editor
 
         static string GetPackageDisplayName(string packageKey)
         {
-            if (packageKey == null) return Project.ExtensionsDirectory;
-            if (packageKey == BonsaiPackageName) return packageKey;
-            return packageKey.Replace(BonsaiPackageName + ".", string.Empty);
+            const string BonsaiPackageName = "Bonsai";
+            const string BonsaiNamespacePrefix = BonsaiPackageName + ".";
+            if (string.IsNullOrEmpty(packageKey))
+                return Project.ExtensionsDirectory;
+            if (packageKey == BonsaiPackageName || !packageKey.StartsWith(BonsaiNamespacePrefix))
+                return packageKey;
+            else
+                return packageKey.Substring(BonsaiNamespacePrefix.Length);
         }
 
         void InitializeToolboxCategory(string categoryName, IEnumerable<WorkflowElementDescriptor> types)

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1830,7 +1830,8 @@ namespace Bonsai.Editor
             if (selection.Length == 0) return;
 
             Func<ExpressionBuilder, bool> predicate;
-            var currentBuilder = ExpressionBuilder.Unwrap(selection[0].Value);
+            var inspectBuilder = selection[0].Value;
+            var currentBuilder = ExpressionBuilder.Unwrap(inspectBuilder);
             if (currentBuilder is SubjectExpressionBuilder ||
                 currentBuilder is SubscribeSubject ||
                 currentBuilder is MulticastSubject)
@@ -1849,15 +1850,16 @@ namespace Bonsai.Editor
                 predicate = builder => builder.MatchElementType(typeName);
             }
 
-            FindNextMatch(predicate, currentBuilder, findPrevious);
+            FindNextMatch(predicate, inspectBuilder, findPrevious);
         }
 
         void FindNextMatch(Func<ExpressionBuilder, bool> predicate, ExpressionBuilder current, bool findPrevious)
         {
             var match = workflowBuilder.Find(predicate, current, findPrevious);
-            if (match != null)
+            if (match is not null)
             {
-                SelectBuilderNode(match);
+                var builder = ExpressionBuilder.Unwrap(match.Builder);
+                SelectBuilderNode(builder);
             }
         }
 

--- a/Bonsai.Editor/ExplorerTreeView.cs
+++ b/Bonsai.Editor/ExplorerTreeView.cs
@@ -60,15 +60,15 @@ namespace Bonsai.Editor
             set => treeView.Renderer = value;
         }
 
-        public event ExplorerTreeViewEventHandler Navigate
+        public event WorkflowNavigateEventHandler Navigate
         {
             add { Events.AddHandler(EventNavigate, value); }
             remove { Events.RemoveHandler(EventNavigate, value); }
         }
 
-        protected virtual void OnNavigate(ExplorerTreeViewEventArgs e)
+        protected virtual void OnNavigate(WorkflowNavigateEventArgs e)
         {
-            if (Events[EventNavigate] is ExplorerTreeViewEventHandler handler)
+            if (Events[EventNavigate] is WorkflowNavigateEventHandler handler)
             {
                 handler(this, e);
             }
@@ -80,7 +80,7 @@ namespace Bonsai.Editor
                 e.Button == MouseButtons.Left &&
                 treeView.HitTest(e.Location).Location == TreeViewHitTestLocations.Label)
             {
-                OnNavigate(new ExplorerTreeViewEventArgs(e.Node, TreeViewAction.ByMouse));
+                OnNavigate(new WorkflowNavigateEventArgs((WorkflowEditorPath)e.Node.Tag));
             }
         }
 
@@ -91,9 +91,8 @@ namespace Bonsai.Editor
 
             if (e.KeyData == openNewTabToolStripMenuItem.ShortcutKeys)
             {
-                OnNavigate(new ExplorerTreeViewEventArgs(
-                    treeView.SelectedNode,
-                    TreeViewAction.ByKeyboard,
+                OnNavigate(new WorkflowNavigateEventArgs(
+                    (WorkflowEditorPath)treeView.SelectedNode.Tag,
                     NavigationPreference.NewTab));
                 e.Handled = true;
                 e.SuppressKeyPress = true;
@@ -101,9 +100,8 @@ namespace Bonsai.Editor
 
             if (e.KeyData == openNewWindowToolStripMenuItem.ShortcutKeys)
             {
-                OnNavigate(new ExplorerTreeViewEventArgs(
-                    treeView.SelectedNode,
-                    TreeViewAction.ByKeyboard,
+                OnNavigate(new WorkflowNavigateEventArgs(
+                    (WorkflowEditorPath)treeView.SelectedNode.Tag,
                     NavigationPreference.NewWindow));
                 e.Handled = true;
                 e.SuppressKeyPress = true;
@@ -111,7 +109,7 @@ namespace Bonsai.Editor
 
             if (e.KeyCode == Keys.Return)
             {
-                OnNavigate(new ExplorerTreeViewEventArgs(treeView.SelectedNode, TreeViewAction.ByKeyboard));
+                OnNavigate(new WorkflowNavigateEventArgs((WorkflowEditorPath)treeView.SelectedNode.Tag));
             }
 
             if (e.Shift && e.KeyCode == Keys.F10)
@@ -151,9 +149,8 @@ namespace Bonsai.Editor
             if (treeView.SelectedNode is null)
                 return;
 
-            OnNavigate(new ExplorerTreeViewEventArgs(
-                treeView.SelectedNode,
-                TreeViewAction.ByMouse,
+            OnNavigate(new WorkflowNavigateEventArgs(
+                (WorkflowEditorPath)treeView.SelectedNode.Tag,
                 NavigationPreference.NewTab));
         }
 
@@ -162,9 +159,8 @@ namespace Bonsai.Editor
             if (treeView.SelectedNode is null)
                 return;
 
-            OnNavigate(new ExplorerTreeViewEventArgs(
-                treeView.SelectedNode,
-                TreeViewAction.ByMouse,
+            OnNavigate(new WorkflowNavigateEventArgs(
+                (WorkflowEditorPath)treeView.SelectedNode.Tag,
                 NavigationPreference.NewWindow));
         }
 
@@ -319,26 +315,5 @@ namespace Bonsai.Editor
     {
         Ready,
         Blocked
-    }
-
-    delegate void ExplorerTreeViewEventHandler(object sender, ExplorerTreeViewEventArgs e);
-
-    class ExplorerTreeViewEventArgs : TreeViewEventArgs
-    {
-        public ExplorerTreeViewEventArgs(TreeNode node, TreeViewAction action)
-            : this(node, action, NavigationPreference.Current)
-        {
-        }
-
-        public ExplorerTreeViewEventArgs(
-            TreeNode node,
-            TreeViewAction action,
-            NavigationPreference navigationPreference)
-            : base(node, action)
-        {
-            NavigationPreference = navigationPreference;
-        }
-
-        public NavigationPreference NavigationPreference { get; }
     }
 }

--- a/Bonsai.Editor/GraphModel/WorkflowBuilderExtensions.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Bonsai.Editor.GraphModel
     {
         public static bool IsGroup(this IWorkflowExpressionBuilder builder)
         {
-            return builder is IncludeWorkflowBuilder || builder is GroupWorkflowBuilder;
+            return builder is GroupWorkflowBuilder || builder is IncludeWorkflowBuilder;
         }
 
         static bool GetCallContext(ExpressionBuilderGraph source, bool readOnly, ExpressionBuilderGraph target, Stack<ContextGrouping> callContext)
@@ -22,13 +22,12 @@ namespace Bonsai.Editor.GraphModel
 
             foreach (var element in context)
             {
-                var groupBuilder = element.Builder as IWorkflowExpressionBuilder;
-                if (IsGroup(groupBuilder) && groupBuilder.Workflow == target)
+                if (element.Builder is IWorkflowExpressionBuilder groupBuilder && IsGroup(groupBuilder))
                 {
-                    return true;
+                    if (groupBuilder.Workflow == target)
+                        return true;
                 }
-
-                if (element.Builder is WorkflowExpressionBuilder workflowBuilder)
+                else if (element.Builder is WorkflowExpressionBuilder workflowBuilder)
                 {
                     if (GetCallContext(workflowBuilder.Workflow, element.IsReadOnly, target, callContext))
                     {
@@ -79,7 +78,7 @@ namespace Bonsai.Editor.GraphModel
                         break;
                     }
 
-                    if (element.Builder is IWorkflowExpressionBuilder workflowBuilder && !workflowBuilder.IsGroup())
+                    if (element.Builder is WorkflowExpressionBuilder workflowBuilder && !IsGroup(workflowBuilder))
                     {
                         callContext.Push(new ContextGrouping(workflowBuilder.Workflow, element.IsReadOnly));
                     }

--- a/Bonsai.Editor/GraphModel/WorkflowBuilderExtensions.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowBuilderExtensions.cs
@@ -79,7 +79,7 @@ namespace Bonsai.Editor.GraphModel
                         break;
                     }
 
-                    if (element.Builder is WorkflowExpressionBuilder workflowBuilder)
+                    if (element.Builder is IWorkflowExpressionBuilder workflowBuilder && !workflowBuilder.IsGroup())
                     {
                         callContext.Push(new ContextGrouping(workflowBuilder.Workflow, element.IsReadOnly));
                     }

--- a/Bonsai.Editor/GraphModel/WorkflowEditorPath.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowEditorPath.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 using Bonsai.Expressions;
 
@@ -37,6 +38,23 @@ namespace Bonsai.Editor.GraphModel
             foreach (var element in stack)
             {
                 yield return element;
+            }
+        }
+
+        public static IEnumerable<KeyValuePair<string, WorkflowEditorPath>> GetPathDisplayElements(WorkflowEditorPath workflowPath, WorkflowBuilder workflowBuilder)
+        {
+            var workflow = workflowBuilder.Workflow;
+            foreach (var pathElement in workflowPath?.GetPathElements() ?? Enumerable.Empty<WorkflowEditorPath>())
+            {
+                var builder = workflow[pathElement.Index].Value;
+                if (ExpressionBuilder.GetWorkflowElement(builder) is IWorkflowExpressionBuilder nestedWorkflowBuilder)
+                {
+                    workflow = nestedWorkflowBuilder.Workflow;
+                }
+
+                yield return new(
+                    key: ExpressionBuilder.GetElementDisplayName(builder),
+                    value: pathElement);
             }
         }
 

--- a/Bonsai.Editor/GraphModel/WorkflowQuery.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowQuery.cs
@@ -96,8 +96,10 @@ namespace Bonsai.Editor.GraphModel
             var matches = FindAll(source, predicate);
             if (current != null)
             {
-                if (findPrevious) matches = matches.TakeWhile(match => match.Builder != current);
-                else matches = matches.SkipWhile(match => match.Builder != current).Skip(1);
+                if (findPrevious)
+                    return matches.TakeWhile(match => match.Builder != current).LastOrDefault();
+                else
+                    matches = matches.SkipWhile(match => match.Builder != current).Skip(1);
             }
             return matches.FirstOrDefault();
         }

--- a/Bonsai.Editor/GraphModel/WorkflowQuery.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowQuery.cs
@@ -172,7 +172,7 @@ namespace Bonsai.Editor.GraphModel
                 if (predicate(builder))
                     yield return new WorkflowQueryResult(node.Value, path = new WorkflowEditorPath(i, parent));
 
-                if (builder is IWorkflowExpressionBuilder workflowBuilder)
+                if (builder is IWorkflowExpressionBuilder workflowBuilder && workflowBuilder.Workflow is not null)
                 {
                     path ??= new WorkflowEditorPath(i, parent);
                     foreach (var result in Query(workflowBuilder.Workflow, predicate, path))

--- a/Bonsai.Editor/GraphModel/WorkflowQuery.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowQuery.cs
@@ -14,11 +14,12 @@ namespace Bonsai.Editor.GraphModel
 
         public static bool MatchSubjectReference(this ExpressionBuilder builder, string name)
         {
-            string referenceName;
-            if (builder is SubscribeSubject subscribeSubject) referenceName = subscribeSubject.Name;
-            else if (builder is MulticastSubject multicastSubject) referenceName = multicastSubject.Name;
-            else return false;
-            return referenceName == name;
+            return builder switch
+            {
+                SubscribeSubject subscribeSubject => subscribeSubject.Name == name,
+                MulticastSubject multicastSubject => multicastSubject.Name == name,
+                _ => false
+            };
         }
 
         public static bool MatchElementType(this ExpressionBuilder builder, string typeName)
@@ -27,13 +28,72 @@ namespace Bonsai.Editor.GraphModel
             return workflowElement.GetType().AssemblyQualifiedName == typeName;
         }
 
+        static Func<ExpressionBuilder, bool> GetSubjectMatch(
+            this WorkflowBuilder workflowBuilder,
+            ExpressionBuilderGraph targetWorkflow,
+            string subjectName)
+        {
+            targetWorkflow ??= workflowBuilder.Workflow;
+            var definition = workflowBuilder.GetSubjectDefinition(targetWorkflow, subjectName);
+            if (definition is null)
+                return _ => false;
+
+            var references = definition
+                .GetDependentExpressions()
+                .SelectMany(context => context)
+                .Where(element => element.Builder.MatchSubjectReference(definition.Subject.Name))
+                .Select(element => ExpressionBuilder.Unwrap(element.Builder))
+                .Prepend(definition.Subject)
+                .ToHashSet();
+            return references.Contains;
+        }
+
+        static Func<ExpressionBuilder, bool> GetElementTypeMatch(
+            this WorkflowBuilder workflowBuilder,
+            ExpressionBuilderGraph targetWorkflow,
+            ElementCategory elementCategory,
+            string key)
+        {
+            return elementCategory switch
+            {
+                ~ElementCategory.Workflow => builder => builder.MatchIncludeWorkflow(key),
+                ~ElementCategory.Source => GetSubjectMatch(workflowBuilder, targetWorkflow, key),
+                _ => builder => builder.MatchElementType(key),
+            };
+        }
+
+        static Func<ExpressionBuilder, bool> GetElementMatch(
+            this WorkflowBuilder workflowBuilder,
+            ExpressionBuilderGraph targetWorkflow,
+            ExpressionBuilder builder)
+        {
+            var matchTarget = ExpressionBuilder.Unwrap(builder);
+            if (matchTarget is SubjectExpressionBuilder ||
+                matchTarget is SubscribeSubject ||
+                matchTarget is MulticastSubject)
+            {
+                var subjectName = ((INamedElement)matchTarget).Name;
+                return GetSubjectMatch(workflowBuilder, targetWorkflow, subjectName);
+            }
+            else if (matchTarget is IncludeWorkflowBuilder includeBuilder)
+            {
+                return builder => builder.MatchIncludeWorkflow(includeBuilder.Path);
+            }
+            else
+            {
+                var workflowElement = ExpressionBuilder.GetWorkflowElement(matchTarget);
+                var typeName = workflowElement.GetType().AssemblyQualifiedName;
+                return builder => builder.MatchElementType(typeName);
+            }
+        }
+
         public static WorkflowQueryResult Find(
             this WorkflowBuilder source,
             Func<ExpressionBuilder, bool> predicate,
             ExpressionBuilder current,
             bool findPrevious)
         {
-            var matches = Query(source.Workflow, predicate);
+            var matches = FindAll(source, predicate);
             if (current != null)
             {
                 if (findPrevious) matches = matches.TakeWhile(match => match.Builder != current);
@@ -47,6 +107,56 @@ namespace Bonsai.Editor.GraphModel
             Func<ExpressionBuilder, bool> predicate)
         {
             return Query(source.Workflow, predicate);
+        }
+
+        public static WorkflowQueryResult FindReference(
+            this WorkflowBuilder source,
+            ExpressionBuilderGraph targetWorkflow,
+            ElementCategory elementCategory,
+            string key,
+            ExpressionBuilder current,
+            bool findPrevious)
+        {
+            var predicate = GetElementTypeMatch(source, targetWorkflow, elementCategory, key);
+            return Find(source, predicate, current, findPrevious);
+        }
+
+        public static WorkflowQueryResult FindReference(
+            this WorkflowBuilder source,
+            ExpressionBuilderGraph targetWorkflow,
+            ExpressionBuilder current,
+            bool findPrevious)
+        {
+            var predicate = GetElementMatch(source, targetWorkflow, current);
+            return Find(source, predicate, current, findPrevious);
+        }
+
+        public static IEnumerable<WorkflowQueryResult> FindAllReferences(
+            this WorkflowBuilder source,
+            ExpressionBuilderGraph targetWorkflow,
+            ExpressionBuilder builder)
+        {
+            return Query(source.Workflow, () => GetElementMatch(source, targetWorkflow, builder));
+        }
+
+        public static IEnumerable<WorkflowQueryResult> FindAllReferences(
+            this WorkflowBuilder source,
+            ExpressionBuilderGraph targetWorkflow,
+            ElementCategory elementCategory,
+            string key)
+        {
+            return Query(source.Workflow, () => GetElementTypeMatch(source, targetWorkflow, elementCategory, key));
+        }
+
+        static IEnumerable<WorkflowQueryResult> Query(
+            ExpressionBuilderGraph workflow,
+            Func<Func<ExpressionBuilder, bool>> predicateFactory)
+        {
+            var predicate = predicateFactory();
+            foreach (var match in Query(workflow, predicate))
+            {
+                yield return match;
+            }
         }
 
         static IEnumerable<WorkflowQueryResult> Query(

--- a/Bonsai.Editor/GraphModel/WorkflowQueryResult.cs
+++ b/Bonsai.Editor/GraphModel/WorkflowQueryResult.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Bonsai.Expressions;
+
+namespace Bonsai.Editor.GraphModel
+{
+    internal class WorkflowQueryResult
+    {
+        public WorkflowQueryResult(ExpressionBuilder builder, WorkflowEditorPath path)
+        {
+            Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+            Path = path ?? throw new ArgumentNullException(nameof(path));
+        }
+
+        public ExpressionBuilder Builder { get; }
+
+        public WorkflowEditorPath Path { get; }
+    }
+}

--- a/Bonsai.Editor/GraphView/EditorToolWindowCollection.cs
+++ b/Bonsai.Editor/GraphView/EditorToolWindowCollection.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.ObjectModel;
+using Bonsai.Editor.Docking;
+
+namespace Bonsai.Editor.GraphView
+{
+    internal class EditorToolWindowCollection : KeyedCollection<string, EditorToolWindow>
+    {
+        protected override string GetKeyForItem(EditorToolWindow item)
+        {
+            return item.GetType().Name;
+        }
+    }
+}

--- a/Bonsai.Editor/GraphView/GraphViewControl.cs
+++ b/Bonsai.Editor/GraphView/GraphViewControl.cs
@@ -236,10 +236,13 @@ namespace Bonsai.Editor.GraphView
 
         public Color CursorColor { get; set; }
 
+        [DefaultValue(null)]
         public WorkflowPathFlags PathFlags { get; set; }
 
+        [DefaultValue(null)]
         public SvgRendererFactory IconRenderer { get; set; }
 
+        [DefaultValue(null)]
         public Image GraphicsProvider { get; set; }
 
         public IReadOnlyList<GraphNodeGrouping> Nodes

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
@@ -58,6 +58,7 @@
             this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this.enableToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.disableToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.findAllReferencesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.graphView = new Bonsai.Editor.GraphView.GraphViewControl();
             this.contextMenuStrip.SuspendLayout();
             this.SuspendLayout();
@@ -75,6 +76,7 @@
             this.defaultEditorToolStripMenuItem,
             this.docsToolStripMenuItem,
             this.goToDefinitionToolStripMenuItem,
+            this.findAllReferencesToolStripMenuItem,
             this.openNewTabToolStripMenuItem,
             this.openNewWindowToolStripMenuItem,
             this.toolStripSeparator2,
@@ -94,7 +96,7 @@
             this.enableToolStripMenuItem,
             this.disableToolStripMenuItem});
             this.contextMenuStrip.Name = "contextMenuStrip";
-            this.contextMenuStrip.Size = new System.Drawing.Size(250, 546);
+            this.contextMenuStrip.Size = new System.Drawing.Size(250, 568);
             this.contextMenuStrip.Closed += new System.Windows.Forms.ToolStripDropDownClosedEventHandler(this.contextMenuStrip_Closed);
             this.contextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStrip_Opening);
             // 
@@ -168,7 +170,7 @@
             this.goToDefinitionToolStripMenuItem.Name = "goToDefinitionToolStripMenuItem";
             this.goToDefinitionToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F12;
             this.goToDefinitionToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
-            this.goToDefinitionToolStripMenuItem.Text = "Go To Definition...";
+            this.goToDefinitionToolStripMenuItem.Text = "Go To Definition";
             this.goToDefinitionToolStripMenuItem.Click += new System.EventHandler(this.goToDefinitionToolStripMenuItem_Click);
             // 
             // openNewTabToolStripMenuItem
@@ -330,6 +332,15 @@
             this.disableToolStripMenuItem.Text = "Disable";
             this.disableToolStripMenuItem.Click += new System.EventHandler(this.disableToolStripMenuItem_Click);
             // 
+            // findAllReferencesToolStripMenuItem
+            // 
+            this.findAllReferencesToolStripMenuItem.Enabled = false;
+            this.findAllReferencesToolStripMenuItem.Name = "findAllReferencesToolStripMenuItem";
+            this.findAllReferencesToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F12)));
+            this.findAllReferencesToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
+            this.findAllReferencesToolStripMenuItem.Text = "Find All References";
+            this.findAllReferencesToolStripMenuItem.Click += new System.EventHandler(this.findAllReferencesToolStripMenuItem_Click);
+            // 
             // graphView
             // 
             this.graphView.AllowDrop = true;
@@ -401,5 +412,6 @@
         private System.Windows.Forms.ToolStripMenuItem docsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openNewTabToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openNewWindowToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem findAllReferencesToolStripMenuItem;
     }
 }

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -817,7 +817,7 @@ namespace Bonsai.Editor.GraphView
         {
             if (e.KeyData == goToDefinitionToolStripMenuItem.ShortcutKeys)
             {
-                LaunchDefinition(graphView.SelectedNode);
+                goToDefinitionToolStripMenuItem_Click(sender, e);
             }
 
             if (e.KeyCode == Keys.Return && !CanEdit)
@@ -1025,7 +1025,7 @@ namespace Bonsai.Editor.GraphView
 
         private void docsToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            editorService.OnKeyDown(new KeyEventArgs(Keys.F1));
+            editorService.OnKeyDown(new KeyEventArgs(docsToolStripMenuItem.ShortcutKeys));
         }
 
         private void goToDefinitionToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1045,7 +1045,7 @@ namespace Bonsai.Editor.GraphView
 
         private void saveAsWorkflowToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            editorService.OnKeyDown(new KeyEventArgs(Keys.Control | Keys.Shift | Keys.S));
+            editorService.OnKeyDown(new KeyEventArgs(saveAsWorkflowToolStripMenuItem.ShortcutKeys));
         }
 
         private void cutToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1033,6 +1033,11 @@ namespace Bonsai.Editor.GraphView
             LaunchDefinition(graphView.SelectedNode);
         }
 
+        private void findAllReferencesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            editorService.OnKeyDown(new KeyEventArgs(findAllReferencesToolStripMenuItem.ShortcutKeys));
+        }
+
         private void openNewTabToolStripMenuItem_Click(object sender, EventArgs e)
         {
             LaunchWorkflowView(graphView.SelectedNodes, NavigationPreference.NewTab);
@@ -1608,6 +1613,7 @@ namespace Bonsai.Editor.GraphView
                 {
                     defaultEditorToolStripMenuItem.Enabled = HasDefaultEditor(builder);
                     goToDefinitionToolStripMenuItem.Enabled = HasDefinition(builder);
+                    findAllReferencesToolStripMenuItem.Enabled = true;
                     docsToolStripMenuItem.Enabled = true;
 
                     var workflowElement = ExpressionBuilder.GetWorkflowElement(builder);

--- a/Bonsai.Editor/GraphView/WorkflowPathNavigationControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowPathNavigationControl.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Windows.Forms;
 using Bonsai.Editor.GraphModel;
 using Bonsai.Editor.Themes;
-using Bonsai.Expressions;
 
 namespace Bonsai.Editor.GraphView
 {
@@ -43,7 +41,7 @@ namespace Bonsai.Editor.GraphView
             {
                 workflowPath = value;
                 var workflowBuilder = (WorkflowBuilder)serviceProvider.GetService(typeof(WorkflowBuilder));
-                var pathElements = GetPathElements(workflowPath, workflowBuilder);
+                var pathElements = WorkflowEditorPath.GetPathDisplayElements(workflowPath, workflowBuilder);
                 SetPath(pathElements);
             }
         }
@@ -57,23 +55,6 @@ namespace Bonsai.Editor.GraphView
         private void OnWorkflowPathMouseClick(WorkflowPathMouseEventArgs e)
         {
             (Events[WorkflowPathMouseClickEvent] as EventHandler<WorkflowPathMouseEventArgs>)?.Invoke(this, e);
-        }
-
-        static IEnumerable<KeyValuePair<string, WorkflowEditorPath>> GetPathElements(WorkflowEditorPath workflowPath, WorkflowBuilder workflowBuilder)
-        {
-            var workflow = workflowBuilder.Workflow;
-            foreach (var pathElement in workflowPath?.GetPathElements() ?? Enumerable.Empty<WorkflowEditorPath>())
-            {
-                var builder = workflow[pathElement.Index].Value;
-                if (ExpressionBuilder.GetWorkflowElement(builder) is IWorkflowExpressionBuilder nestedWorkflowBuilder)
-                {
-                    workflow = nestedWorkflowBuilder.Workflow;
-                }
-
-                yield return new(
-                    key: ExpressionBuilder.GetElementDisplayName(builder),
-                    value: pathElement);
-            }
         }
 
         private void SetPath(IEnumerable<KeyValuePair<string, WorkflowEditorPath>> pathElements)

--- a/Bonsai.Editor/IWorkflowEditorService.cs
+++ b/Bonsai.Editor/IWorkflowEditorService.cs
@@ -24,9 +24,11 @@ namespace Bonsai.Editor
 
         void NavigateTo(WorkflowEditorPath workflowPath, NavigationPreference navigationPreference = default);
 
-        void SelectNextControl(bool forward);
+        void SelectBuilderNode(ExpressionBuilder builder, NavigationPreference navigationPreference = default);
 
-        void SelectBuilderNode(ExpressionBuilder builder);
+        void SelectBuilderNode(WorkflowEditorPath builderPath, NavigationPreference navigationPreference = default);
+
+        void SelectNextControl(bool forward);
 
         bool ValidateWorkflow();
 

--- a/Bonsai.Editor/ListView.cs
+++ b/Bonsai.Editor/ListView.cs
@@ -1,0 +1,10 @@
+﻿namespace Bonsai.Editor
+{
+    internal class ListView : System.Windows.Forms.ListView
+    {
+        public ListView()
+        {
+            DoubleBuffered = true;
+        }
+    }
+}

--- a/Bonsai.Editor/Project.cs
+++ b/Bonsai.Editor/Project.cs
@@ -114,6 +114,15 @@ namespace Bonsai.Editor
             return Path.Combine(Path.GetTempPath(), DefinitionsDirectory + "." + GuidHelper.GetProcessGuid().ToString());
         }
 
+        internal static string GetFileNamespace(string relativePath)
+        {
+            var fileNamespace = Path.GetDirectoryName(relativePath)
+                                    .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
+                                    .Replace(Path.DirectorySeparatorChar, ExpressionHelper.MemberSeparator.First());
+            if (string.IsNullOrEmpty(fileNamespace)) fileNamespace = DefaultWorkflowNamespace;
+            return fileNamespace;
+        }
+
         public static IEnumerable<WorkflowElementDescriptor> EnumerateExtensionWorkflows(string basePath)
         {
             IEnumerable<string> workflowFiles;
@@ -137,11 +146,7 @@ namespace Bonsai.Editor
                 catch (SystemException) { continue; }
 
                 var relativePath = PathConvert.GetProjectPath(fileName);
-                var fileNamespace = Path.GetDirectoryName(relativePath)
-                                        .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
-                                        .Replace(Path.DirectorySeparatorChar, ExpressionHelper.MemberSeparator.First());
-                if (string.IsNullOrEmpty(fileNamespace)) fileNamespace = DefaultWorkflowNamespace;
-
+                var fileNamespace = GetFileNamespace(relativePath);
                 yield return new WorkflowElementDescriptor
                 {
                     Name = Path.GetFileNameWithoutExtension(relativePath),

--- a/Bonsai.Editor/Project.cs
+++ b/Bonsai.Editor/Project.cs
@@ -10,7 +10,7 @@ namespace Bonsai.Editor
 {
     static class Project
     {
-        const string DefaultWorkflowNamespace = "Unspecified";
+        internal const string DefaultWorkflowNamespace = "Unspecified";
         internal const string BonsaiExtension = ".bonsai";
         internal const string LayoutExtension = ".layout";
         internal const string EditorExtension = ".editor";

--- a/Bonsai.Editor/Properties/Resources.Designer.cs
+++ b/Bonsai.Editor/Properties/Resources.Designer.cs
@@ -829,6 +829,33 @@ namespace Bonsai.Editor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Auto Hide.
+        /// </summary>
+        internal static string ToolTipAutoHide {
+            get {
+                return ResourceManager.GetString("ToolTipAutoHide", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Close.
+        /// </summary>
+        internal static string ToolTipClose {
+            get {
+                return ResourceManager.GetString("ToolTipClose", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Window Position.
+        /// </summary>
+        internal static string ToolTipOptions {
+            get {
+                return ResourceManager.GetString("ToolTipOptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The specified type could not be found..
         /// </summary>
         internal static string TypeNotFound_Error {

--- a/Bonsai.Editor/Properties/Resources.resx
+++ b/Bonsai.Editor/Properties/Resources.resx
@@ -654,4 +654,13 @@ The visualizer layout may be corrupt. Do you want to delete the layout file?</va
         kQDw7TLDa/cHU8MIBKODqWCEAq6GEPQwAoGoHmYA1FrXs7P8/yQ7mKAz9dbnzhUAAAAASUVORK5CYII=
 </value>
   </data>
+  <data name="ToolTipClose" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="ToolTipOptions" xml:space="preserve">
+    <value>Window Position</value>
+  </data>
+  <data name="ToolTipAutoHide" xml:space="preserve">
+    <value>Auto Hide</value>
+  </data>
 </root>

--- a/Bonsai.Editor/Properties/Resources.resx
+++ b/Bonsai.Editor/Properties/Resources.resx
@@ -134,39 +134,37 @@
   <data name="StatusBlockedImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAAK5JREFUOE9jQAffvn1LAOL9QPwfDYPEEqDKMAFQUgGIz3/at/P/q2jf/09FGFAw
-        SAwkB1IDUgvVBgFQze9fZ8ZgaETHb8pzQIa8RzEEyDkPksCmARuGGnIepjkB5DRsCvFhqHcSQAbsx+Zn
-        QhikB6QXZABWBcRgkF4UA4gFtDOAVAwzgOJApCwaoWnhPDGpEIZREhIIADngpExMasSalEEAagh5mQkZ
-        ACVJyM4MDAD69UvNH5WBiAAAAABJRU5ErkJggg==
+        vAAADrwBlbxySQAAAKRJREFUOE+1k70JgDAUhDOEA7iQE2iRVrB3NhsdwSlsVBAsro0cGEmeEaPig2vy
+        3n3k56KUKAAaQAfACHFNy/mjAKQA+rVtzJhnZkiUJ66xxxnOhszLVBYno9RcV4QsHoRUNuTwlXZIb82a
+        W5NDd9qPownoQme+Ez30EnBqxopeDxBb/wGeygI+X+K3Z7RBikmhlRckN8oxaQxG2YG8+0xuPf3OG/r1
+        S83VLHhoAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="StatusReadyImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAANdJREFUOE+dU7kNwzAM1CjZwQtpBA/gwqVX8CKpAggI4FojuHNrwIVahZeQhh7a
-        cXLAFSJ5Rz2UKRFCsERHjAURs1xWg5I3op/mKbb3NjZjkxEx5FCDWpZ9wOK1e3SVsOTwHGCyZia08Eho
-        Ao1s4kVssTWtUNi7PgLLtuwxPo6FgdPOnBJCAEYSgwZaGGTFJbXuQmi/GmjdhapBKjjrDqoGqeisOygG
-        1SWKEDjqnl5i9YyyC+Co+/6MPAv+yhQKs0ECaPEe5SvTqI4ywCb/faYUlPzhOxvzAkO1WA01cJaNAAAA
-        AElFTkSuQmCC
+        vAAADrwBlbxySQAAAMpJREFUOE+dU7sNgzAUZJTswEIegQEoKFmBRVJFshSJmhHoaJEornV0Es96fjYO
+        yZOueX5358+5aUwBcAA8gGDAnrPzsQA8ACzzOofu2YV2ahOwxzXOcLZE3vtXnxEtxvdIkT0RoSoX7PAV
+        TpFFyI5bs0Magx8Cazu22DuP4yjgS2fWIJFFIemRQy4FMoJGyV1A7leBkntVQBNq7pcCmlRz1wLZJQqx
+        5q4vMXtG2UXNPT6jBOlOCgVJkHSU76SxGGUl8t9n0vXrd/4AQ7VYDU+lEVUAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="StatusCriticalImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAANRJREFUOE+1U8ENwjAMzBAMwAiMwAJMAI98kfgzGx86QqbgU5CCeOSHgi/YlZNY
-        SFBx0qmNfXdtWse1SCl54kDMDVHzLOtBzSUxPM6nPG43+bJwFVFDDxpo2fYGm+N1v+uMLW/HA0JiFUKL
-        gAYE43pV2Bp1nUOCmD1eTUTPeyzUIVadt+MRMMieRQiI2KoVLXngRcD0JCvEMgvh7QJAHQJYZvA/AdqM
-        q75vQyRg9kec9xt5FoJMIQTaLNT1apAAWpRRlmn8RHOUAQ757TBpUPOL4+zcCzIffKHxkkn8AAAAAElF
-        TkSuQmCC
+        vAAADrwBlbxySQAAAMVJREFUOE+1U7ENwjAQ9BAMwAiMwAKZIBRukeiZjYaMkCloApIRxXXI6Kx89H6b
+        SCTipWved+e3fXbOFAAPoAMQDdjzlj8VgC2A/nW9xKFt4m3jMrDHNXLIrYnD/XgohBaP84kmITOhKxfS
+        TvtdghXq/mjSi9hzNCG9nyFBm9T643E8DTo5sxBZQq71Erdt0sXSoBhVC2piAbWFgTX5Jv6fwZIjrL7E
+        dc8oQZIUyq56VNvPgqSjLGmcQzXKymTZZ9L163f+ADIffKHtBOXkAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="StatusRunningImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vgAADr4B6kKxwAAAAMFJREFUOE9jQAffvn1LAOL9QPwfDYPEEqDKMAFQUgGIzx+9f/R/wbaC/8YzjVEw
-        SAwkB1IDUgvVBgFQze9r9tRgaETHHYc6QIa8RzEEyDkPksCmARuGGnIepjkB5DR0RTff3PwfuSYSQxyG
-        od5JABmwH5ufYWDmmZkYciAM0gPSCzIAqwJkgMs1IL1EGQAD6K6hnwGEvEBxIFIWjdC0cJ6YVAjDKAkJ
-        BIAccFImJjViTcogADWEvMyEDICSJGRnBgYARwha+z9sKMcAAAAASUVORK5CYII=
+        vQAADr0BR/uQrQAAALpJREFUOE+9U8EJhDAQtBR7sBp/KcECLMAW0sO973UgCP4OfPuyAcHffCMD7pFs
+        Ipc7wYH57O4MuzopCgUABkAPwCmyZvT8BwBKANO4jK55Nq6yVUDW2OMMZ1PirX21kVCzGzqabIEJXdnQ
+        w2c8TCYRG66mh+Z1dvWjjurC4xxDgz51s8C+bdQjqaGWBlHTNyDOtqE2y0Cgt7nP4NsJlz/itd8oQcpJ
+        oTAIkh/lnDQmo+yZ/PeYfPz6nHdHCFr78ATOaQAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="AttributionNotices" xml:space="preserve">
@@ -220,10 +218,10 @@ Copyright (c) .NET Foundation and Contributors</value>
   <data name="StatusUpdateAvailable" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vQAADr0BR/uQrQAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAKdJREFUOE+lkMEN
-        wyAQBCktooV8U4KLyTuklnxSkJ0P300WaZ3jwDaSLY18HLeDTQDQkHPG7f5CuD4LrNnzc6Rp+PCRpFps
-        hUVP8i9+Dzc1PD3eVVD1kEAn2ZAkjYANi8LECvyeKIKUEmKM5V1tOgHxs0ENiw1Y/Byz1S/0ZB6dLNbL
-        UINDy/wpKGTXmlsv0QguowJlSFewx5Dg9BecFuxxKBhBGQDhC/DB5AQ227rCAAAAAElFTkSuQmCC
+        vAAADrwBlbxySQAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAKFJREFUOE+lkUEO
+        wjAMBP00lC9w5Qk8hnPDW7jwIODiq5EjLTibKLXUw7ausztOZTEzYamqXW4Pk/O9yWvvsc81NDi8B0mF
+        V5B/IdIAMF+3ZxdEnQJgUgwBMgC8EYUwA/js5/FHrdVKKe3dHRJg5hU0ongKxD7Pdr8wg7GGW8YVYsr7
+        9WlCKH7DN2xBVU9ZwHSNEbBSCnD4BocBK+0CMoqAL/DB5ARcI8kAAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="PackageUpdatesAvailable_Notification" xml:space="preserve">
@@ -359,285 +357,282 @@ The visualizer layout may be corrupt. Do you want to delete the layout file?</va
   <data name="BrowseDirectoryMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAAMBJREFUOE9jIAS+fPli8O3bt/dA/B8bhirDDmCa29ra/js5OWFgFAOQTUXGIM3N
-        zS3/P7z/iIKxGoBuAwgja4aJ4TUAppgQpp4BIAKGyTYAxCEWYzPgfH5+PoZCXPjokaOoBnz9+rVh+fLl
-        GApx4b6+flQDQInlypUrGApx4eSkZFQDoDHwPjIyEkMxLnzr5m0wDTcA6I35uJIrNrx+3XowDTfg+/fv
-        Cfv27cNQSAjDDXj//r0AiEMOBhtAPmBgAABlf1By6VZQbwAAAABJRU5ErkJggg==
+        wQAADsEBuJFr7QAAAMBJREFUOE9jYCAAvnz5YvDt27f33759+48No6tHATDNbW1t/52cnDAwigHoJsMw
+        SHNzc8v/D+8/omCsBqDbAMLImmFieA1AtwkXpp4ByP4l2wB0f+PD2Aw4n5+fj6EQFz565CiqAV+/fm1Y
+        vnw5hkJcuK+vH9UAUGK5cuUKhkJcODkpGdUAaAy8j4yMxFCMC9+6eRvVgK9fv87HlVyx4fXr1qMa8P37
+        94R9+/ZhKCSE4Qa8f/9eADk9kILhKZFcAABlf1ByrNmc2AAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="CopyMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAAFhJREFUOE9jwAa+ffv2nxgMVY4JQJJOTk54Mf0M+PD+IwrGagCIQwzGawBMAhem
-        nwEwv8IwsoZhYACMDeNDtdPRAHQM1Y5qAC6MogEdUMUAYjBUORJgYAAAnlgvt6X+ezUAAAAASUVORK5C
-        YII=
+        wQAADsEBuJFr7QAAAFFJREFUOE9jYMACvn379p8YjK4PDkCSTk5OeDH9DPjw/iMKxmoAut9wYbwGoDsR
+        HdPPAHx+RucPQQNg7IEzAB1jNQAXRtGADqhiADEYXR8IAACeWC+3+cBtLwAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="CutMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAARNJREFUOE+Vkj2OgzAQRn2EPcIeIWegR9qWU3CFvUEOQ09PlS3olyLZhiKJ+Csd
-        PzNDDCSW9pNG2PO98YwtTKi+7w/jOF4Jpw9JG9aah5H0XgB5ntuiKOwwDN+SNqzJ4cFIei9n2iRJbJZl
-        HqSzdieHByP4XiGoU2j38GDB9wIuy3IFh4dWVbW62kt1XffLXXUK7U4OT7D3ch2+6rpeptDu5PAEiyuc
-        4l/dEa/etq0vvJz/fLCOvj5ywBGIeHdAEEcpm0WCO6Zp6uFYwMCuDuFUjNPpx96ud/8FZhKdJvRgqZHy
-        5x8IoMG+aRofrzxqpmn6XA7YTqBdYp4vRm6zegO+es+YJ+WzBF66hr/s1mM/O8Y8AKj29kGG9z1nAAAA
-        AElFTkSuQmCC
+        wQAADsEBuJFr7QAAAQhJREFUOE+VkrFtxDAMRW+EjJARbgb3BtJ6Cq+QDW4Y9+5dXQr3cXFJ40IJbNGl
+        Dk8ABUpnX5APEJb5P8lPQaeTwbquZxFxhHPuRfOcNY/G1mRA0LZt6LoueO/fNc+ZHByavMpAREJVVaFp
+        mihksk4nB4emrEuwQnWh023jsi4Bcd/3mdg2HYYhW20Xy7J8squ60Onk4Er9A7z3b+M4Jhc6nRxcqd+F
+        dfGv6YBbn+c5Fn7dvmP8eftARC6IiKMGJi4PxexY13WyfRRo0GZN6ApxvX6EH/cbv4hxom4shzZbSV8g
+        Ag3+p2mKscdRs23b66EDnfKMsw6yO7B7PuNSA21ib9o+2ZKzxXeo9vZBw9kiawAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="DeleteMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAAVdJREFUOE+lk7FKw1AUhn0BwQdwcHJwEpzcsjkJmZ06+AABfYDqA1h3h+AiHQrS
-        xUkoOjiIEFwERSgOtoqDdcl6/b+bc9OmJHbwhx+Sc/7z33NyT5acc/9iiTzP18S2mIgrFq6AuJiKA2Mr
-        JKKfz7F7PDv11PtQrJjoPZ58jL4fTo7d2+01mqzU6CGl8Hx92fPu6ADBpeU4tTPK7l0v2nD93W2HkWKb
-        vhjMG0A7hZGGT93UXWytemKkWGylBRTwI+AeDBATo5s508TKqlCiVWcSnulCmtTk9agzgTeH+xRPP1oT
-        FhgMTFYPCTpfr8+LRmicP+XrzhZgRDfcezCzG5heH2gqtruOxYzTibMHk/F7dcm4mlAIMeJkiSLyiMUU
-        HbmrvR1yfsk8Qouh2NosdnwGiiXk6IKaUhOc/yoOUC5iNEZ86XeLdaZA5AW2TdsIafhr2Qkdlme/FMP+
-        sdnP7QgAAAAASUVORK5CYII=
+        vAAADrwBlbxySQAAAUhJREFUOE+lk71KQ0EQhfMCgg9gYWVhJVjZpbMSUltZ+AABfYDoA6i9xcVGUgQk
+        jZUQtLAQIdgIihAsTBQLY3PalW+zc+/ukp/CAwPJ7syZOTvn1pxztf9ECUmrklqSmpKWq5sKnEsqJPVC
+        7NlF/fdr5J7Oz3xIGuQkkhrjz+HP48mxe7+7Iadf5sBK4cXako/7owMSrqKup8P+g+vU1113Z8tBJGkj
+        Zk8IiNAFSYPnduEuN1d8QMQ01WyRBNiNgGTOmCYjbSbFBh5kGon9ZgomzesSTCMhbg/300ebhQUEvTw/
+        AS/9/faySMJM/QWvGxdAxDTs3cjCBqr1zSsOu26gne6c44Px6CM1GauJ9dr6WG1o4O1LHnfXu9ulyTxs
+        xGzMiccjoN/cSE2ZY8zzig1MhTQkvnbbEztTIIk/RCsvyhG+WjzhvfEHFMP+sfzNOIsAAAAASUVORK5C
+        YII=
 </value>
   </data>
   <data name="DisableMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAABl0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC4yMfEgaZUAAAEvSURBVDhPpZIx
-        TsNAEEW3oIhl2YXNAeLKLUVqFz4CXQoa1+7TcQxOQEHHMXwEJHo6JEs4MW7MMs94N8mysoIY6Us7O3/+
-        zM6s0lr/C/5LpVaCjaCewXnl5boXSZLchmH4kef5oaqqEXAOgmAfRdGdyz9zJPkhy7LPpmnEPTfuiInI
-        o7i/BagMoes6cf1GDE4cx1txjwK8j7Z9lV2DA1dyrsS1AhveOTEuMLiScyNHK1AzrCnq2DiOehgG3fe9
-        hXTxVZblTsLLAiST8L6r9du1ssBv21ZC/XrxCVR2k09FRODZDpE9u0Okui/ZgPgkAPgksqLhdI1GwGfc
-        719fjgIgTdMnREwnf+rAgE9ivjLTvmgGLpgJgy2K4p5puyJzMmv42cISIFFJMLU8A3+ttVbfua7AOcnu
-        SOAAAAAASUVORK5CYII=
+        wQAADsEBuJFr7QAAABl0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC4yMfEgaZUAAAEmSURBVDhPpVOx
+        bsJADPXAQBRdhoQP4KasHZgz5BPYGFgyZ2frZ/QLOrD1M+4TKnXvVikSAZMlHHqQOx1uoK1q6Uk5+/n5
+        znbIWkv/wTfHxUk0JaIFEdUD8D2VvFGBNE2XcRzv8jw/VFXVA/iOomivlFpLvkx+0VofjTFWGnyIKaVe
+        RwVQGYS2bWWuN8TASZJkdSOA9+HaY5WlgQMuEU1CgQXeKcn3DFwiegoFajRLEmF939uu6ywzexhjTmVZ
+        bn4UQDISvja1/ZyRB85N0zAzzx8+AZVlcijCzG++iZizbCKqy8QQiPsxYkm01l04RicwZvDvP95vtyrL
+        si1E3E3+dAMHLIlbZXT7Vz2QcD9TURTP6LYUGZIxhusUHgEkVAr3YDjPET8Dua7AOeoCC5YAAAAASUVO
+        RK5CYII=
 </value>
   </data>
   <data name="DocsMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAOBJREFUOE+dU0sKwjAQzT3ceCj35gIuXHsGD+ExBCEI4jZeQVd+kNJNwYXEee2M
-        JJNUqw8eNPPmPZpkYjSaprFERwyKqFluy0HimOjdsQ7TzTmMVqeEqEFDD3rZ1oHN1Wx7zYyai/0NIVUS
-        QgsPQZrmu3uoH88gwDdqKsSL2eLXRAT7EPfwdiwCnN6zYLK+tBTEPfDAi4BEKFGg6/B+DFgearZ20PrX
-        gBgI0/rggJIGSkB2iEMYH2J2jUJBSXtfI8+CL02hQNeTQQJo0Y5yPI19LI4ywCH/PaYYJP7wnI15AZ9a
-        s/c7lU10AAAAAElFTkSuQmCC
+        wgAADsIBFShKgAAAANNJREFUOE+dk00KwjAQhXsPNx7KvbmAC9eewUN4DEEIgritV9CVP0jJ5oELiTwx
+        YTJJSu3AgzIz72t+Jk2jAoABYAF4JeaM7o8BYAqgtWfn57urn2wuiZhjjT3sLZm7xf6eGbVWxwchXQIh
+        lYXQtDw8vXu9fQh+M6cgbTAbLk3+pRay57cdQ4DVew4x296+KgHooZeApFBSCUDR2wtYn1w0jwLIIEzX
+        BwN0XgOyQxwieYjZNQb1rSBeYxik0hTWAMkgyVGW01hTcZQFZNxjkvHvc/4An1qz99vHnYMAAAAASUVO
+        RK5CYII=
 </value>
   </data>
   <data name="EditExtensionsMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAAGJJREFUOE/NjkEKwDAIBH2b//9L24vXhpYubMRQtZcKQzaKg2Jm5xdugaq2+Jlg
-        344SkyDLUoCTwKpXFlwv51cBFjwlAbL/twVMS8A5JfDwDJl7k4AHUS+iJJCoYMrwrFCJDPPTzd8i9/0e
-        AAAAAElFTkSuQmCC
+        wQAADsEBuJFr7QAAAFpJREFUOE/NkTEKACAMA/u2/v8v6tJVcRA0RLF1sXAdAl4DipnVF6QvVQ3xmSCn
+        4mIR3LIVsGoscwvG5WsBVg4JWJMnwUxI4G6AMNmcHX8BM4ZLIGzQeALf9mnz083fK2ThnAAAAABJRU5E
+        rkJggg==
 </value>
   </data>
   <data name="EnableMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAABl0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC4yMfEgaZUAAAFjSURBVDhPpVKx
-        TsNADM3A0ChKhuQHmikrUjtHVeZ2YcvAkrk7G3N/oEhMLIAYkBj6Byxh6A9k6dCBASEiEQhZgvG7Jtfm
-        OEVIWHrS+ez37LPPIKJ/QX9pGAPGmDFvgPNAm6teuK57YlnWexAEn0mS1ADOpml+2LZ9quZ3HCZf+L7/
-        laYpu13DHWIscs3ubwFURkJRFOzqDTHkOI4Ts7sXwPvQtq6yashBLnOO2JUCY7xTZPzBkMucYz5KgTmG
-        JaKK1XVNVVVRWZYS3MV3FEVnHO4XABmExeOCRpcjieXTkvI851A57H0CKqvkydWEsteMtm9biD/IIWLP
-        6hBRXUcGpjdTERcCAD4Jr6g6XCMS4vuY1s9rmt3OJBlCENy8bPYCgOd5dxBpO4FAWxV2SAY6HbTAJ2m/
-        MqaNGYC0ylYdMu5ZYDcDFZgJBhuG4TmmrQ6yIWMNuy30AUmoxBAtN4A/JCLjB1bFyfCzDqNWAAAAAElF
-        TkSuQmCC
+        wQAADsEBuJFr7QAAABl0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC4yMfEgaZUAAAFYSURBVDhPpVOx
+        TsMwEL2BoVHkDMkP1FNWpHaOqsztwpaBJXN3Nub+QJGYWAAxIDH0D1jM0B/I0qEDA0JEImCyBKNXEis5
+        Qhk46UmO/d47++5Cxhj6D35s7DaJBkQ0JqJ5DawHnNdr4Pv+keu6r2EYvqdpWgFYO47zJoQ45nwuPpNS
+        fiilDA/s4UwIcdlrgMwgFEXBtTZwBo7neUnHAO/Dtfsy8wAHXCI6aBuM8U5O/i3AJaLDtsEcxeJERFVV
+        pixLo7W2UEp9xnF88qcBxBAs7hdmdD6yWD4sTZ7nWms93PsEZObiycXEZM+Z2b5sYX5ni4g+8yIie58Y
+        mF5Nd+e2jRgSKWXZbiMIyW1i1o9rM7ueWTGMYLh52nSnKgiCG5g0N4FBkxXRFgOdGzTAkDSjjGqjBhCt
+        slVHjH1bA47mZ4qi6BTV5oWsxWjDdxf2ASRkas9B/T3E+RdWxcnw2SwQDAAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="FindNextMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wQAADsEBuJFr7QAAAK1JREFUOE+tkDEOwyAMRTlSz8DO1LXnYW0OUKk3YWdKb0IqAaurj2yJ0tBSlC99
-        WTh+3wQlSindc87UGn0e+S0JuSyO1PlW6nBIvXUqBEMA9jwUckhA7fYXGl8Ze1fvEZ1zZIwhrXWp3vvP
-        EIH3DGhdH7SFZ6k4o8/od2EQmwGLcR4KiDGeJODvGzAcrLUlQNx9g1otjIqNlfswVAcwHNDjz2OSkClY
-        BHAaHpNSL7T3hUMbVcA9AAAAAElFTkSuQmCC
+        wAAADsABataJCQAAAKtJREFUOE+tkT0OwyAMhTlSz8DO1LXnYW0OUKk3YWdKb0IrAaurh7CUuiV1ojzp
+        ycLy+/gzpquUcq+1kjT6PPNXDLlMgcz51qoaInfeDMEQAr+sghwCWLuC8FXmm0aPGEIg5xxZa1uNMX5D
+        Rt8IIzTPD3qmV6tYo/8BGAmD2BlhNtYqQM75xIDNJ+jh5L1vAPbwDZaSYVTVL7CWgB5O6Mm5VTFkV5iF
+        4O6wVm+094VDXxlEOgAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="FindPreviousMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wQAADsEBuJFr7QAAAKlJREFUOE+1krENwyAQRRkpM9BTpc08tPYAmYWeytmEREK0l3x0pxBiY2zLX/o6
-        ge79A4SqFWO8pJTCx1Q4YJ9bliXwbXSkrndCPQr/mFv/VcNzPjcA6rlC5YHRr1ohzjkyxpDWOlfvfTtE
-        QDGgaXrQM7xyxRr7jLWFRkwGLMa6K4BPlIHNJ5DrWGtzgLj5BqIaRsXEwsswVAYw3PelS0nILlgEcDe8
-        LqXesOyDraOJECgAAAAASUVORK5CYII=
+        wAAADsABataJCQAAAKhJREFUOE+1kjEOwyAMRTlSz8DO1LXnYW0O0LOwM6U3oZWQV1cfxZXrRoS0ype+
+        LBDvgwHnjGqtJyIqRMTKBfN27ZcEvkyJ3fnGqP/CH7bMWxZe87EBkA1Za8H4ajO6ISklDiGw977VnHM/
+        xO4IaJ7v/CjPVjHebEuEhdgZsBjjoYDlRA3YfQJpJ8bYAsTdOxBZGHXzFbR0wAKPfWkt9SL7YRHAn+ER
+        vQCw7IOtDEAH+wAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="ForumMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAKxJREFUOE/NkrENwyAURD2KZ6FnALZI6YzBBJ7DblJTOQV7OGloz5xFHBx+ZMdu
-        8qUnwf93hwRUAE4hNn/hvYgVQmgj2KCltgjgwHsPrTWUUiKcUUOtFDALhuGOx/gU4YwaasUAniIZc6j5
-        44Czd1C8Ak1Nc132nH19hc9/QEPf9TDGzPsM+R/k9Qrgic45mi5ptNSuAGstzbfUXtVmQGKM1Km9qiLg
-        KGJzP6gm/JDKQpSrS7MAAAAASUVORK5CYII=
+        wgAADsIBFShKgAAAAKZJREFUOE/Nkr0NwyAQhW8Uz0LPAGyR0h6DCTyH3aSmsgv2cNJce9GLiBI4JGO7
+        yUmfhHg/SACJCF1BbRzluyAiZh6ZWXYY4VUFEGKMYq0VY0wVaPDAWyt4G5Zllcf2rAINHnirBTilDJXA
+        88cFV+9AvQJCfT+0vUL5DxCYp1mcc23/4Hc+BTgxhIDQLTO0FnjvEb5nYprdgsTGzF0mplEFZ1EbR3kB
+        /JDKQt8vvbQAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="GalleryMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAA
-        JQAAACUBVfdSxgAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAE2SURBVDhPnZLL
-        SsNAFIaz8kFEEN24VRAXKrVKBUEUCrrwLcQLgiAIIq6U6sbL0stCWh8lrQ/RdFKczEyImV/PdIJGTdP4
-        wU+YM+f858whzg/wD6VAESi/V/aFvRoMyjdFRZVgz+muWkio5zpE7cp8dSDsTY++BlGzBTZbQnB8gu7m
-        FtrDo+hMzSByXZvRx4A6U7G4uIRWCohj+GtV+JUVsLkFaClNXqYBjeuNT0A9PEGHoYkZtEa3ugFVb5hj
-        pgF1Dk7PEHsewsYL1P0jxHkNfGffPIXuiUwDmoCVltAeGYO/ug55c2cKE+VOQNumhXUmp8EPj6A5h7y+
-        NTE2X87fARG5TbDFZfC9A1P8tr0LVq7gvfVqM3IMCOpE49J/QLtIOifYou/6FRhEKT4DQwX0p0FhWRzn
-        Aw2/UgbF/z9wAAAAAElFTkSuQmCC
+        JAAAACQBh7CwIgAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAEtSURBVDhPrVLL
+        SsNAFM3KDxFBdNOtgrhQaatUEEShoAv/QqoiCIIg4kqpbnwsfSyk9VPS+hFNJ8VJZkLMHLmDCRkjiREP
+        HOYyM+fcM5exLBP4A02DMvg3g++RCpkxSEP5AvKlA799rVfl+cZ5rkHY64MtVOGdnGK0vYPB+CSGs/MI
+        bdsQpevEgDqT2L+8gpISiCK4G024jTWwxRqUEPkGFNeZrkA+PkMFQXIJSmHU3ILsdBNRDMOAOntn54gc
+        B0H3FfLhCf5FG7x1oJ9C57kGlIBVVzCYmIK7vglxe6+FMQsT0LRpYMOZOfCjYyjOIW7u9B5bqhfPgBDa
+        PbDlVfD9Qy1+390Dqzfw0X8zROk6+w+E0HHpH9As4s4xvkRpZjZ+QwOwrLES/NGgNBN8Ag2/Ugbi3EnF
+        AAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="GroupMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAMNJREFUOE/NksEN
-        AiEQRbcESzLUwp0WbIEKPFIABXimCumANQQ44s6Gj8Ci8aY/eclmZv4HFpb/UM55ChRjzAUXQrg6505t
-        f2omIDIzxnaklHkLubX9doUOBNE357yGoFdFBTTHIWJb8WKtPfSqELC6xw6GAA1jhtBaZ+/9vdj7AAwB
-        BJBBCNHVi/14hHEnXwWAdwHoEUopqrtif11jOwSoNvuJKaVzsfcBM8j88RoRMAIZY6p5+pBGI4Da3Uyf
-        8g+1LE+tWt3EvXbfEwAAAABJRU5ErkJggg==
+        wQAADsEBuJFr7QAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAALVJREFUOE/NktEN
+        AiEMQG8ERzLMwj8ruAIT+MkADOA3U8gG1ZDCJ4aLJQV6xj9t8pILpa+FY9v+ImqtIhQ55/oGEPEKACee
+        XwolgVJqx1pbEfE2CFiHARK1b611l1BO7DBvaiDiJca45BbBA547tIlPwpt472tK6S4KjiZpBcaYYX0R
+        EPMkXwmIIwFv4pxr69AF/LalI0iXWEo5iwKJVvzxN5JghiKE0IvFhzQXzgI+jfiUfxovrVrdxEt18xsA
+        AAAASUVORK5CYII=
 </value>
   </data>
   <data name="NewMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAAMRJREFUOE/NkjsOAiEYhDmCtSew9AycyAtYyjVsPImJhRWHsLESjUCLDv4T2V1Y
-        X42TTDbAzLf/PlSpEMLCOTeJMSYaa+xLpK17aC0li+t2OSUkr3Eu0aFwB4R2q1k67De5SADW2BdIfRIZ
-        2zJ8PR1zAdcCapGTSlcI0yw37Lz3c6k9hUOMXDx30loPbIypQ1iCOQEKZ3fpuAnpv4MxQAmRev0r1AA0
-        zpCR+kP9/+BjAIRJ+Cd+BaD+BzDml4B3LPFfpNQN8wIwvWiZlr0AAAAASUVORK5CYII=
+        wQAADsEBuJFr7QAAAMFJREFUOE/NkrENwjAQRTMCNROkZAZPxAKU8Ro0TIJEQeUhaKgwCJ9bo2/5rIu5
+        BEjFl76sc+6/nBN3nRARbb33qxhjYqPGvuxTRUT7EnJYj7s1Q3KN522mCm9A02no0+V8yEEGoMZ+geiT
+        lLEdNz9v1xzAKqAOfW02S56ZwxP2IYRNm88AjCzOnYwxb7bW6hBtAgTu/jHyJKT9BnMACakA7S9oAAlC
+        TwUUyOge/AwokHoTFwFY/wOY80fAN25zi/QC8wIwvVk/HesAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="OpenMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAARxJREFUOE+VkrGqwjAUhvsG9z6J3Ee49BVcWlBw6F7wCZw6qrMIF1TodB9Ah+6d
-        XAqiLsVBB4X0atqO5+aENiRNoxj4SM/J//9Nm1j1oJR+FUVBGCBBsF9JXg8Uny8Z6Qx/werOoTeNeEiF
-        HCyorJbFikndvNwykEPiOAbbtjVEAJpn6wQ++gtuaoJr9/sDMvInaAZwM75td7pqO6APKkyIElCW5Td/
-        YOJn5iZPd4A1YjIjIqAWy/8A6zaTjBKAhed5EEURpGnKF7DXRlvA1vd9TWhis96oAXmej8Iw1IQmxuOJ
-        GoC3L0kSTWjCcRw1oDoF4rquJjZx2B/5LALYZ/wEQaAJTayWKz6LAHaZBngCTeErRAAh5BOL9yngH20J
-        kTZzqhGFAAAAAElFTkSuQmCC
+        wQAADsEBuJFr7QAAARlJREFUOE+VkjFqwzAUhn2D9CQlRyi+QhYbUujg3dATdPKYdA6BQBvw1AMkg3dP
+        XQyl7WI6NEMCchLpaXzliUhYUpRQwQe29f+fZclRdBqc8yEAMADAHoye68zVQeHfTcduH98wGs1x/Fwp
+        yRmxwZQBYKofbnYd9iV1XWMcxx5GQOXZqsHB/YsqudDc4XDEju0NrkCV6W0fP1tvBfzITYmwBFLKO3Ux
+        ml8su1xcgd6LUNkS6HB/D+jeLbhYArrJsgyrqsK2bdWEu+P973cF73mee8EQ69XaFgghnsqy9IIhJpOp
+        LaC/r2kaLxgiSRJbcDoFlqapFw7x9fltC4QQi6IovGCI5evSFkgpH+gE3OA1jIAxdqP/h//yB20JkTaU
+        XJ1xAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="PackageManagerMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAAJ1JREFUOE+1j7ENxCAMRTPCjXCz0LMFg6SivQXY5ZZgCwouDa3j78MKikBRFIH0
-        JGP7P8kLEQn6SikrQ0xmXhXU6K117chpwcM3840xknOOQggIfABq9DDDDnZ7goxFY4xgraWUkoBa+1Wc
-        ewIZ6iLw3gttrwo40hEAPaENgeaEseAcGjFf8MubMPrPF1wxX/D4hMeCK+YJ7vDP0bIDFVes7Wn8RVwA
+        vAAADrwBlbxySQAAAJ1JREFUOE+1j7ENAyEQBL8El+BayOmCQj4idQP04iboggB/sulZe+IshEAvB7w0
+        0nHsjp5DRA5iH4ATgACoAB4Nztydlvv1bADwBPDOOUsIQVJKLLwIZ+54xwyzM0Fl0DmneO+llKJwtn0T
+        15lALy1IYoxKv2sCmQqIPaEvke4Ja8FYWrFf8KmXsjrvF9yxXzD+8njeL7hjn+AfrPcFFVes7cvarvYA
         AAAASUVORK5CYII=
 </value>
   </data>
   <data name="PasteMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAAJZJREFUOE/djk0KwyAQRj1CjxTce0Pvksuk3biwhY4uU77BSSROTQJZ5YMHw/w8
-        Nb3EGB9ENKaUZoAavTLeDw6897O1lkGNXhn/T855wIshBD58Ti8GtfymrLaRBSAv14JaAsrZmvqwxjnX
-        9E4JNHYF7/hRaQQoNOhLzCGBNLdgdligLd5EIAdbrhdoYNZjEfTgJTXG/AAVUVH4tEXMkQAAAABJRU5E
+        wQAADsEBuJFr7QAAAJZJREFUOE/dkkEKwyAQRXOEHim494beJZdpunFhAxldGr5gmIyjTaGrfngwTP7/
+        KmSaBgohPIhoiTFmgBk76esKAedcNsYUMGMnfY1SSjNO9N6X4Pp8FTDX28jMqWoA9WRewEvUIh7kWGub
+        3VcFGh8L3mFTaQr4mzi0U+FWgbweN90u0Ix/UlADkt8XaODbiOF/cDF1dAAVUVH4raIH0gAAAABJRU5E
         rkJggg==
 </value>
   </data>
   <data name="RedoMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAATZJREFUOE+Nkr9KA0EQh+8NzCPcE0heRBDSRsgDWNnaW1hZB+FAsLAQW9PYpDGF
-        XCMErCSgFglcqmvH+cbZdde7SH7wg9358+3e7BWp2rYt1ZW6UYubNbFJsh9SLyLWZyL4ud4257cLOTi5
-        kWJ0bWZNjObZy7uMr54iJAJ0U9J8eHYfG/+a3N38zdYBkgIqTgnFRxePdhpmHeLpzbRH+38BTUjSoPua
-        GEV4OnuNjR2ALsqvzTYmnpcfJI/VQ/XOz8oAy9U6Jrg2AL+ZDbYPEgFe2PcJA8/ZTdTWlDoFZENMn+qn
-        ol8poPOM+0AiAFEIhMYAAciANTfxskwZAAHh1H0hHQBySH35UEcIA/bnrbzM1AtAWjgAkv5Ap9N5mIm9
-        DtoJQA6pwu/szdlA/wUEAVED6LyGiBTfLb0HlUjXbw0AAAAASUVORK5CYII=
+        vAAADrwBlbxySQAAASJJREFUOE+Nk7FqAkEQhu8N4iPkCYIvIgi2EXwAK1v7FKmsRTgIWKSQtNrY2GgR
+        rgkIViLEFAbOatoN32VnmfP25H4YmNvZ+XZ2Zi9JjETkUURSEclFxHnDZ21gvtvsd86VktvnyzUfz3fu
+        of/mkt6sMHzWSF59Ht3zZB0gAcDJJD+NFiHx1oi9bw6FrxALSDlFN3delsVpGL6tRn0qsoBcgySISGb7
+        MF19VSoKAMr/+b2GwHb/TbDLHYHUXasE2J8uIUDZAGxjY5AmV2gp5GaswWqbaEf1vyOuu2NsAok+JBIV
+        ApAG8wptoqoEQHrfppAKAHlI9vqRBQgN9uNN7d4oADEBIPYBDacb7UkxHVQLQB6S6nOONfQuQOV/ZQCV
+        aQD4Ay29B5Xvs9QsAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="ReloadExtensionsMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAAQVJREFUOE+dkzFuhDAQRX2EPULOQo+UQ9BzlIgeKYfgAKmp2II+B6DwggOUDg88
-        aLSL8O6O9GUznv8YjG10jOP46Zz7nabJx7TU/lhrL8G6mbuu83me+yRJoirLcoUEuzG8+VmziE5WM63w
-        IAs32x9Km9FbAOq0VgDxCiBYtpjn+WNJWiFqDb2LA5ZE07atT9N074AiRnbaub8owB8Bqqpac0CGfjgH
-        8PsoFhM5DWF+CmCBYuZ0w4jqut5NUQDFYhQI0KcA0j5z/czI55Frmuv+OcG6xXKev9koDeFNKMsyz/0Q
-        aOjyK1i3CKfQFkWxtygATHpPHswSHCZulirUsqyH0rsw5h/GwnbQ7xsxswAAAABJRU5ErkJggg==
+        wQAADsEBuJFr7QAAAPZJREFUOE+tkzEOgzAMRTlCj9CzsCP1EOwcpWJH6iE4QGcmOrD3AAwupDZjqo9w
+        lFBEqFRLFkrs/7CdJEk8Y+aLMeYpIjbmzHwnolMg7vveFkVh0zSNelVVM8QB8OejYnVUMotRChYaeNGw
+        6X8BrGfhWvgF4ESwaZrOIkJrMnwcTBwgIm3XdTbLsqA3fDFpY95RgN0C1HU97wEyDuM+AMeHZBVpC/56
+        F4AAkrUaBTRN40RRAJJVqBBADwG0fAX47aA97LXtw7UTAJj5hkH5EB1mnucW70OhS5XXALDcQirLMjhC
+        OET+TL7EarhMeFleou+E+Fqj9gHGwnbQ/oGC4wAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="ReportBugMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAGhJREFUOE9j+P//
-        P8O3b9/+E4HfA7EBAxIA6YUb4OTkhBe3tbVhGEKSASCMbghWAz68/4gVYzOELAOQDSFogJ2dHRgji8HU
-        gfSMBAMeP3wKxshiJBkw8F7AhgkaQCymvgHk4P///zMAAA+12OcyLyvuAAAAAElFTkSuQmCC
+        wQAADsEBuJFr7QAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAGRJREFUOE/lzjEO
+        gCAMhWGO5Ak69HC9pzHO6PLWmnYisREsbpL8TLwvFFUtAHSgCmApzbGtX/aAmR8TkRvyCoiQEDjqGRYh
+        KaBFugAReRFkmz8A27p7aWD6B9NAVBcY7Xsgk20vD7XY540iwSkAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="RestartMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAAQJJREFUOE+lk7ERgzAMRRkhI2SEjJCjZy1ajp4dKJiCngHoKdxwUBI/nRQMUUgR
-        3f0LlvS/v2wnO8c8z49lWULEdkKgpm1+GLksyy3PcwHf/5IN7bquT20/hkdOURSFiI3jiFCltD1UQJo8
-        AQNCwzB8imBtmiaxmorUdb31fb81TSNkE8HJYZxIbCGCs4jl2NlENNcqXQTexa7rhOABJ+aCtZBDCDfs
-        245Y9k6bHDXruxTw7twTiLm7FFnYCNiM630+DXLuCARFOziKelXycPSK28tDpJGrsQZ+2Q3L4Oc1ElGx
-        SnfxQM19SBYUUMdiKsQ3ua9POQ2sMV+EHFQC58+UZS/3uQOpPz8OfAAAAABJRU5ErkJggg==
+        vAAADrwBlbxySQAAAPVJREFUOE+lU7ENhDAMZIQf4Uf4EV70WYsW0bNDCqZIzwDpKdKgpMzrrBgZv0Ev
+        vSVLIfadz3boOmX7vr9yzinnXJUnxHT+yRg8DEPt+54c53/B7L6U8tY4Mgss3TlHZDFGEI0azwSUpMGa
+        aF3XbxJI27aNpEqSaZpqCKHO80xgJoGSUzvoD0Du2ZoDKjNJu/OS4Aguy6LXdziUsAp8Ezil9IB8rgjJ
+        1rRxhxjn3RJYO7cISilPCsoWIPPUXzPcmS1wkAcnVkUPp63Y3w4RiViNXBWqQfJPa2wqRlnF8suHxIYA
+        2CFREuF8+5SlQRr602/g6mf6APe5A6lA9/l/AAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="SaveMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAAFZJREFUOE9joAr49u3bfxLw+y9fvhhAtUIASMLJyQmOP7z/CMfIYiC6ra0N0xBS
-        DABhmCFQ7aQbAMIgPVDt+A1AxshqaGsAMXjUgEFpADkYqp0SwMAAAO0M932fmoqVAAAAAElFTkSuQmCC
+        wQAADsEBuJFr7QAAAEtJREFUOE9jYKAG+Pbt238S8PsvX74YYBjg5OQExx/ef4RjZDEQ3dbWhmkIKQYg
+        G0K2ASAM0kOUAdgMo70BxOBRAwalAeRguAGUAADtDPd9Y4OdkQAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="SelectAllMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAAP5JREFUOE+Nkb0Ng0AMhRkho2SEiJ4B6FLQs0Iq2iyAlCHo6anS0GcACgr+SsJn
-        2dIFjsCTLJ+P9559JnAxDMOLGMdxtrA7pezDhFVViTAMQ8lWH5pAgIywLMs5TVPJ1NwfGtCFQNQ0jZzJ
-        1PZNqX5AoBudOSdJIgbU9hyl+mFdbAJEmNR1fW6C9Q7IRBRFZvJs2/ai9C18f8GNoii4fx+amNHagMjz
-        fO667tP3/VUlfuwZEFmWMUk7TdNN6VuYAeQ4juXs/k6LxeSukl/wUTvJ2zHAiPrvDgzaQcYk2xSYLTt6
-        KG0fiGxRCFZTLEMcTOFuGTKiJeQJxKkpziEIvpWXnrziDNdiAAAAAElFTkSuQmCC
+        wQAADsEBuJFr7QAAAPhJREFUOE+NkT0OgzAMhXuEHqVHqNg5AFsHdq7QibUXQOoh2NmZurD3AAwZIGSk
+        +ixcBfcHnmQ5TvxeXpzDIYL3/k5M0zRr6F7c9xVKbNtWiEmSSNZ6U4QGmiE2TTMXRSGZmv1NAbUMqe97
+        WZOp9cxyVlDb3Mw6z3MRoNbnWM4K1gEkRLqu2+fAzoBMpGmqIjfn3NHy3vj2C3HUdc3+Y1NEhawAUVXV
+        PAzDcxzHk+Wu8EuAKMsSJy6EcLa8N1SA5izLZB1/p0YI4WK5Ag6Xm+TtCCBE/XcGiuUGsUlWF4h576+2
+        /wOQdFAQjAu36SKeMs2Q4rfvcrEXL5WXnryKPa/OAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="StartMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAABp0RVh0U29mdHdhcmUAUGFpbnQuTkVUIHYzLjUuMTFH80I3AAAAhklEQVQ4T2NA
-        Bt++fTv/5csXAyiXdAA04D8Qv//+/XsCVIg0ADIgZl7E/3sv7/3/+vXr/Pfv3wtApYgDIAMsukz+u0x0
-        +L/7yk6Qa0jzEswAGO7e2Umal9ANAGGSvITNABAm2ku4DIBhgl6imQEUeYGiQCQ7GilKSBQnZZKcjA5I
-        djIDAwMAzoYpdCHKEbUAAAAASUVORK5CYII=
+        vAAADrwBlbxySQAAABp0RVh0U29mdHdhcmUAUGFpbnQuTkVUIHYzLjUuMTFH80I3AAAAiElEQVQ4T2Ng
+        QALfvn07/+XLFwNkMZLAt2/f/n/79u399+/fE9DliAIgA2LmRfy/9/Le/69fv85///69ALoavABkgEWX
+        yX+XiQ7/d1/ZCXINaV6CGQDD3Ts7SfMSugEgTJKXsBlAkpdwGUC0l2hmAEVeoCgQCToZHVAlIZHkZHRA
+        jcxEmpOBAADOhil0mH9HUwAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="StartWithoutDebuggingMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAAJ1JREFUOE9jQAbfvn07/+XLFwMol3QANOA/EL///v17AlSINAAyIGZexP97L+/9
-        //r16/z3798LQKWIAyADLLpM/rtMdPi/+8pOkGtI8xLMABju3tlJmpfQDQBhkryEbMC5O+f+R88NB7OJ
-        9hKyAR/ef/z/9OXT/7UbquFiBL1EVQMo9gIMkx2IIEx2NFKUkChOyiQ5GR2Q7GQGBgYA9iM1vHWiKSMA
+        wQAADsEBuJFr7QAAAJ1JREFUOE9jYEAC3759O//lyxcDZDGSwLdv3/5/+/bt/ffv3xPQ5YgCIANi5kX8
+        v/fy3v+vX7/Of//+vQC6GrwAZIBFl8l/l4kO/3df2QlyDWleghkAw907O0nzEroBIEySl5ANOHfn3P/o
+        ueGkeQnZgA/vP/5/+vLp/9oN1cR7iaoGUOwFGCY7EIlyMjqgSkIiycnogBqZiTQnAwEA9iM1vIvrIxkA
         AAAASUVORK5CYII=
 </value>
   </data>
   <data name="StopMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAABp0RVh0U29mdHdhcmUAUGFpbnQuTkVUIHYzLjUuMTFH80I3AAAAK0lEQVQ4T2MY
-        ZuDbt2//icFAANWBBkCSc1V48OJRA0aGAcRgnAYMRcDAAABv0ByWmJsKVQAAAABJRU5ErkJggg==
+        vAAADrwBlbxySQAAABp0RVh0U29mdHdhcmUAUGFpbnQuTkVUIHYzLjUuMTFH80I3AAAALElEQVQ4T2Ng
+        GF7g27dv/4nB////R9cKASDJuSo8ePGoASPDAGIwTgOGJgAAb9Acls01b08AAAAASUVORK5CYII=
 </value>
   </data>
   <data name="ThemeMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wQAADsEBuJFr7QAAABl0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC4yMfEgaZUAAAE6SURBVDhPnVMh
-        joRAEOQp9xYEGolAkFtegULheQP+NrwAg0EhwJAgEHdnuQsBguqdmp0mM7DkkuukBN1VNT09jXWMdV2D
-        eZ6LZVlIB3KoKdo5RPFNEOuqqiiKIrJt2wByqIEDrpI9Q4nHJElOQobruuR5HqVpCpPRMIErCkdRGIYS
-        /J1lGd3eb2xSSzHuhdZ0IaNtW+q6bv+O45h+xl/ZCTTQWhjOqzsDIPq+v3+jAxjcP+5yJtCifUN0Bcxg
-        2zZp8PX5LXPQ/mngOI7sYhgGKWagdmmA0/I8p2maDJGOSwOc2Pf9SxHDuMJxiGiXiU3TSOhiwBji8Rn5
-        qQDO6WKcbjwjQrRS8xYGQbCTy7KkoigM8WmREFhLkRh5GzFEFrEQbV+uMkKZ/O9n0gP3wnAEUU6ZgRxq
-        iqbCsh4tKngZQqIKKQAAAABJRU5ErkJggg==
+        wAAADsABataJCQAAABl0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC4yMfEgaZUAAAEiSURBVDhPnVMx
+        boQwELyn5C0U1JQUFFaOV1BR0fMG+iBeQENDdQU0SBQUSVouQtii2mgsLbINuUtiaQqvd2bH6/Xl4iyl
+        lFjXtZZSkgnEcObm70sp9SKlvLVtS0mSkOd5FhDDGXKQe0aesyw7EBlBEFAYhpTnOURmSwSqOHBJcRxr
+        8L4oCrq+XlnkxtUFrLlkoO97GoZh36dpSvf5SzsBR/cEzTm7M4DEKIosBxAo30rdE3Bh/0A8A3qwbZsW
+        +Hj/1DFwnwr4vq9dTNOkyYyHAqhWVRUty2KRfiWAiuM4HggmrCu4TYRdTuy6TsMVsJroPiM/FdsE3OrW
+        M/Ig8RQKIfbkpmmormuLfBgkc5R5GtFEtyps/zjKhsj/PpO5/vqdvwEtKngZ6b5JLAAAAABJRU5ErkJg
+        gg==
 </value>
   </data>
   <data name="UndoMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vAAADrwBlbxySQAAATFJREFUOE+FUzFuwkAQ9A/CD/ALkJ/AB5CQ0gaJLk0KREufgiq1FclSJESFaHFD
-        kwYK5AaJliZQJJJdud3MOLeHjc/OSiPt7c3M3a3Xnkae5wGQAgL4QFRaE8xZ843EE5G/BMXg8p2lvenK
-        kmeLvTyMPsR7fC/AnDXukU9dYYCFr2ISrz+ZaO6COYQmvhr048PZErrPS5sPXjfCPYK51s1NIqeBIoyP
-        +hw9MVETPoe1VgPi6W2rYjZ4WOZhDX2LQVlsGt1swIUDZXEHcD/hv6AJybyRnl5pYluAxNtVxLXP2BQg
-        jO9ngkacGezdBskVIExcYnNyIWY4DUCIdqevyhjP1wnFCWD/A0bNAAR2O30JP63YDBTFHUOz0XSDous6
-        xsj5B9bEjLYe6GxEpuQMEfF+AfxFE7ZW3d20AAAAAElFTkSuQmCC
+        vAAADrwBlbxySQAAASJJREFUOE+FU7FKA0EQvT9I/sD7Askn+AOCkNaAnU0KsbVPkSp1CBwEgpXYmsYm
+        jRZyjWBrk1gkcKleO/LCzDp7t3c+GJibnfd2Zm42yxQABgAqAAIgB1C4bxp9xnLjiMgfebc/Vuf3TyH5
+        YfUuvdFSsuHiZPQZU6FBEKCikZn4cziK+SnTSyiSm8DF+uM7JJzdPgb/cvIiPKPRt7hWUiQFzObrT2vH
+        bixNhO0w1ilAu569hp4BXPk8CncKeLIOul3AlVov28j91hb+g+0HK7LboyF2QauLyI3f2AYAN/WdoBB3
+        JlqkFADcpch+LkRSgL29fW2jNZ4+lySX/h0QDQGddjWebwJZF4rkfpydECBs6rbG+gIbZCIpQLjdKOpn
+        HhT4BfxFE7YIXh08AAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="UngroupMenuImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAAMpJREFUOE/NksEN
-        wjAQBFMCJaHU4n9aoIVUwNMFpADeqQJ3YJAV+2myF290CQbBC1ZaRb69G50cN/+hnHPVWt77wzRN5xij
-        n53hEn0GmIcvfd/ntm3FGwCJe2sQzhw2xkguAaRD+h3AOZfnjU4SQAxv/i4mgA4hXIdhWAGoldFFGsAm
-        3cwc7rpOgGV0kW6Aa5swewnQjRWAt9auENTK6CJeFgHaqKWUjjp7ukQNqBk9+BKA3wiIDEME7K21f0jj
-        OH4HUE95s9mv1TQPfme85eKlWOEAAAAASUVORK5CYII=
+        wQAADsEBuJFr7QAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMC41ZYUyZQAAALNJREFUOE/NksEJ
+        QyEMht8IHak4i3dX6ApO0KMDOEDPTtG3QVok8WhRCETNo7xTG/gOYvzyo27bX1StVUUWAFwQ8U5EQES1
+        cUqAiA/vfTXGdAYBG2ekqK35sLV2FfCmnHAk2Pe9IuJtEbzg3WEBk3N+xhj1+LNASyKnO+e6UBUwWpKv
+        AtmoCCCEMKQaBHxZcxJuLqVc5d5yiVKg0XqkoD1jkyyCGVnzR0opnROIrzwk+319AH5nvOXCzk1GAAAA
+        AElFTkSuQmCC
 </value>
   </data>
   <data name="InvalidWorkflowPath_Error" xml:space="preserve">
@@ -646,18 +641,17 @@ The visualizer layout may be corrupt. Do you want to delete the layout file?</va
   <data name="WorkflowReadOnlyImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAYAAAA71pVKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wAAADsABataJCQAAAH9JREFUOE/VjdEJwCAMRB2ls7ih/+7gHG7hBrY/+mk9iWKNVAqF0oMjJHmXiFcV
-        Y9xCCCY7dTaYEzIXBb1SKkkpm9FjfnsAH8bgcMAQypWXDdZaJ2ttqXWGPaFcfdg5V2DUfkYoF+CVCeXC
-        sn6Z+VF498el/0l49DK8MqGfSogTPS0oz8b0R/8AAAAASUVORK5CYII=
+        vwAADr8BOAVTJAAAAH1JREFUOE/VkNEJwCAMRB2ls7ih/+7gHG7hBrY/8dMS0ZAeUikUSg+O4JmXiMa8
+        qVLKRkSBiKpy4Bx7L+pgds5Va62Yz5zfDuANCMKAgIyInziavfc1xtjqyPgeGZGGU0qtmavOkBHBJ02N
+        jEhvnvkRvOfjjzB6Ca+MzDc6AT0tKM8KuUQ8AAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="WorkflowEditableImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wQAADsEBuJFr7QAAAJVJREFUOE+9kLENAyEQBCnFJbgEi1qoggKok4yAwAmCEHssTkL4/3UE9kob8Ghm
-        xZu/pJRyp+O4F8Ba65NuSwQOIXS6JZmWP7C1Vi9Zl3PO3Tmnk8wwgEAioaeCI3iVpJSuYe/9F0wvlwmX
-        7/YjAfDpsgR4fusWTBAArD9MBRMRyGqMUQ8TBEv1sASgtfYYvY3Pv4wxL5igM/WVQzVaAAAAAElFTkSu
-        QmCC
+        wAAADsABataJCQAAAJFJREFUOE+9kLENgCAURB3FERzBMAtTMABz0lFQ2BAoMWe8hHzRfAu95BrIe5f8
+        afojOecFle+qACylbOhrCWHvfUNfSbrlAzbG6CVyOaXUrLU6SQ8DIEQJeisYwVISY3yGnXMXGH1cRniw
+        kQDw7TLDa/cHU8MIBKODqWCEAq6GEPQwAoGoHmYA1FrXs7P8/yQ7mKAz9dbnzhUAAAAASUVORK5CYII=
 </value>
   </data>
 </root>

--- a/Bonsai.Editor/WorkflowNavigateEventArgs.cs
+++ b/Bonsai.Editor/WorkflowNavigateEventArgs.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Bonsai.Editor.GraphModel;
+
+namespace Bonsai.Editor
+{
+    delegate void WorkflowNavigateEventHandler(object sender, WorkflowNavigateEventArgs e);
+
+    class WorkflowNavigateEventArgs : EventArgs
+    {
+        public WorkflowNavigateEventArgs(
+            WorkflowEditorPath workflowPath,
+            NavigationPreference navigationPreference = NavigationPreference.Current)
+        {
+            WorkflowPath = workflowPath;
+            NavigationPreference = navigationPreference;
+        }
+
+        public WorkflowEditorPath WorkflowPath { get; }
+
+        public NavigationPreference NavigationPreference { get; }
+    }
+}

--- a/Bonsai.System/IO/Ports/SerialRead.cs
+++ b/Bonsai.System/IO/Ports/SerialRead.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Reactive;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using System.Xml.Serialization;

--- a/Bonsai.System/Resources/ResourceNameConverter.cs
+++ b/Bonsai.System/Resources/ResourceNameConverter.cs
@@ -40,7 +40,7 @@ namespace Bonsai.Resources
 
         static bool IsGroup(IWorkflowExpressionBuilder builder)
         {
-            return builder is IncludeWorkflowBuilder || builder is GroupWorkflowBuilder;
+            return builder is GroupWorkflowBuilder || builder is IncludeWorkflowBuilder;
         }
 
         static IEnumerable<ExpressionBuilder> SelectContextElements(ExpressionBuilderGraph source)
@@ -51,8 +51,7 @@ namespace Bonsai.Resources
                 if (element is DisableBuilder) continue;
                 yield return element;
 
-                var workflowBuilder = element as IWorkflowExpressionBuilder;
-                if (IsGroup(workflowBuilder))
+                if (element is IWorkflowExpressionBuilder workflowBuilder && IsGroup(workflowBuilder))
                 {
                     var workflow = workflowBuilder.Workflow;
                     if (workflow == null) continue;
@@ -74,13 +73,12 @@ namespace Bonsai.Resources
 
             foreach (var element in SelectContextElements(source))
             {
-                var groupBuilder = element as IWorkflowExpressionBuilder;
-                if (IsGroup(groupBuilder) && groupBuilder.Workflow == target)
+                if (element is IWorkflowExpressionBuilder groupBuilder && IsGroup(groupBuilder))
                 {
-                    return true;
+                    if (groupBuilder.Workflow == target)
+                        return true;
                 }
-
-                if (element is WorkflowExpressionBuilder workflowBuilder)
+                else if (element is WorkflowExpressionBuilder workflowBuilder)
                 {
                     if (GetCallContext(workflowBuilder.Workflow, target, context))
                     {


### PR DESCRIPTION
Finding all references of subjects and operators is becoming a significant problem with increasing workflow complexity and size.

This PR introduces a set of editor tools for finding references and displaying search results, using the same rules as the existing find next and find previous feature. Scoping rules are enforced for subject searches.

A detailed breakdown of all references found across the workflow is shown in a new dock panel interactive list view which can also be used for direct navigation into each found reference.

Fixes #2214 
Fixes #2217 