### PR TITLE
Add missing editor default properties

### DIFF
--- a/Bonsai.Shaders/WarpPerspective.cs
+++ b/Bonsai.Shaders/WarpPerspective.cs
@@ -13,6 +13,7 @@ namespace Bonsai.Shaders
     /// for planar projection mapping.
     /// </summary>
     [Combinator]
+    [DefaultProperty(nameof(Destination))]
     [WorkflowElementCategory(ElementCategory.Transform)]
     [Description("Creates a warp perspective transform matrix for planar projection mapping.")]
     public class WarpPerspective

--- a/Bonsai.Vision/CropPolygon.cs
+++ b/Bonsai.Vision/CropPolygon.cs
@@ -11,6 +11,7 @@ namespace Bonsai.Vision
     /// Represents an operator that crops a polygonal region of interest for each
     /// image in the sequence.
     /// </summary>
+    [DefaultProperty(nameof(Regions))]
     [Description("Crops a polygonal region of interest for each image in the sequence.")]
     public class CropPolygon : Transform<IplImage, IplImage>
     {

--- a/Bonsai.Vision/Drawing/CropCanvas.cs
+++ b/Bonsai.Vision/Drawing/CropCanvas.cs
@@ -10,6 +10,7 @@ namespace Bonsai.Vision.Drawing
     /// Represents an operator that crops the active drawing subregion of each
     /// canvas in the sequence.
     /// </summary>
+    [DefaultProperty(nameof(RegionOfInterest))]
     [Description("Crops the active drawing subregion of each canvas in the sequence.")]
     public class CropCanvas : Transform<Canvas, Canvas>
     {

--- a/Bonsai.Vision/GoodFeaturesToTrack.cs
+++ b/Bonsai.Vision/GoodFeaturesToTrack.cs
@@ -10,6 +10,7 @@ namespace Bonsai.Vision
     /// Represents an operator that finds strong corner features for each image
     /// in the sequence.
     /// </summary>
+    [DefaultProperty(nameof(RegionOfInterest))]
     [Description("Finds strong corner features for each image in the sequence.")]
     public class GoodFeaturesToTrack : Transform<IplImage, KeyPointCollection>
     {


### PR DESCRIPTION
Wherever reasonable we want to add default properties to make it easier to launch visual editors from the workflow itself.