### PR TITLE
Add new VisualizerWindow operator

### DIFF
--- a/Bonsai.Core/Expressions/ISupportPropertyAssignment.cs
+++ b/Bonsai.Core/Expressions/ISupportPropertyAssignment.cs
@@ -1,6 +1,0 @@
-﻿namespace Bonsai.Expressions
-{
-    interface ISupportPropertyAssignment : INamedElement
-    {
-    }
-}

--- a/Bonsai.Core/Expressions/IncludeWorkflowBuilder.cs
+++ b/Bonsai.Core/Expressions/IncludeWorkflowBuilder.cs
@@ -21,7 +21,7 @@ namespace Bonsai.Expressions
     [WorkflowElementCategory(ElementCategory.Workflow)]
     [XmlType("IncludeWorkflow", Namespace = Constants.XmlNamespace)]
     [TypeDescriptionProvider(typeof(IncludeWorkflowTypeDescriptionProvider))]
-    public sealed class IncludeWorkflowBuilder : VariableArgumentExpressionBuilder, IGroupWorkflowBuilder, ISupportPropertyAssignment, IRequireBuildContext
+    public sealed class IncludeWorkflowBuilder : VariableArgumentExpressionBuilder, IGroupWorkflowBuilder, INamedElement, IRequireBuildContext
     {
         const char AssemblySeparator = ':';
         internal const string BuildUriPrefix = "::build:";

--- a/Bonsai.Core/Expressions/TypeMapping.cs
+++ b/Bonsai.Core/Expressions/TypeMapping.cs
@@ -5,9 +5,9 @@ using System.Xml.Serialization;
 namespace Bonsai.Expressions
 {
     /// <summary>
-    /// Represents the target type to be created from selected member variables. This type is manipulated internally
-    /// by <see cref="InputMappingBuilder"/>, <see cref="MemberSelectorBuilder"/> and <see cref="VisualizerMappingBuilder"/>
-    /// to specify output and visualizer types.
+    /// Represents the target type to be used by a mapping operator. Instances of this type are
+    /// manipulated internally by <see cref="InputMappingBuilder"/>, <see cref="MemberSelectorBuilder"/>,
+    /// and instances of <see cref="VisualizerMappingExpressionBuilder"/> to specify output and visualizer types.
     /// </summary>
     [XmlType(Namespace = Constants.XmlNamespace)]
     [TypeConverter(typeof(TypeMappingConverter))]
@@ -17,13 +17,13 @@ namespace Bonsai.Expressions
     }
 
     /// <summary>
-    /// Represents the target type to be created from selected member variables. This type is manipulated internally
-    /// by <see cref="InputMappingBuilder"/> and <see cref="MemberSelectorBuilder"/> to force a specific
-    /// output type.
+    /// Represents the target type to be used by a mapping operator. Instances of this type are
+    /// manipulated internally by <see cref="InputMappingBuilder"/>, <see cref="MemberSelectorBuilder"/>,
+    /// and instances of <see cref="VisualizerMappingExpressionBuilder"/> to specify output and visualizer types.
     /// </summary>
-    /// <typeparam name="T">The target type to be created from selected member variables.</typeparam>
+    /// <typeparam name="T">The target type to be used by the mapping operator.</typeparam>
     [XmlType(Namespace = Constants.XmlNamespace)]
-    public class TypeMapping<T> : TypeMapping
+    public sealed class TypeMapping<T> : TypeMapping
     {
         internal override Type TargetType
         {

--- a/Bonsai.Core/Expressions/VisualizerMappingBuilder.cs
+++ b/Bonsai.Core/Expressions/VisualizerMappingBuilder.cs
@@ -11,28 +11,13 @@ namespace Bonsai.Expressions
     /// Represents an expression builder specifying an observable sequence to be combined
     /// in a mashup visualizer.
     /// </summary>
-    [WorkflowElementCategory(ElementCategory.Property)]
-    [WorkflowElementIcon("Bonsai:ElementIcon.Visualizer")]
     [XmlType("VisualizerMapping", Namespace = Constants.XmlNamespace)]
     [Description("Specifies an observable sequence to be combined in a mashup visualizer.")]
-    public sealed class VisualizerMappingBuilder : SingleArgumentExpressionBuilder, INamedElement, IArgumentBuilder, ISerializableElement
+    public sealed class VisualizerMappingBuilder : VisualizerMappingExpressionBuilder, INamedElement, IArgumentBuilder
     {
-        /// <summary>
-        /// Gets or sets a value specifying the visualizer type used to combine the
-        /// observable sequence with a mashup visualizer.
-        /// </summary>
-        [Externalizable(false)]
-        [Description("Specifies the visualizer type used to combine the observable sequence with a mashup visualizer.")]
-        public TypeMapping VisualizerType { get; set; }
-
         string INamedElement.Name
         {
             get { return VisualizerType?.TargetType.Name; }
-        }
-
-        object ISerializableElement.Element
-        {
-            get { return VisualizerType; }
         }
 
         /// <summary>

--- a/Bonsai.Core/Expressions/VisualizerMappingExpressionBuilder.cs
+++ b/Bonsai.Core/Expressions/VisualizerMappingExpressionBuilder.cs
@@ -1,0 +1,29 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.Expressions
+{
+    /// <summary>
+    /// Represents expression builder instances that map observable sequences to
+    /// a specified visualizer type.
+    /// </summary>
+    [WorkflowElementCategory(ElementCategory.Property)]
+    [WorkflowElementIcon("Bonsai:ElementIcon.Visualizer")]
+    public abstract class VisualizerMappingExpressionBuilder : SingleArgumentExpressionBuilder, ISerializableElement
+    {
+        internal VisualizerMappingExpressionBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets a value specifying the visualizer type to be used by the operator.
+        /// </summary>
+        [Externalizable(false)]
+        [Description("Specifies the visualizer type to be used by the operator.")]
+        public TypeMapping VisualizerType { get; set; }
+
+        object ISerializableElement.Element
+        {
+            get { return VisualizerType; }
+        }
+    }
+}

--- a/Bonsai.Core/Expressions/WorkflowExpressionBuilder.cs
+++ b/Bonsai.Core/Expressions/WorkflowExpressionBuilder.cs
@@ -16,7 +16,7 @@ namespace Bonsai.Expressions
     [WorkflowElementCategory(ElementCategory.Combinator)]
     [XmlType("Workflow", Namespace = Constants.XmlNamespace)]
     [TypeDescriptionProvider(typeof(WorkflowTypeDescriptionProvider))]
-    public abstract class WorkflowExpressionBuilder : ExpressionBuilder, IWorkflowExpressionBuilder, ISupportPropertyAssignment, IPropertyMappingBuilder, IRequireBuildContext
+    public abstract class WorkflowExpressionBuilder : ExpressionBuilder, IWorkflowExpressionBuilder, INamedElement, IPropertyMappingBuilder, IRequireBuildContext
     {
         IBuildContext buildContext;
         readonly ExpressionBuilderGraph workflow;

--- a/Bonsai.Core/Properties/AssemblyInfo.cs
+++ b/Bonsai.Core/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using Bonsai;
+using System.Runtime.CompilerServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -6,3 +7,4 @@
 [assembly: XmlNamespacePrefix("clr-namespace:Bonsai.Reactive", "rx")]
 [assembly: WorkflowNamespaceIcon("Bonsai.Reactive", "Bonsai:ElementIcon.Reactive")]
 [assembly: WorkflowNamespaceIcon("Bonsai.Expressions", "Bonsai:ElementIcon.Numerics")]
+[assembly: InternalsVisibleTo("Bonsai.Design")]

--- a/Bonsai.Core/Properties/Resources.Designer.cs
+++ b/Bonsai.Core/Properties/Resources.Designer.cs
@@ -115,7 +115,7 @@ namespace Bonsai.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No property or named element &apos;{0}&apos; was found in the workflow. .
+        ///   Looks up a localized string similar to No property or named element &apos;{0}&apos; was found in the workflow..
         /// </summary>
         internal static string Exception_PropertyNotFound {
             get {
@@ -165,15 +165,6 @@ namespace Bonsai.Properties {
         internal static string Exception_UnsupportedMinArgumentCount {
             get {
                 return ResourceManager.GetString("Exception_UnsupportedMinArgumentCount", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The named element &apos;{0}&apos; does not support nested element assignment..
-        /// </summary>
-        internal static string Exception_UnsupportedNestedAssignment {
-            get {
-                return ResourceManager.GetString("Exception_UnsupportedNestedAssignment", resourceCulture);
             }
         }
     }

--- a/Bonsai.Core/Properties/Resources.resx
+++ b/Bonsai.Core/Properties/Resources.resx
@@ -136,7 +136,7 @@
     <value>Pending property assignments have been found on some of the missing included workflows. Please restore the missing files and reload the workflow.</value>
   </data>
   <data name="Exception_PropertyNotFound" xml:space="preserve">
-    <value>No property or named element '{0}' was found in the workflow. </value>
+    <value>No property or named element '{0}' was found in the workflow.</value>
   </data>
   <data name="Exception_SerializingNonPublicType" xml:space="preserve">
     <value>The workflow contains non-public types. Please ensure any internal operators have been fully converted or removed before saving the workflow.</value>
@@ -152,8 +152,5 @@
   </data>
   <data name="Exception_UnsupportedMinArgumentCount" xml:space="preserve">
     <value>Unsupported number of arguments. This node requires at least {0} input connection(s).</value>
-  </data>
-  <data name="Exception_UnsupportedNestedAssignment" xml:space="preserve">
-    <value>The named element '{0}' does not support nested element assignment.</value>
   </data>
 </root>

--- a/Bonsai.Design/Properties/AssemblyInfo.cs
+++ b/Bonsai.Design/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿using Bonsai;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: XmlNamespacePrefix("clr-namespace:Bonsai.Design", "ui")]
+[assembly: WorkflowNamespaceIcon("Bonsai:ElementIcon.Visualizer")]

--- a/Bonsai.Design/VisualizerWindow.cs
+++ b/Bonsai.Design/VisualizerWindow.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Windows.Forms;
+using Bonsai.Expressions;
+
+namespace Bonsai.Design
+{
+    /// <summary>
+    /// Represents an expression builder specifying that a visualizer window should be
+    /// displayed on this operator at workflow start.
+    /// </summary>
+    [DefaultProperty(nameof(Name))]
+    [Description("Specifies that a visualizer window should be displayed on this operator at workflow start.")]
+    public sealed class VisualizerWindow : VisualizerMappingExpressionBuilder, INamedElement
+    {
+        /// <summary>
+        /// Gets or sets the name of the visualizer window.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Design))]
+        [Description("The name of the visualizer window.")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying whether the visualizer window is visible
+        /// on start.
+        /// </summary>
+        [Description("Specifies whether the visualizer window is visible on start.")]
+        public bool Visible { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value specifying the position of the upper-left corner of the
+        /// visualizer window, in screen coordinates.
+        /// </summary>
+        [Description("Specifies the position of the upper-left corner of the visualizer window, in screen coordinates.")]
+        public Point Location { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying the size of the visualizer window.
+        /// </summary>
+        [Description("Specifies the size of the visualizer window.")]
+        public Size Size { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying whether the visualizer window should start
+        /// minimized, maximized, or normal.
+        /// </summary>
+        [Description("Specifies whether the visualizer window should start minimized, maximized, or normal.")]
+        public FormWindowState WindowState { get; set; }
+
+        /// <summary>
+        /// Generates an <see cref="Expression"/> node from a collection of input arguments.
+        /// The result can be chained with other builders in a workflow.
+        /// </summary>
+        /// <param name="arguments">
+        /// A collection of <see cref="Expression"/> nodes that represents the input arguments.
+        /// </param>
+        /// <returns>An <see cref="Expression"/> tree node.</returns>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            return arguments.First();
+        }
+    }
+}

--- a/Bonsai.Design/VisualizerWindow.cs
+++ b/Bonsai.Design/VisualizerWindow.cs
@@ -12,16 +12,16 @@ namespace Bonsai.Design
     /// Represents an expression builder specifying that a visualizer window should be
     /// displayed on this operator at workflow start.
     /// </summary>
-    [DefaultProperty(nameof(Name))]
+    [DefaultProperty(nameof(Text))]
     [Description("Specifies that a visualizer window should be displayed on this operator at workflow start.")]
     public sealed class VisualizerWindow : VisualizerMappingExpressionBuilder, INamedElement
     {
         /// <summary>
-        /// Gets or sets the name of the visualizer window.
+        /// Gets or sets the text of the visualizer window title bar.
         /// </summary>
-        [Category(nameof(CategoryAttribute.Design))]
-        [Description("The name of the visualizer window.")]
-        public string Name { get; set; }
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("The text of the visualizer window title bar.")]
+        public string Text { get; set; }
 
         /// <summary>
         /// Gets or sets a value specifying whether the visualizer window is visible
@@ -40,6 +40,7 @@ namespace Bonsai.Design
         /// <remarks>
         /// If no value is specified, the value in the cached layout settings is used.
         /// </remarks>
+        [Category(nameof(CategoryAttribute.Layout))]
         [Description("Specifies the position of the upper-left corner of the visualizer window, in screen coordinates.")]
         public Point? Location { get; set; }
 
@@ -49,6 +50,7 @@ namespace Bonsai.Design
         /// <remarks>
         /// If no value is specified, the value in the cached layout settings is used.
         /// </remarks>
+        [Category(nameof(CategoryAttribute.Layout))]
         [Description("Specifies the size of the visualizer window.")]
         public Size? Size { get; set; }
 
@@ -59,8 +61,11 @@ namespace Bonsai.Design
         /// <remarks>
         /// If no value is specified, the value in the cached layout settings is used.
         /// </remarks>
+        [Category(nameof(CategoryAttribute.Layout))]
         [Description("Specifies whether the visualizer window should start minimized, maximized, or normal.")]
         public FormWindowState? WindowState { get; set; }
+
+        string INamedElement.Name => Text;
 
         /// <summary>
         /// Generates an <see cref="Expression"/> node from a collection of input arguments.

--- a/Bonsai.Design/VisualizerWindow.cs
+++ b/Bonsai.Design/VisualizerWindow.cs
@@ -27,28 +27,40 @@ namespace Bonsai.Design
         /// Gets or sets a value specifying whether the visualizer window is visible
         /// on start.
         /// </summary>
+        /// <remarks>
+        /// If no value is specified, the value in the cached layout settings is used.
+        /// </remarks>
         [Description("Specifies whether the visualizer window is visible on start.")]
-        public bool Visible { get; set; } = true;
+        public bool? Visible { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value specifying the position of the upper-left corner of the
         /// visualizer window, in screen coordinates.
         /// </summary>
+        /// <remarks>
+        /// If no value is specified, the value in the cached layout settings is used.
+        /// </remarks>
         [Description("Specifies the position of the upper-left corner of the visualizer window, in screen coordinates.")]
-        public Point Location { get; set; }
+        public Point? Location { get; set; }
 
         /// <summary>
         /// Gets or sets a value specifying the size of the visualizer window.
         /// </summary>
+        /// <remarks>
+        /// If no value is specified, the value in the cached layout settings is used.
+        /// </remarks>
         [Description("Specifies the size of the visualizer window.")]
-        public Size Size { get; set; }
+        public Size? Size { get; set; }
 
         /// <summary>
         /// Gets or sets a value specifying whether the visualizer window should start
         /// minimized, maximized, or normal.
         /// </summary>
+        /// <remarks>
+        /// If no value is specified, the value in the cached layout settings is used.
+        /// </remarks>
         [Description("Specifies whether the visualizer window should start minimized, maximized, or normal.")]
-        public FormWindowState WindowState { get; set; }
+        public FormWindowState? WindowState { get; set; }
 
         /// <summary>
         /// Generates an <see cref="Expression"/> node from a collection of input arguments.

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
@@ -144,6 +144,7 @@
             this.visualizerToolStripMenuItem.Name = "visualizerToolStripMenuItem";
             this.visualizerToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
             this.visualizerToolStripMenuItem.Text = global::Bonsai.Editor.Properties.Resources.ShowVisualizerMenuItem;
+            this.visualizerToolStripMenuItem.Click += new System.EventHandler(this.visualizerToolStripMenuItem_Click);
             // 
             // defaultEditorToolStripMenuItem
             // 

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1434,9 +1434,14 @@ namespace Bonsai.Editor.GraphView
             GraphNode selectedNode)
         {
             var visualizerElement = ExpressionBuilder.GetVisualizerElement(inspectBuilder);
-            var canShowVisualizer = inspectBuilder.Builder is not VisualizerMappingExpressionBuilder;
+            var isRunningVisualizerWindow = editorState.WorkflowRunning && inspectBuilder.Builder is VisualizerWindow;
+            var canShowVisualizer = inspectBuilder.Builder is not VisualizerMappingExpressionBuilder || isRunningVisualizerWindow;
             ownerItem.Text = canShowVisualizer ? Resources.ShowVisualizerMenuItem : Resources.SelectVisualizerMenuItem;
-            if (visualizerElement.ObservableType is not null &&
+            if (isRunningVisualizerWindow)
+            {
+                ownerItem.Enabled = true;
+            }
+            else if (visualizerElement.ObservableType is not null &&
                 (!editorState.WorkflowRunning ||
                 visualizerElement.PublishNotifications &&
                 canShowVisualizer))
@@ -1630,6 +1635,18 @@ namespace Bonsai.Editor.GraphView
                     var activeVisualizer = GetActiveVisualizerTypeName(workflowElement, inspectBuilder);
                     CreateVisualizerMenuItems(activeVisualizer, inspectBuilder, visualizerToolStripMenuItem, selectedNode);
                 }
+            }
+        }
+
+        private void visualizerToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (!editorState.WorkflowRunning || visualizerToolStripMenuItem.HasDropDownItems)
+                return;
+
+            var selectedNodes = selectionModel.SelectedNodes.ToArray();
+            if (selectedNodes.Length == 1)
+            {
+                LaunchVisualizer(selectedNodes[0]);
             }
         }
 

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1417,7 +1417,7 @@ namespace Bonsai.Editor.GraphView
             }
             else
             {
-                if (workflowElement is VisualizerMappingBuilder mappingBuilder &&
+                if (workflowElement is VisualizerMappingExpressionBuilder mappingBuilder &&
                     mappingBuilder.VisualizerType is not null)
                     return mappingBuilder.VisualizerType.GetType().GetGenericArguments()[0].FullName;
                 else
@@ -1434,7 +1434,7 @@ namespace Bonsai.Editor.GraphView
             GraphNode selectedNode)
         {
             var visualizerElement = ExpressionBuilder.GetVisualizerElement(inspectBuilder);
-            var canShowVisualizer = inspectBuilder.Builder is not VisualizerMappingBuilder;
+            var canShowVisualizer = inspectBuilder.Builder is not VisualizerMappingExpressionBuilder;
             ownerItem.Text = canShowVisualizer ? Resources.ShowVisualizerMenuItem : Resources.SelectVisualizerMenuItem;
             if (visualizerElement.ObservableType is not null &&
                 (!editorState.WorkflowRunning ||
@@ -1464,7 +1464,7 @@ namespace Bonsai.Editor.GraphView
             menuItem = new ToolStripMenuItem(itemText, null, delegate
             {
                 var inspectBuilder = (InspectBuilder)selectedNode.Value;
-                if (ExpressionBuilder.Unwrap(inspectBuilder) is VisualizerMappingBuilder mappingBuilder)
+                if (inspectBuilder.Builder is VisualizerMappingExpressionBuilder mappingBuilder)
                 {
                     if (emptyVisualizer) mappingBuilder.VisualizerType = null;
                     else

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1509,7 +1509,7 @@ namespace Bonsai.Editor.GraphView
                             visualizerSettings[inspectBuilder] = dialogSettings;
                     }
                 }
-                else if (editorState.WorkflowRunning)
+                else if (editorState.WorkflowRunning && !emptyVisualizer)
                 {
                     LaunchVisualizer(selectedNode);
                 }

--- a/Bonsai.Editor/Layout/DialogLauncher.cs
+++ b/Bonsai.Editor/Layout/DialogLauncher.cs
@@ -35,7 +35,7 @@ namespace Bonsai.Design
                 VisualizerDialog.Load += delegate
                 {
                     var bounds = Bounds;
-                    if (!bounds.IsEmpty && (SystemInformation.VirtualScreen.Contains(bounds) || WindowState != FormWindowState.Normal))
+                    if (!bounds.IsEmpty && (SystemInformation.VirtualScreen.IntersectsWith(bounds) || WindowState != FormWindowState.Normal))
                     {
                         VisualizerDialog.LayoutBounds = bounds;
                         VisualizerDialog.WindowState = WindowState;

--- a/Bonsai.Editor/Layout/VisualizerDialogSettings.cs
+++ b/Bonsai.Editor/Layout/VisualizerDialogSettings.cs
@@ -24,7 +24,7 @@ namespace Bonsai.Design
         [XmlIgnore]
         public object Tag { get; set; }
 
-        public bool Visible { get; set; }
+        public bool Visible { get; set; } = true;
 
         public Point Location { get; set; }
 
@@ -52,7 +52,7 @@ namespace Bonsai.Design
         // [Obsolete]
         public Collection<int> Mashups { get; } = new Collection<int>();
 
-        public bool VisibleSpecified => Visible;
+        public bool VisibleSpecified => !Visible;
 
         public bool LocationSpecified => !Location.IsEmpty;
 

--- a/Bonsai.Editor/Layout/VisualizerLayoutMap.cs
+++ b/Bonsai.Editor/Layout/VisualizerLayoutMap.cs
@@ -37,12 +37,15 @@ namespace Bonsai.Design
 
                 if (source.Builder is VisualizerWindow visualizerWindow)
                 {
+                    if (!lookup.TryGetValue(source, out VisualizerDialogSettings cachedSettings))
+                        cachedSettings = new();
+
                     lookup[source] = new VisualizerDialogSettings
                     {
-                        Visible = visualizerWindow.Visible,
-                        Location = visualizerWindow.Location,
-                        Size = visualizerWindow.Size,
-                        WindowState = visualizerWindow.WindowState,
+                        Visible = visualizerWindow.Visible.GetValueOrDefault(cachedSettings.Visible),
+                        Location = visualizerWindow.Location.GetValueOrDefault(cachedSettings.Location),
+                        Size = visualizerWindow.Size.GetValueOrDefault(cachedSettings.Size),
+                        WindowState = visualizerWindow.WindowState.GetValueOrDefault(cachedSettings.WindowState),
                         VisualizerTypeName = visualizerWindow.VisualizerType?
                             .GetType()
                             .GetGenericArguments()[0]
@@ -74,12 +77,6 @@ namespace Bonsai.Design
             var unused = new HashSet<InspectBuilder>(lookup.Keys);
             foreach (var dialog in visualizerDialogs)
             {
-                if (dialog.Source.Builder is VisualizerWindow)
-                {
-                    dialog.Hide();
-                    continue;
-                }
-
                 unused.Remove(dialog.Source);
                 if (!lookup.TryGetValue(dialog.Source, out VisualizerDialogSettings dialogSettings))
                 {
@@ -96,7 +93,7 @@ namespace Bonsai.Design
 
                 var visualizer = dialog.Visualizer.Value;
                 var visualizerType = visualizer.GetType();
-                if (visualizerType.IsPublic)
+                if (visualizerType.IsPublic && dialog.Source.Builder is not VisualizerWindow)
                 {
                     dialogSettings.VisualizerTypeName = visualizerType.FullName;
                     dialogSettings.VisualizerSettings = LayoutHelper.SerializeVisualizerSettings(


### PR DESCRIPTION
This operator allows declaring which specific visualizer windows should be launched on workflow start, and makes it possible to have frontend applications launch correctly even in the absence of a visualizer layout file.

The new `VisualizerWindow` operator does not allow changing the visualizer type at runtime, but it is possible to relaunch the window from the context menu in case it is closed.

Note that while basic window settings may be cached in the local layout file, runtime visualizer settings are not currently saved for explicitly launched visualizers. If required, such logic should be embedded in the frontend UI itself.

`VisualizerWindow` properties which are explicitly set will always overrule the cache.

Fixes #2137 