### PR TITLE
Fix package source configuration dialog missing from the taskbar

### DIFF
--- a/Bonsai.NuGet.Design/PackageSourceConfigurationDialog.Designer.cs
+++ b/Bonsai.NuGet.Design/PackageSourceConfigurationDialog.Designer.cs
@@ -274,9 +274,8 @@
             this.MinimizeBox = false;
             this.Name = "PackageSourceConfigurationDialog";
             this.ShowIcon = false;
-            this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Options";
+            this.Text = "Bonsai Package Source Options";
             this.ResumeLayout(false);
             this.PerformLayout();
 


### PR DESCRIPTION
This was an annoyance I encountered when reviewing https://github.com/bonsai-rx/bonsai/pull/2285.

The package source configuration dialog is hidden from the taskbar, which isn't necessarily unreasonable or uncommon for modal dialogs. However the package manager dialog [hides itself when you click the options button](https://github.com/bonsai-rx/bonsai/blob/44253e33b5d521fd8ea0fddc26f7836cf6f15aef/Bonsai.NuGet.Design/PackageManagerDialog.cs#L216), which means the window can easily get lost under other apps.

This PR fixes this by letting it appear in the taskbar. While I was at it I also changed the window title to make it less vague for degenerates like me that enable taskbar labels.

------------------

It's been like this since [the dialog was initially created](https://github.com/bonsai-rx/bonsai/commit/611cc1b841d15c501c748603b6ed323ea3b74e5b#diff-6dcd013b5a2443438464bd48da76854056f41b0b0418b0aa1fa23cbd37921e9eR208), but it made more sense back then as the package manager dialog [used to not hide itself](https://github.com/bonsai-rx/bonsai/blob/142a6510b339aab49dd6e237b41da9d70474d970/Bonsai.NuGet/PackageManagerDialog.cs#L355) (which meant the modal had it as an anchor - clicking it in the taskbar would bring back the modal.)

(The `Hide();` was actually added [a few days later](https://github.com/bonsai-rx/bonsai/commit/056951053e12623789cc073cfcfa34701f0eaf9b#diff-eb40a67564a701792198596a54fc82b24860459fdff563d7847073dd5420fcf8). Based on the commit I assume the original motivation was to avoid showing the package manager UI suddenly change when the changes are applied? I actually originally assumed it was to avoid having the unmovable/unclickable/frozen dialog when the modal is visible, which is definitely an annoying aspect of modals in the classic Windows modal UI paradigm that this implicitly uses.)