### PR TITLE
Set user agent string used for NuGet network calls

### DIFF
--- a/Bonsai.Configuration/PackageConfigurationUpdater.cs
+++ b/Bonsai.Configuration/PackageConfigurationUpdater.cs
@@ -33,7 +33,6 @@ namespace Bonsai.Configuration
         readonly SourceRepository galleryRepository;
         readonly PackageConfiguration packageConfiguration;
         readonly PackageConfigurationPlugin configurationPlugin;
-        static readonly string ContentFolder = PathUtility.EnsureTrailingSlash(PackagingConstants.Folders.Content);
         static readonly char[] DirectorySeparators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
         static readonly NuGetFramework NativeFramework = NuGetFramework.ParseFrameworkName("native,Version=v0.0", DefaultFrameworkNameProvider.Instance);
         static readonly NuGetFramework WindowsFramework = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows, FrameworkConstants.EmptyVersion);

--- a/Bonsai.NuGet/PackageManager.cs
+++ b/Bonsai.NuGet/PackageManager.cs
@@ -19,6 +19,11 @@ namespace Bonsai.NuGet
 {
     public class PackageManager : IPackageManager
     {
+        static PackageManager()
+        {
+            UserAgent.SetUserAgentString(new UserAgentStringBuilder(nameof(Bonsai)));
+        }
+
         public PackageManager(PackageSourceProvider packageSourceProvider, string path)
             : this(packageSourceProvider.Settings, packageSourceProvider, path)
         {


### PR DESCRIPTION
The `PackageManager` class is used to bottleneck all access to the networked NuGet client API, so we initialize the user agent string in its static constructor. This will allow us to differentiate bootstrapper package access stats on NuGet going forward.

Repackaging the assembly using ILMerge also incidentally sets the correct client version.

Fixes #2220 