### PR TITLE
Update upstream dependencies

### DIFF
--- a/Bonsai.Configuration.Tests/Bonsai.Configuration.Tests.csproj
+++ b/Bonsai.Configuration.Tests/Bonsai.Configuration.Tests.csproj
@@ -6,10 +6,10 @@
     <EmbeddedResource Include="**\*.bonsai" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Bonsai.Core.Tests/Bonsai.Core.Tests.csproj
+++ b/Bonsai.Core.Tests/Bonsai.Core.Tests.csproj
@@ -6,10 +6,10 @@
     <EmbeddedResource Include="**\*.bonsai" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
+++ b/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
@@ -6,10 +6,10 @@
     <EmbeddedResource Include="**\*.bonsai" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Bonsai.Editor/Bonsai.Editor.csproj
+++ b/Bonsai.Editor/Bonsai.Editor.csproj
@@ -14,10 +14,10 @@
   
   <ItemGroup>
     <PackageReference Include="DockPanelSuite.ThemeVS2015" Version="3.1.1" />
-    <PackageReference Include="SvgNet" Version="3.3.8" />
-    <PackageReference Include="YamlDotNet" Version="16.0.0" />
-    <PackageReference Include="Markdig" Version="0.37.0" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2592.51" />
+    <PackageReference Include="SvgNet" Version="3.5.0" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
+    <PackageReference Include="Markdig" Version="0.41.1" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Bonsai.Editor/Properties/Resources.Designer.cs
+++ b/Bonsai.Editor/Properties/Resources.Designer.cs
@@ -63,7 +63,7 @@ namespace Bonsai.Editor.Properties {
         /// <summary>
         ///   Looks up a localized string similar to {1}
         ///
-        ///{0} includes software and media content from the Reactive Extensions for .NET and the NuGet projects developed at the .NET Foundation (https://dotnetfoundation.org/).
+        ///{0} includes software and media content from the Reactive Extensions for .NET, Source Link, and NuGet projects developed at the .NET Foundation (https://dotnetfoundation.org/).
         ///
         ///Copyright (c) .NET Foundation and Contributors.
         /// </summary>

--- a/Bonsai.NuGet/Bonsai.NuGet.csproj
+++ b/Bonsai.NuGet/Bonsai.NuGet.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.Protocol" Version="6.14.0" />
-    <PackageReference Include="NuGet.Resolver" Version="6.14.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.7.1" />
+    <PackageReference Include="NuGet.Resolver" Version="6.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/Bonsai.NuGet/Bonsai.NuGet.csproj
+++ b/Bonsai.NuGet/Bonsai.NuGet.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.Protocol" Version="6.6.1" />
-    <PackageReference Include="NuGet.Resolver" Version="6.6.1" />
+    <PackageReference Include="NuGet.Protocol" Version="6.14.0" />
+    <PackageReference Include="NuGet.Resolver" Version="6.14.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/Bonsai.System.Tests/Bonsai.System.Tests.csproj
+++ b/Bonsai.System.Tests/Bonsai.System.Tests.csproj
@@ -3,10 +3,10 @@
     <TargetFrameworks>net472;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Bonsai.Vision/LoadExtrinsics.cs
+++ b/Bonsai.Vision/LoadExtrinsics.cs
@@ -17,7 +17,7 @@ namespace Bonsai.Vision
         /// Gets or sets the name of the camera extrinsics file.
         /// </summary>
         [Description("The name of the camera extrinsics file.")]
-        [FileNameFilter("YML Files (*.yml)|*.yml|All Files|*.*")]
+        [FileNameFilter("YAML Files (*.yml;*.yaml)|*.yml;*.yaml|All Files|*.*")]
         [Editor("Bonsai.Design.OpenFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         public string FileName { get; set; }
 

--- a/Bonsai.Vision/LoadIntrinsics.cs
+++ b/Bonsai.Vision/LoadIntrinsics.cs
@@ -17,7 +17,7 @@ namespace Bonsai.Vision
         /// Gets or sets the name of the camera intrinsics file.
         /// </summary>
         [Description("The name of the camera intrinsics file.")]
-        [FileNameFilter("YML Files (*.yml)|*.yml|All Files|*.*")]
+        [FileNameFilter("YAML Files (*.yml;*.yaml)|*.yml;*.yaml|All Files|*.*")]
         [Editor("Bonsai.Design.OpenFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         public string FileName { get; set; }
 

--- a/Bonsai.Vision/SaveExtrinsics.cs
+++ b/Bonsai.Vision/SaveExtrinsics.cs
@@ -16,7 +16,7 @@ namespace Bonsai.Vision
         /// <summary>
         /// Gets or sets the name of the file on which to write the camera extrinsics.
         /// </summary>
-        [FileNameFilter("YML Files (*.yml)|*.yml|All Files|*.*")]
+        [FileNameFilter("YAML Files (*.yml;*.yaml)|*.yml;*.yaml|All Files|*.*")]
         [Editor("Bonsai.Design.SaveFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         [Description("The name of the file on which to write the camera extrinsics.")]
         public string FileName { get; set; }

--- a/Bonsai.Vision/SaveIntrinsics.cs
+++ b/Bonsai.Vision/SaveIntrinsics.cs
@@ -16,7 +16,7 @@ namespace Bonsai.Vision
         /// <summary>
         /// Gets or sets the name of the file on which to write the camera intrinsics.
         /// </summary>
-        [FileNameFilter("YML Files (*.yml)|*.yml|All Files|*.*")]
+        [FileNameFilter("YAML Files (*.yml;*.yaml)|*.yml;*.yaml|All Files|*.*")]
         [Editor("Bonsai.Design.SaveFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         [Description("The name of the file on which to write the camera intrinsics.")]
         public string FileName { get; set; }

--- a/Bonsai/Bonsai.csproj
+++ b/Bonsai/Bonsai.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" PrivateAssets="all" />
-    <PackageReference Include="ILRepack" Version="2.0.34">
+    <PackageReference Include="ILRepack" Version="2.0.42">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -49,15 +49,15 @@
   <!-- Embed System.Resources.Extensions and its dependencies, see Bonsai.SystemResourcesExtensionsSupport -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="System.Resources.Extensions" Version="8.0.0" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="System.Memory" Version="4.5.5" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.Memory" Version="4.6.3" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.Buffers" Version="4.6.1" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.6.1" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" GeneratePathProperty="true" PrivateAssets="all" />
     <EmbeddedResource Include="$(PkgSystem_Resources_Extensions)/lib/net462/System.Resources.Extensions.dll" Visible="false" />
-    <EmbeddedResource Include="$(PkgSystem_Memory)/lib/net461/System.Memory.dll" Visible="false" />
-    <EmbeddedResource Include="$(PkgSystem_Buffers)/lib/net461/System.Buffers.dll" Visible="false" />
-    <EmbeddedResource Include="$(PkgSystem_Numerics_Vectors)/lib/net46/System.Numerics.Vectors.dll" Visible="false" />
-    <EmbeddedResource Include="$(PkgSystem_Runtime_CompilerServices_Unsafe)/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" Visible="false" />
+    <EmbeddedResource Include="$(PkgSystem_Memory)/lib/net462/System.Memory.dll" Visible="false" />
+    <EmbeddedResource Include="$(PkgSystem_Buffers)/lib/net462/System.Buffers.dll" Visible="false" />
+    <EmbeddedResource Include="$(PkgSystem_Numerics_Vectors)/lib/net462/System.Numerics.Vectors.dll" Visible="false" />
+    <EmbeddedResource Include="$(PkgSystem_Runtime_CompilerServices_Unsafe)/lib/net462/System.Runtime.CompilerServices.Unsafe.dll" Visible="false" />
   </ItemGroup>
 
   <Target Name="NuGetConfig" AfterTargets="Build">

--- a/Bonsai32/Bonsai32.csproj
+++ b/Bonsai32/Bonsai32.csproj
@@ -28,6 +28,6 @@
       If you get MSB3277 warnings referencing this or other packages, add explicit references here for the newest
       version referenced by the warning.
     -->
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Here we perform maintenance upstream dependency updates. A few packages were left behind either because of known issues, e.g. WebView2 (https://github.com/MicrosoftEdge/WebView2Feedback/issues/4924), or to avoid moving into .NET 9 runtime packages.

Upgrading YamlDotNet also motivated fixing file name editor extension strings in a few places.