### PR TITLE
Update spelling of open source to match convention

### DIFF
--- a/Bonsai.Audio/README.md
+++ b/Bonsai.Audio/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Audio` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Audio` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Core/README.md
+++ b/Bonsai.Core/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Core` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Core` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Design.Visualizers/README.md
+++ b/Bonsai.Design.Visualizers/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Design.Visualizers` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Design.Visualizers` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Design/README.md
+++ b/Bonsai.Design/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Design` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Design` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Dsp.Design/README.md
+++ b/Bonsai.Dsp.Design/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Dsp.Design` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Dsp.Design` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Dsp/README.md
+++ b/Bonsai.Dsp/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Dsp` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Dsp` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Editor/README.md
+++ b/Bonsai.Editor/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Editor` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Editor` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Osc/README.md
+++ b/Bonsai.Osc/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Osc` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Osc` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Player/README.md
+++ b/Bonsai.Player/README.md
@@ -23,4 +23,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Player` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Player` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Scripting.Expressions.Design/README.md
+++ b/Bonsai.Scripting.Expressions.Design/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Scripting.Expressions.Design` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Scripting.Expressions.Design` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Scripting.Expressions/README.md
+++ b/Bonsai.Scripting.Expressions/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Scripting.Expressions` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Scripting.Expressions` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Shaders.Design/README.md
+++ b/Bonsai.Shaders.Design/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Shaders.Design` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Shaders.Design` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Shaders.Rendering/README.md
+++ b/Bonsai.Shaders.Rendering/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Shaders.Rendering` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Shaders.Rendering` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Shaders/README.md
+++ b/Bonsai.Shaders/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Shaders` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Shaders` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.StarterPack/README.md
+++ b/Bonsai.StarterPack/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.StarterPack` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.StarterPack` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.System.Design/README.md
+++ b/Bonsai.System.Design/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.System.Design` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.System.Design` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.System/README.md
+++ b/Bonsai.System/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.System` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.System` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Templates/README.md
+++ b/Bonsai.Templates/README.md
@@ -28,4 +28,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Templates` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Templates` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Vision.Design/README.md
+++ b/Bonsai.Vision.Design/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Vision.Design` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Vision.Design` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Vision/README.md
+++ b/Bonsai.Vision/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Vision` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Vision` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai.Windows.Input/README.md
+++ b/Bonsai.Windows.Input/README.md
@@ -12,4 +12,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai.Windows.Input` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai.Windows.Input` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).

--- a/Bonsai/README.md
+++ b/Bonsai/README.md
@@ -19,4 +19,4 @@ For additional documentation and examples, refer to the [official Bonsai documen
 
 ## Feedback & Contributing
 
-`Bonsai` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).
+`Bonsai` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/bonsai).


### PR DESCRIPTION
As a compound adjective it should be hyphenated, but not when used as a compound noun in a sentence.