### PR TITLE
Make package source configuration dialog a true modal window

### DIFF
--- a/Bonsai.NuGet.Design/GalleryDialog.cs
+++ b/Bonsai.NuGet.Design/GalleryDialog.cs
@@ -167,12 +167,10 @@ namespace Bonsai.NuGet.Design
 
         private void settingsButton_Click(object sender, EventArgs e)
         {
-            Hide();
             if (packageViewController.ShowPackageSourceConfigurationDialog() == DialogResult.OK)
             {
                 InitializePackageSourceItems();
             }
-            Show();
         }
 
         private void closeButton_Click(object sender, EventArgs e)

--- a/Bonsai.NuGet.Design/PackageManagerDialog.cs
+++ b/Bonsai.NuGet.Design/PackageManagerDialog.cs
@@ -213,12 +213,10 @@ namespace Bonsai.NuGet.Design
 
         private void settingsButton_Click(object sender, EventArgs e)
         {
-            Hide();
             if (packageViewController.ShowPackageSourceConfigurationDialog() == DialogResult.OK)
             {
                 InitializePackageSourceItems();
             }
-            Show();
         }
 
         private void closeButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
Hiding the parent window when launching a modal dialog is a confusing design given that it is both unexpected, and creates a series of annoying side-effects such as hiding the taskbar for the application.

Here we revert the dialog to standard modal behavior.

Fixes #2296 