### PR TITLE
Add support for Prepend and Append operators

### DIFF
--- a/Bonsai.Core/Expressions/BinaryOperatorBuilder.cs
+++ b/Bonsai.Core/Expressions/BinaryOperatorBuilder.cs
@@ -19,8 +19,7 @@ namespace Bonsai.Expressions
         static readonly MethodInfo MoveNextMethod = typeof(IEnumerator).GetMethod("MoveNext");
 
         /// <summary>
-        /// Gets or sets the value of the right hand operand which will be paired with elements
-        /// of the observable sequence in case the sequence itself is not composed of paired elements.
+        /// Gets or sets the value of the operand used to process the observable sequence.
         /// </summary>
         [Browsable(false)]
         public WorkflowProperty Operand { get; set; }
@@ -176,7 +175,7 @@ namespace Bonsai.Expressions
 
         static readonly Attribute[] ValueAttributes = new[]
         {
-            new DescriptionAttribute("The value of the right hand operand in the binary operator.")
+            new DescriptionAttribute("The value of the operand used to process the observable sequence.")
         };
 
         AttributeCollection ICustomTypeDescriptor.GetAttributes()

--- a/Bonsai.Core/Expressions/OperandCombinatorExpressionBuilder.cs
+++ b/Bonsai.Core/Expressions/OperandCombinatorExpressionBuilder.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Xml.Serialization;
+
+namespace Bonsai.Expressions
+{
+    /// <summary>
+    /// Provides a base class for expression builders combining a single observable sequence with
+    /// an auxiliary operand value whose type is inferred from the sequence. This is an abstract class.
+    /// </summary>
+    [XmlType(Namespace = Constants.XmlNamespace)]
+    [WorkflowElementCategory(ElementCategory.Combinator)]
+    public abstract class OperandCombinatorExpressionBuilder : BinaryOperatorBuilder
+    {
+        internal OperandCombinatorExpressionBuilder()
+        {
+        }
+
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            var source = arguments.First();
+            return BuildSelector(source);
+        }
+
+        /// <inheritdoc/>
+        protected override Expression BuildSelector(Expression expression)
+        {
+            var operand = Operand;
+            var source = expression;
+            var parameterType = source.Type.GetGenericArguments()[0];
+            if (operand is null)
+            {
+                if (parameterType.IsInterface ||
+                    parameterType.IsClass && parameterType != typeof(string) &&
+                    parameterType.GetConstructor(Type.EmptyTypes) == null)
+                {
+                    throw new InvalidOperationException(
+                        $"{parameterType} cannot be used as operand because it does not have a parameterless constructor.");
+                }
+
+                var propertyType = GetWorkflowPropertyType(parameterType);
+                Operand = operand = (WorkflowProperty)Activator.CreateInstance(propertyType);
+            }
+
+            var operandExpression = ExpressionHelper.Property(
+                Expression.Constant(operand),
+                "Value");
+            return BuildSelector(source, operandExpression);
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/Append.cs
+++ b/Bonsai.Core/Reactive/Append.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq.Expressions;
+using System.Reactive;
+using System.Reactive.Linq;
+using Bonsai.Expressions;
+
+namespace Bonsai.Reactive
+{
+    /// <summary>
+    /// Represents an operator that appends a value to an observable sequence.
+    /// </summary>
+    [Description("Appends a value to an observable sequence.")]
+    public sealed class Append : OperandCombinatorExpressionBuilder
+    {
+        /// <inheritdoc/>
+        protected override Expression BuildSelector(Expression left, Expression right)
+        {
+            return Expression.Call(typeof(Append), nameof(Process), new[] { right.Type }, left, right);
+        }
+
+        static IObservable<TSource> Process<TSource>(IObservable<TSource> source, TSource value)
+        {
+            return Observable.Create<TSource>(observer =>
+            {
+                var appendObserver = Observer.Create<TSource>(
+                    observer.OnNext,
+                    observer.OnError,
+                    () =>
+                    {
+                        observer.OnNext(value);
+                        observer.OnCompleted();
+                    });
+                return source.SubscribeSafe(appendObserver);
+            });
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/Prepend.cs
+++ b/Bonsai.Core/Reactive/Prepend.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq.Expressions;
+using System.Reactive.Linq;
+using Bonsai.Expressions;
+
+namespace Bonsai.Reactive
+{
+    /// <summary>
+    /// Represents an operator that prepends a value to an observable sequence.
+    /// </summary>
+    [Description("Prepends a value to an observable sequence.")]
+    public sealed class Prepend : OperandCombinatorExpressionBuilder
+    {
+        /// <inheritdoc/>
+        protected override Expression BuildSelector(Expression left, Expression right)
+        {
+            return Expression.Call(typeof(Prepend), nameof(Process), new[] { right.Type }, left, right);
+        }
+
+        static IObservable<TSource> Process<TSource>(IObservable<TSource> source, TSource value)
+        {
+            return Observable.Create<TSource>(observer =>
+            {
+                observer.OnNext(value);
+                return source.SubscribeSafe(observer);
+            });
+        }
+    }
+}


### PR DESCRIPTION
There are many cases in which empty sequences may cause undesired behavior due to downstream operator constraints enforcing a minimum of one value for successful processing (e.g. see #1617). Similarly, it can also be useful to enforce that a sequence always ends with a specific value, no matter when it terminates.

For both of these cases the `Prepend` and `Append` operators can be very convenient. Although equivalent behavior may be obtained using `Concat` and similar observable combinators, the convenience of `Prepend` and `Append` lays in the fact that the desired value can be specified inline with the sequence itself, without requiring merging of external sequences.

The current limitation is that any such appended or prepended values must be XML serializable as they will be stored together with the workflow. This is the same limitation present in other binary operators such as `Add`, `Subtract`, etc. when used by themselves.

Fixes #657 
Closes #1617 