### PR TITLE
Ensure node argument range indicator is displayed

### DIFF
--- a/Bonsai.Editor/GraphModel/GraphNode.cs
+++ b/Bonsai.Editor/GraphModel/GraphNode.cs
@@ -89,7 +89,7 @@ namespace Bonsai.Editor.GraphModel
         {
             get
             {
-                return (Flags & NodeFlags.Disabled | NodeFlags.RangeUndefined) != 0 || Value is null
+                return (Flags & (NodeFlags.Disabled | NodeFlags.RangeUndefined)) != 0 || Value is null
                     ? EmptyRange
                     : Value.ArgumentRange;
             }


### PR DESCRIPTION
Extracting the argument range of an editor graph node suffered a regression in #2235 due to a logical error specifying operator precedence.

Fixes #2283 