### PR TITLE
Ensure visualizer predecessor search can extend to nested scopes

### DIFF
--- a/Bonsai.Core/Expressions/ExpressionBuilder.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilder.cs
@@ -85,12 +85,11 @@ namespace Bonsai.Expressions
         /// </returns>
         public static ExpressionBuilder Unwrap(ExpressionBuilder builder)
         {
-            if (builder == null)
-            {
+            if (builder is null)
                 throw new ArgumentNullException(nameof(builder));
-            }
 
-            if (builder is InspectBuilder inspectBuilder) return Unwrap(inspectBuilder.Builder);
+            if (builder is InspectBuilder inspectBuilder)
+                return inspectBuilder.Builder;
             return builder;
         }
 

--- a/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilderGraphExtensions.cs
@@ -1400,23 +1400,22 @@ namespace Bonsai.Expressions
 
         /// <summary>
         /// Returns a filtered collection of the descendant elements for this workflow, including elements
-        /// nested inside grouped workflows. Any descendants of disabled groups will not be included in the result.
+        /// inside nested workflows. Any descendants of disabled groups will not be included in the result.
         /// </summary>
         /// <param name="source">The expression builder workflow to search.</param>
         /// <returns>An enumerable sequence of all the descendant elements in this workflow.</returns>
         public static IEnumerable<ExpressionBuilder> Descendants(this ExpressionBuilderGraph source)
         {
-            return Descendants(source, unwrap: true);
+            return source.DescendantNodes().Select(node => ExpressionBuilder.Unwrap(node.Value));
         }
 
         /// <summary>
-        /// Returns a filtered collection of the descendant elements for this workflow, including elements
-        /// nested inside grouped workflows. Any descendants of disabled groups will not be included in the result.
+        /// Returns a filtered collection of the descendant nodes for this workflow, including elements
+        /// inside nested workflows. Any nodes nested inside disabled groups will not be included in the result.
         /// </summary>
         /// <param name="source">The expression builder workflow to search.</param>
-        /// <param name="unwrap">A value indicating whether to unwrap descendant elements.</param>
-        /// <returns>An enumerable sequence of all the descendant elements in this workflow.</returns>
-        public static IEnumerable<ExpressionBuilder> Descendants(this ExpressionBuilderGraph source, bool unwrap)
+        /// <returns>An enumerable sequence of all the descendant nodes in this workflow.</returns>
+        public static IEnumerable<Node<ExpressionBuilder, ExpressionBuilderArgument>> DescendantNodes(this ExpressionBuilderGraph source)
         {
             var stack = new Stack<IEnumerator<Node<ExpressionBuilder, ExpressionBuilderArgument>>>();
             stack.Push(source.GetEnumerator());
@@ -1432,11 +1431,11 @@ namespace Bonsai.Expressions
                         break;
                     }
 
-                    var nodeValue = nodeEnumerator.Current.Value;
-                    var builder = ExpressionBuilder.Unwrap(nodeValue);
-                    yield return unwrap ? builder : nodeValue;
+                    var node = nodeEnumerator.Current;
+                    yield return node;
 
-                    if (builder is IWorkflowExpressionBuilder workflowBuilder && workflowBuilder.Workflow != null)
+                    var builder = ExpressionBuilder.Unwrap(node.Value);
+                    if (builder is IWorkflowExpressionBuilder workflowBuilder && workflowBuilder.Workflow is not null)
                     {
                         stack.Push(workflowBuilder.Workflow.GetEnumerator());
                         break;

--- a/Bonsai.Editor/Layout/LayoutHelper.cs
+++ b/Bonsai.Editor/Layout/LayoutHelper.cs
@@ -46,10 +46,10 @@ namespace Bonsai.Design
 
         public static void SetLayoutNotifications(ExpressionBuilderGraph source, VisualizerDialogMap lookup)
         {
-            foreach (var builder in source.Descendants(unwrap: false))
+            foreach (var node in source.DescendantNodes())
             {
-                var inspectBuilder = (InspectBuilder)builder;
-                if (lookup.TryGetValue((InspectBuilder)builder, out VisualizerDialogLauncher _))
+                var inspectBuilder = (InspectBuilder)node.Value;
+                if (lookup.TryGetValue(inspectBuilder, out VisualizerDialogLauncher _))
                 {
                     SetVisualizerNotifications(inspectBuilder);
                 }

--- a/Bonsai.Vision.Design/BinaryRegionExtremesVisualizer.cs
+++ b/Bonsai.Vision.Design/BinaryRegionExtremesVisualizer.cs
@@ -53,20 +53,8 @@ namespace Bonsai.Vision.Design
         /// <inheritdoc/>
         public override void Load(IServiceProvider provider)
         {
-            var workflow = (ExpressionBuilderGraph)provider.GetService(typeof(ExpressionBuilderGraph));
-            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
-            if (workflow != null && context != null)
-            {
-                var predecessorNode = workflow.Where(node => node.Value == context.Source)
-                                              .Select(node => workflow.Predecessors(node).FirstOrDefault())
-                                              .FirstOrDefault();
-                if (predecessorNode != null)
-                {
-                    var inputInspector = (InspectBuilder)predecessorNode.Value;
-                    inputHandle = inputInspector.Output.Merge().Subscribe(value => connectedComponent = (ConnectedComponent)value);
-                }
-            }
-
+            var imageInput = VisualizerHelper.ObservableInput(provider, typeof(ConnectedComponent));
+            inputHandle = imageInput?.Subscribe(value => connectedComponent = (ConnectedComponent)value);
             base.Load(provider);
         }
 

--- a/Bonsai.Vision.Design/CircleVisualizer.cs
+++ b/Bonsai.Vision.Design/CircleVisualizer.cs
@@ -68,21 +68,10 @@ namespace Bonsai.Vision.Design
         /// <inheritdoc/>
         public override void Load(IServiceProvider provider)
         {
-            var inputInspector = default(InspectBuilder);
-            var workflow = (ExpressionBuilderGraph)provider.GetService(typeof(ExpressionBuilderGraph));
-            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
-            if (workflow != null && context != null)
+            var imageInput = VisualizerHelper.ImageInput(provider);
+            if (imageInput != null)
             {
-                inputInspector = workflow.Where(node => node.Value == context.Source)
-                                         .Select(node => workflow.Predecessors(node)
-                                                                 .Select(p => p.Value as InspectBuilder)
-                                                                 .FirstOrDefault())
-                                         .FirstOrDefault();
-            }
-
-            if (inputInspector != null && inputInspector.ObservableType == typeof(IplImage))
-            {
-                inputHandle = inputInspector.Output.Merge().Subscribe(value => input = (IplImage)value);
+                inputHandle = imageInput.Subscribe(value => input = (IplImage)value);
                 base.Load(provider);
             }
             else

--- a/Bonsai.Vision.Design/LineSegmentVisualizer.cs
+++ b/Bonsai.Vision.Design/LineSegmentVisualizer.cs
@@ -68,21 +68,10 @@ namespace Bonsai.Vision.Design
         /// <inheritdoc/>
         public override void Load(IServiceProvider provider)
         {
-            var inputInspector = default(InspectBuilder);
-            var workflow = (ExpressionBuilderGraph)provider.GetService(typeof(ExpressionBuilderGraph));
-            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
-            if (workflow != null && context != null)
+            var imageInput = VisualizerHelper.ImageInput(provider);
+            if (imageInput != null)
             {
-                inputInspector = workflow.Where(node => node.Value == context.Source)
-                                         .Select(node => workflow.Predecessors(node)
-                                                                 .Select(p => p.Value as InspectBuilder)
-                                                                 .FirstOrDefault())
-                                         .FirstOrDefault();
-            }
-
-            if (inputInspector != null && inputInspector.ObservableType == typeof(IplImage))
-            {
-                inputHandle = inputInspector.Output.Merge().Subscribe(value => input = (IplImage)value);
+                inputHandle = imageInput.Subscribe(value => input = (IplImage)value);
                 base.Load(provider);
             }
             else

--- a/Bonsai.Vision.Design/VisualizerHelper.cs
+++ b/Bonsai.Vision.Design/VisualizerHelper.cs
@@ -12,6 +12,11 @@ namespace Bonsai.Vision.Design
     {
         internal static IObservable<object> ImageInput(IServiceProvider provider)
         {
+            return ObservableInput(provider, typeof(IplImage));
+        }
+
+        internal static IObservable<object> ObservableInput(IServiceProvider provider, Type observableType)
+        {
             var inputInspector = default(InspectBuilder);
             var workflow = (ExpressionBuilderGraph)provider.GetService(typeof(ExpressionBuilderGraph));
             var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
@@ -24,7 +29,7 @@ namespace Bonsai.Vision.Design
                                          .FirstOrDefault();
             }
 
-            if (inputInspector != null && inputInspector.ObservableType == typeof(IplImage))
+            if (inputInspector != null && inputInspector.ObservableType == observableType)
             {
                 return inputInspector.Output.Merge();
             }

--- a/Bonsai.Vision.Design/VisualizerHelper.cs
+++ b/Bonsai.Vision.Design/VisualizerHelper.cs
@@ -1,5 +1,4 @@
-﻿using Bonsai.Dag;
-using Bonsai.Design;
+﻿using Bonsai.Design;
 using Bonsai.Expressions;
 using OpenCV.Net;
 using System;
@@ -22,11 +21,10 @@ namespace Bonsai.Vision.Design
             var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
             if (workflow != null && context != null)
             {
-                inputInspector = workflow.Where(node => node.Value == context.Source)
-                                         .Select(node => workflow.Predecessors(node)
-                                                                 .Select(p => p.Value as InspectBuilder)
-                                                                 .FirstOrDefault())
-                                         .FirstOrDefault();
+                inputInspector = (from node in workflow.DescendantNodes()
+                                  from successor in node.Successors
+                                  where successor.Target.Value == context.Source
+                                  select node.Value as InspectBuilder).FirstOrDefault();
             }
 
             if (inputInspector != null && inputInspector.ObservableType == observableType)


### PR DESCRIPTION
Specific visualizers may require accessing inputs from the predecessor node, which are found from a search through the workflow in which the visualizer is embedded. However, if the visualizer is being propagated upwards through nested scopes or mapped into other containers, this association between the visualizer source and its predecessor can be lost.

This fix uses `ITypeVisualizerContext` to identify the correct source of visualizer data, and then relies on visualizer and visualizer mapping propagation semantics to guide a recursive search for the correct predecessor and ensure the association is preserved.

Fixes #2251 