### PR TITLE
Await initialization before loading layout

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -308,9 +308,9 @@ namespace Bonsai.Editor
                 Path.GetExtension(initialFileName) == Project.BonsaiExtension &&
                 File.Exists(initialFileName);
 
-            InitializeSubjectSources(formCancellation.Token);
-            InitializeWorkflowFileWatcher(formCancellation.Token);
-            InitializeWorkflowExplorerWatcher(formCancellation.Token);
+            InitializeSubjectSourcesAsync(formCancellation.Token);
+            InitializeWorkflowFileWatcherAsync(formCancellation.Token);
+            InitializeWorkflowExplorerWatcherAsync(formCancellation.Token);
             updatesAvailable.ObserveOn(formScheduler).Do(HandleUpdatesAvailable).ToTask(formCancellation.Token);
 
             var currentDirectory = Project.GetCurrentBaseDirectory(out bool currentDirectoryRestricted);
@@ -327,8 +327,8 @@ namespace Bonsai.Editor
             if (extensionsPath.Exists) OnExtensionsDirectoryChanged(EventArgs.Empty);
 
             InitializeEditorToolboxTypes();
-            initialization = InitializeEditorExtensions(formCancellation.Token);
-            _ = InitializeWorkflow(validFileName ? initialFileName : default);
+            initialization = InitializeEditorExtensionsAsync(formCancellation.Token);
+            _ = InitializeWorkflowAsync(validFileName ? initialFileName : default);
             base.OnLoad(e);
         }
 
@@ -421,7 +421,7 @@ namespace Bonsai.Editor
             }
         }
 
-        Task InitializeSubjectSources(CancellationToken cancellationToken)
+        Task InitializeSubjectSourcesAsync(CancellationToken cancellationToken)
         {
             var selectedViewChanged = Observable.FromEventPattern<EventHandler, EventArgs>(
                 handler => selectionModel.SelectionChanged += handler,
@@ -464,7 +464,7 @@ namespace Bonsai.Editor
                 .ToTask(cancellationToken);
         }
 
-        Task InitializeWorkflowExplorerWatcher(CancellationToken cancellationToken)
+        Task InitializeWorkflowExplorerWatcherAsync(CancellationToken cancellationToken)
         {
             var selectedViewChanged = Observable.FromEventPattern<EventHandler, EventArgs>(
                 handler => selectionModel.SelectionChanged += handler,
@@ -494,7 +494,7 @@ namespace Bonsai.Editor
             .ToTask(cancellationToken);
         }
 
-        Task InitializeWorkflowFileWatcher(CancellationToken cancellationToken)
+        Task InitializeWorkflowFileWatcherAsync(CancellationToken cancellationToken)
         {
             var extensionsDirectoryChanged = Observable.FromEventPattern<EventHandler, EventArgs>(
                 handler => Events.AddHandler(ExtensionsDirectoryChanged, handler),
@@ -574,7 +574,7 @@ namespace Bonsai.Editor
                 .Select(xs => Unit.Default);
         }
 
-        Task InitializeTypeVisualizers(CancellationToken cancellationToken)
+        Task InitializeTypeVisualizersAsync(CancellationToken cancellationToken)
         {
             var visualizerMapping = from typeVisualizer in visualizerElements
                                     let targetType = Type.GetType(typeVisualizer.TargetTypeName)
@@ -589,7 +589,7 @@ namespace Bonsai.Editor
                 .ToTask(cancellationToken);
         }
 
-        Task InitializeToolbox(CancellationToken cancellationToken)
+        Task InitializeToolboxAsync(CancellationToken cancellationToken)
         {
             return toolboxElements
                 .ObserveOn(formScheduler)
@@ -600,17 +600,17 @@ namespace Bonsai.Editor
                 .ToTask(cancellationToken);
         }
 
-        async Task InitializeEditorExtensions(CancellationToken cancellationToken)
+        async Task InitializeEditorExtensionsAsync(CancellationToken cancellationToken)
         {
             using var shutdown = ShutdownSequence();
             await Task.WhenAll(
-                InitializeToolbox(cancellationToken),
-                InitializeTypeVisualizers(cancellationToken));
+                InitializeToolboxAsync(cancellationToken),
+                InitializeTypeVisualizersAsync(cancellationToken));
         }
 
-        async Task InitializeWorkflow(string initialFileName)
+        async Task InitializeWorkflowAsync(string initialFileName)
         {
-            if (!string.IsNullOrEmpty(initialFileName) && await OpenWorkflow(initialFileName, false))
+            if (!string.IsNullOrEmpty(initialFileName) && await OpenWorkflowAsync(initialFileName, false))
             {
                 foreach (var assignment in propertyAssignments)
                 {
@@ -802,12 +802,12 @@ namespace Bonsai.Editor
             UpdateTitle();
         }
 
-        Task<bool> OpenWorkflow(string fileName)
+        Task<bool> OpenWorkflowAsync(string fileName)
         {
-            return OpenWorkflow(fileName, true);
+            return OpenWorkflowAsync(fileName, true);
         }
 
-        async Task<bool> OpenWorkflow(string fileName, bool setWorkingDirectory)
+        async Task<bool> OpenWorkflowAsync(string fileName, bool setWorkingDirectory)
         {
             WorkflowBuilder builderCandidate;
             SemanticVersion workflowVersion;
@@ -1088,7 +1088,7 @@ namespace Bonsai.Editor
 
             if (openWorkflowDialog.ShowDialog() == DialogResult.OK)
             {
-                await OpenWorkflow(openWorkflowDialog.FileName);
+                await OpenWorkflowAsync(openWorkflowDialog.FileName);
             }
         }
 
@@ -2419,7 +2419,7 @@ namespace Bonsai.Editor
                     {
                         ClearWorkflow();
                     }
-                    else await OpenWorkflow(fileName);
+                    else await OpenWorkflowAsync(fileName);
                 }
                 else
                 {

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -328,7 +328,7 @@ namespace Bonsai.Editor
 
             InitializeEditorToolboxTypes();
             initialization = InitializeEditorExtensions(formCancellation.Token);
-            _ = InitializeWorkflow(validFileName ? initialFileName : default, formCancellation.Token);
+            _ = InitializeWorkflow(validFileName ? initialFileName : default);
             base.OnLoad(e);
         }
 
@@ -608,9 +608,9 @@ namespace Bonsai.Editor
                 InitializeTypeVisualizers(cancellationToken));
         }
 
-        async Task InitializeWorkflow(string initialFileName, CancellationToken cancellationToken)
+        async Task InitializeWorkflow(string initialFileName)
         {
-            if (!string.IsNullOrEmpty(initialFileName) && await OpenWorkflow(initialFileName, false, cancellationToken))
+            if (!string.IsNullOrEmpty(initialFileName) && await OpenWorkflow(initialFileName, false))
             {
                 foreach (var assignment in propertyAssignments)
                 {
@@ -802,16 +802,13 @@ namespace Bonsai.Editor
             UpdateTitle();
         }
 
-        Task<bool> OpenWorkflow(string fileName, CancellationToken cancellationToken)
+        Task<bool> OpenWorkflow(string fileName)
         {
-            return OpenWorkflow(fileName, true, cancellationToken);
+            return OpenWorkflow(fileName, true);
         }
 
-        async Task<bool> OpenWorkflow(string fileName, bool setWorkingDirectory, CancellationToken cancellationToken)
+        async Task<bool> OpenWorkflow(string fileName, bool setWorkingDirectory)
         {
-            if (cancellationToken.IsCancellationRequested)
-                return false;
-
             WorkflowBuilder builderCandidate;
             SemanticVersion workflowVersion;
             try { builderCandidate = ElementStore.LoadWorkflow(fileName, out workflowVersion); }
@@ -1085,13 +1082,13 @@ namespace Bonsai.Editor
             ClearWorkflow();
         }
 
-        private void openToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void openToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (!CloseWorkflow()) return;
 
             if (openWorkflowDialog.ShowDialog() == DialogResult.OK)
             {
-                OpenWorkflow(openWorkflowDialog.FileName, formCancellation.Token);
+                await OpenWorkflow(openWorkflowDialog.FileName);
             }
         }
 
@@ -2411,7 +2408,7 @@ namespace Bonsai.Editor
             EditorDialog.ShowAboutBox();
         }
 
-        private void welcomeToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void welcomeToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var result = EditorDialog.ShowStartScreen(out string fileName);
             if (result != EditorResult.Exit && CloseWorkflow())
@@ -2422,7 +2419,7 @@ namespace Bonsai.Editor
                     {
                         ClearWorkflow();
                     }
-                    else OpenWorkflow(fileName, formCancellation.Token);
+                    else await OpenWorkflow(fileName);
                 }
                 else
                 {

--- a/Bonsai.Editor/IWorkflowEditorService.cs
+++ b/Bonsai.Editor/IWorkflowEditorService.cs
@@ -22,8 +22,6 @@ namespace Bonsai.Editor
 
         WorkflowBuilder LoadWorkflow(string fileName);
 
-        void OpenWorkflow(string fileName);
-
         void NavigateTo(WorkflowEditorPath workflowPath, NavigationPreference navigationPreference = default);
 
         void SelectNextControl(bool forward);


### PR DESCRIPTION
Here we refactor the initialization of toolbox and visualizer modules as an async task and integrate it into the process of opening a workflow. This is to ensure all visualizer types are loaded before validating the layout assignments.

To do this we refactored several asynchronous initialization and monitoring tasks which previously were implemented as observable sequences. A shared cancellation token tied to form closing is introduced as a way to cancel all tasks on exit. 

Because continuations should automatically capture the form dispatcher there is no need for explicit locking.

Fixes #2229 