### PR TITLE
Allow multi-channel data when reading whole files using MatrixReader

### DIFF
--- a/Bonsai.Dsp/MatrixReader.cs
+++ b/Bonsai.Dsp/MatrixReader.cs
@@ -146,7 +146,7 @@ namespace Bonsai.Dsp
                 var bufferLength = BufferLength;
                 if (bufferLength == 0)
                 {
-                    bufferLength = (int)(reader.BaseStream.Length - offset) / depthSize;
+                    bufferLength = (int)(reader.BaseStream.Length - offset) / depthSize / channelCount;
                 }
 
                 byte[] buffer = null;


### PR DESCRIPTION
Buffer length is calculated in samples per channel so we need to divide by channel count to correctly get the number of samples in the whole file.

Fixes #2300 