### PR TITLE
Initialize editor layout after workflow validation

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -834,7 +834,8 @@ namespace Bonsai.Editor
             workflowBuilder.Workflow.Clear();
             if (editorControl.AnnotationPanel.Tag is ExpressionBuilder)
                 editorControl.ClearAnnotationPanel();
-            editorControl.ResetEditorLayout();
+            editorControl.CloseAll();
+            editorControl.InitializeEditorLayout();
             editorSite.ValidateWorkflow();
             visualizerSettings.Clear();
             ResetProjectStatus();
@@ -872,10 +873,11 @@ namespace Bonsai.Editor
             ClearWorkflowError();
             FileName = fileName;
 
+            editorControl.CloseAll();
+            editorSite.ValidateWorkflow();
             var settingsDirectory = Project.GetWorkflowSettingsDirectory(fileName);
             var editorPath = Project.GetEditorSettingsPath(settingsDirectory, fileName);
-            editorControl.ResetEditorLayout(editorPath);
-            editorSite.ValidateWorkflow();
+            editorControl.InitializeEditorLayout(editorPath);
 
             visualizerSettings.Clear();
             var layoutPath = LayoutHelper.GetCompatibleLayoutPath(settingsDirectory, fileName);

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -257,9 +257,8 @@ namespace Bonsai.Editor.GraphView
             document.WriteTo(writer);
         }
 
-        public void ResetEditorLayout(string fileName = default)
+        public void InitializeEditorLayout(string fileName = default)
         {
-            CloseAll();
             if (File.Exists(fileName))
             {
                 CloseToolWindows();
@@ -359,7 +358,7 @@ namespace Bonsai.Editor.GraphView
             }
         }
 
-        void CloseAll()
+        public void CloseAll()
         {
             var contents = new List<IDockContent>(dockPanel.Contents.Count);
             IEnumerable<INestedPanesContainer> paneContainers = dockPanel.DockWindows;


### PR DESCRIPTION
This ensures that all include workflows have been expanded in case any editor dock panel is targeting their contents.

Fixes #2254 