### PR TITLE
Avoid corrupting editor state when loading workflow with circular includes

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -821,18 +821,6 @@ namespace Bonsai.Editor
             UpdateWorkflowDirectory(fileName, setWorkingDirectory);
             if (EditorResult == EditorResult.ReloadEditor) return false;
 
-            if (builderCandidate.Workflow.Count > 0)
-            {
-                try { builderCandidate.Workflow.Build(); }
-                catch (WorkflowBuildException ex)
-                {
-                    var errorMessage = ex.InnerException != null ? ex.InnerException.Message : ex.Message;
-                    errorMessage = string.Format(Resources.OpenWorkflow_Error, Path.GetFileName(fileName), errorMessage);
-                    MessageBox.Show(this, errorMessage, Resources.OpenWorkflow_Error_Caption, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    return false;
-                }
-            }
-
             workflowBuilder = PrepareWorkflow(builderCandidate, workflowVersion, out bool upgraded);
             ClearWorkflowError();
             FileName = fileName;

--- a/Bonsai.Editor/GraphModel/GraphNode.cs
+++ b/Bonsai.Editor/GraphModel/GraphNode.cs
@@ -46,8 +46,11 @@ namespace Bonsai.Editor.GraphModel
                 if (expressionBuilder.IsBuildDependency()) Flags |= NodeFlags.BuildDependency;
                 Category = elementCategoryAttribute.Category;
                 Icon = new ElementIcon(workflowElement);
-                if (workflowElement is IWorkflowExpressionBuilder)
+                if (workflowElement is IWorkflowExpressionBuilder workflowBuilder)
                 {
+                    if (workflowBuilder.Workflow is null)
+                        Flags |= NodeFlags.RangeUndefined;
+
                     if (Category == ElementCategory.Workflow)
                     {
                         Category = ElementCategory.Combinator;
@@ -84,7 +87,12 @@ namespace Bonsai.Editor.GraphModel
 
         public Range<int> ArgumentRange
         {
-            get { return (Flags & NodeFlags.Disabled) != 0 || Value == null ? EmptyRange : Value.ArgumentRange; }
+            get
+            {
+                return (Flags & NodeFlags.Disabled | NodeFlags.RangeUndefined) != 0 || Value is null
+                    ? EmptyRange
+                    : Value.ArgumentRange;
+            }
         }
 
         public ExpressionBuilder Value { get; private set; }
@@ -178,7 +186,8 @@ namespace Bonsai.Editor.GraphModel
             BuildDependency = 0x8,
             NestedScope = 0x10,
             NestedGroup = 0x20,
-            Annotation = 0x40
+            Annotation = 0x40,
+            RangeUndefined = 0x80
         }
 
         static class CategoryColors

--- a/Bonsai.Editor/Layout/VisualizerLayoutMap.cs
+++ b/Bonsai.Editor/Layout/VisualizerLayoutMap.cs
@@ -112,7 +112,8 @@ namespace Bonsai.Design
                     layoutSettings.VisualizerSettings = dialogSettings.VisualizerSettings;
                 }
 
-                if (ExpressionBuilder.Unwrap(builder) is IWorkflowExpressionBuilder workflowBuilder)
+                if (ExpressionBuilder.Unwrap(builder) is IWorkflowExpressionBuilder workflowBuilder &&
+                    workflowBuilder.Workflow is not null)
                 {
                     layoutSettings.NestedLayout = GetVisualizerLayout(workflowBuilder.Workflow);
                 }


### PR DESCRIPTION
The workaround in ce64bc9a35558e294a25f8cde7edb31d24196aec for avoiding stack overflow when loading self-referential workflows was insufficient, as it preemptively returned `false` while failing to prepare the workflow and editor state adequately.

Here we replace this approach with a single validation of the workflow, while fixing issues with self-reference by avoiding indirect loading of cyclic workflows. The following issues were resolved:

  - Workflows which fail to build are not shown in the editor due to early exit (692794fe4783bc77053ba7756adbb9ea9d1a8156)
  - Layout fails to serialize in self-referential workflows due to null workflow references (f5cfd9c9623c87fb283a09d1023f3ce094f7a779)
  - Self-referential include chains allow manual navigation in the editor (2427e89136ed8133546354bee298ba7bee54985e)

Fixes #2234 