### PR TITLE
Avoid collapsing WinForms designer files in the PR review UI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,6 +30,9 @@
 *.bonsai text
 *.wxs text
 
+# Prevent GitHub from hiding designer files from PRs
+*.Designer.cs text linguist-generated=false
+
 # Documents
 LICENSE text
 *.md text diff=markdown


### PR DESCRIPTION
By default GitHub collapses designer files in PRs because they're "generated". IMO they don't really count as generated though, and having them collapse makes it easy to overlook changes to the UI.

I finally got annoyed enough to actually read [the documentation](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) (or maybe they recently added the link to collapsed files) and it turns out you can disable the functionality, which this PR does.

If you're not sure what I'm talking about, compare the changes on these two PRs:

* [Before](https://github.com/NgrDavid/bonsai/pull/2/files)
* [After](https://github.com/NgrDavid/bonsai/pull/3/files)

We might also consider just disabling the automatic generated file detection entirely (IE: Applying it to `*` rather than `*.Designer.cs`) as [some of these rules](https://github.com/github-linguist/linguist/blob/2ad529c77a5f001ac4abfa881d9f0490533e3b36/lib/linguist/generated.rb) seem dubious at best. Many of these things shouldn't even be committed in the first place, so seeing the giant diff in a PR would help highlight mistakes.