### PR TITLE
Avoid setting minimum size on text visualizer

### DIFF
--- a/Bonsai.Design/ObjectTextVisualizer.cs
+++ b/Bonsai.Design/ObjectTextVisualizer.cs
@@ -147,7 +147,7 @@ namespace Bonsai.Design
             textPanel = new UserControl();
             textPanel.SuspendLayout();
             textPanel.Dock = DockStyle.Fill;
-            textPanel.MinimumSize = textPanel.Size = new Size(320, 2 * AutoScaleHeight);
+            textPanel.Size = new Size(320, 2 * AutoScaleHeight);
             textPanel.AutoScaleDimensions = new SizeF(6F, AutoScaleHeight);
             textPanel.AutoScaleMode = AutoScaleMode.Font;
             textPanel.Paint += textPanel_Paint;


### PR DESCRIPTION
Setting a minimum size can cause layout problems when composing multiple visualizers in containers.

Fixes #2252 