### PR TITLE
Account for variable length parameters correctly

### DIFF
--- a/Bonsai.Core.Tests/OverloadedCombinatorBuilderTests.cs
+++ b/Bonsai.Core.Tests/OverloadedCombinatorBuilderTests.cs
@@ -135,6 +135,13 @@ namespace Bonsai.Core.Tests
                 => Observable.Return(default(T));
         }
 
+        [Combinator]
+        class SourceWithSingleGenericParamsOverloadMock
+        {
+            public IObservable<T> Process<T>(params IObservable<T>[] sources)
+                => Observable.Return(default(T));
+        }
+
         private TResult RunOverload<TSource, TResult, TCombinator>(TSource value)
             where TCombinator : new()
         {
@@ -337,6 +344,19 @@ namespace Bonsai.Core.Tests
 
             var result = await workflow.BuildObservable<int>();
             Assert.AreEqual(expected: 0, result);
+        }
+
+        [TestMethod]
+        public void ArgumentRange_SourceWithSingleGenericParamsOverload_LowerBoundIsEqualToOne()
+        // Overload with a single unassigned generic params parameter should require at least one argument
+        {
+            // related to https://github.com/bonsai-rx/bonsai/issues/2280
+            var combinatorBuilder = new CombinatorBuilder
+            {
+                Combinator = new SourceWithSingleGenericParamsOverloadMock()
+            };
+
+            Assert.AreEqual(expected: 1, combinatorBuilder.ArgumentRange.LowerBound);
         }
     }
 }

--- a/Bonsai.Core.Tests/OverloadedCombinatorBuilderTests.cs
+++ b/Bonsai.Core.Tests/OverloadedCombinatorBuilderTests.cs
@@ -142,6 +142,13 @@ namespace Bonsai.Core.Tests
                 => Observable.Return(default(T));
         }
 
+        [Combinator]
+        class SourceWithSingleNonGenericParamsOverloadMock
+        {
+            public IObservable<int> Process(params IObservable<int>[] sources)
+                => Observable.Return(default(int));
+        }
+
         private TResult RunOverload<TSource, TResult, TCombinator>(TSource value)
             where TCombinator : new()
         {
@@ -347,7 +354,7 @@ namespace Bonsai.Core.Tests
         }
 
         [TestMethod]
-        public void ArgumentRange_SourceWithSingleGenericParamsOverload_LowerBoundIsEqualToOne()
+        public void ArgumentRange_SourceWithSingleGenericParamsOverload_LowerBoundIsOne()
         // Overload with a single unassigned generic params parameter should require at least one argument
         {
             // related to https://github.com/bonsai-rx/bonsai/issues/2280
@@ -357,6 +364,19 @@ namespace Bonsai.Core.Tests
             };
 
             Assert.AreEqual(expected: 1, combinatorBuilder.ArgumentRange.LowerBound);
+        }
+
+        [TestMethod]
+        public void ArgumentRange_SourceWithSingleNonGenericParamsOverload_LowerBoundIsZero()
+        // Overload with a single unassigned generic params parameter should require at least one argument
+        {
+            // related to https://github.com/bonsai-rx/bonsai/issues/2280
+            var combinatorBuilder = new CombinatorBuilder
+            {
+                Combinator = new SourceWithSingleNonGenericParamsOverloadMock()
+            };
+
+            Assert.AreEqual(expected: 0, combinatorBuilder.ArgumentRange.LowerBound);
         }
     }
 }

--- a/Bonsai.Core/Expressions/ExpressionBuilder.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilder.cs
@@ -423,7 +423,7 @@ namespace Bonsai.Expressions
                 Attribute.IsDefined(parameters[offset], typeof(ParamArrayAttribute));
 
             return paramArray &&
-                (parameters.Length != arguments.Length ||
+                (parameters.Length < arguments.Length || parameters.Length == arguments.Length &&
                  !MatchParamArrayTypeReferences(parameters[offset].ParameterType, arguments[arguments.Length - 1]));
         }
 


### PR DESCRIPTION
Handling method overload resolution with variable length parameters was relying on specific edge cases. This PR attempts to resolve this by correctly checking for `params` expansion during overload resolution phase, and improving the way the lower bound for the combinator argument range is computed by taking into account whether a method with a single `params` contains unassigned generic parameters.

Specifically this allows defining operators with a single non-generic overload with `params`, e.g.:

```c#
public IObservable<int> Process(params IObservable<int>[] sources)
```

Unit tests were added which may help to guide discovery and resolution of future edge cases related to methods with hybrid variable length generic overloads.

Fixes #2280 