### PR TITLE
Add issue template for language proposals

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Propose a language idea or ask a question
+    url: https://github.com/orgs/bonsai-rx/discussions
+    about: Starting with discussion is the way to create a new proposal.

--- a/.github/ISSUE_TEMPLATE/proposal-template.md
+++ b/.github/ISSUE_TEMPLATE/proposal-template.md
@@ -1,0 +1,48 @@
+---
+name: Create a language specification
+about: For proposals that have been invited by a team member
+title: 'Feature name'
+labels: proposal
+assignees: ''
+
+---
+
+<!--
+Hello, and thanks for your interest in contributing to the Bonsai language standard! If you haven't been invited by a team member to open an issue, please instead open a discussion marked [proposal] at https://github.com/orgs/bonsai-rx/discussions and we'll try to give you feedback on how to get to an issue-ready proposal.
+
+New specification proposals should aim to fully fill out this template, at least up to and including detailed design. The sections on drawbacks, alternatives and unresolved questions may be omitted from the initial proposal.
+-->
+* [x] Proposed
+* [ ] Prototype: Not Started
+* [ ] Implementation: Not Started
+* [ ] Specification: Not Started
+
+## Summary
+
+<!-- One paragraph explanation of the feature. -->
+
+## Motivation
+
+<!-- Why are we doing this? What use cases does it support? What is the expected outcome? -->
+
+## Detailed Design
+
+<!-- This is the bulk of the proposal. The Bonsai language standard comprises multiple levels including the language itself, the compiler, the editor, package management, visualization, and all associated tooling. Changes to the existing specifications might impact any or all of these levels, so please make sure you have considered the impact of your proposal on all the levels in the detailed design.
+
+Explain the design in enough detail for somebody familiar with the Bonsai language to understand, and for somebody familiar with the impacted levels to implement, and include examples of how the feature will be used. Please include links to relevant parts of the existing specification to describe the changes necessary to implement this feature. An initial proposal does not need to cover all cases, but it should have enough detail to enable a team member to bring this proposal to design if they so choose. -->
+
+## Drawbacks
+
+<!-- Why should we *not* do this? -->
+
+## Alternatives
+
+<!-- What other designs have been considered? What is the impact of not doing this? -->
+
+## Unresolved Questions
+
+<!-- What parts of the design are still undecided? -->
+
+## Design Meetings
+
+<!-- Link to development meetings where this proposal has been discussed. -->


### PR DESCRIPTION
As the language evolves we want to make sure we are both as inclusive as possible, and as structured as possible, so that we do not miss the opportunity to document details of new language features as they are being investigated.

Here we introduce a template for creating language proposals with the goal of helping our language discussion and documentation.

Fixes #1738 