### PR TITLE
Ensure await of background tasks

### DIFF
--- a/Bonsai.Editor/TaskHelper.cs
+++ b/Bonsai.Editor/TaskHelper.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bonsai.Editor
+{
+    static class TaskHelper
+    {
+        public static Task ToTask(this CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<object>();
+            cancellationToken.Register(() => tcs.TrySetCanceled(), useSynchronizationContext: false);
+            return tcs.Task;
+        }
+    }
+}


### PR DESCRIPTION
Tasks started without an awaiter will not propagate exceptions to the top-level form. Here we explore setting up an explicit awaiter for all background tasks to ensure both error propagation and cancellation.

Fixes #2256 