### PR TITLE
Add missing null guard in SelectPackageDetails

### DIFF
--- a/Bonsai.NuGet.Design/PackageViewController.cs
+++ b/Bonsai.NuGet.Design/PackageViewController.cs
@@ -425,7 +425,7 @@ namespace Bonsai.NuGet.Design
                 {
                     var selectedNode = evt.EventArgs.Node;
                     var selectedRepository = SelectedRepository;
-                    var selectedPackage = (IPackageSearchMetadata)selectedNode.Tag;
+                    var selectedPackage = (IPackageSearchMetadata)selectedNode?.Tag;
                     if (selectedPackage == null) return null;
 
                     var localPackageNode = selectedNode.Nodes.Count > 0 ? selectedNode.Nodes[Resources.UpdatesNodeName] : null;


### PR DESCRIPTION
Tree view selection changes can transiently report a null selected node. The conditions causing this on refresh can be difficult to determine, but in general we want to account for this possibility and treat it identical to a null package and hide the details.

Fixes #2288 