### PR TITLE
Rename save workflow extension menu item

### DIFF
--- a/Bonsai.Editor/EditorForm.Designer.cs
+++ b/Bonsai.Editor/EditorForm.Designer.cs
@@ -42,7 +42,7 @@
             this.toolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveAsWorkflowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveAsExtensionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportImageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -219,7 +219,7 @@
             this.toolStripSeparator,
             this.saveToolStripMenuItem,
             this.saveAsToolStripMenuItem,
-            this.saveAsWorkflowToolStripMenuItem,
+            this.saveAsExtensionToolStripMenuItem,
             this.toolStripSeparator6,
             this.exportToolStripMenuItem,
             this.toolStripSeparator1,
@@ -271,15 +271,15 @@
             this.saveAsToolStripMenuItem.Text = "Save &As...";
             this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.saveAsToolStripMenuItem_Click);
             // 
-            // saveAsWorkflowToolStripMenuItem
+            // saveAsExtensionToolStripMenuItem
             // 
-            this.saveAsWorkflowToolStripMenuItem.Enabled = false;
-            this.saveAsWorkflowToolStripMenuItem.Name = "saveAsWorkflowToolStripMenuItem";
-            this.saveAsWorkflowToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+            this.saveAsExtensionToolStripMenuItem.Enabled = false;
+            this.saveAsExtensionToolStripMenuItem.Name = "saveAsExtensionToolStripMenuItem";
+            this.saveAsExtensionToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.S)));
-            this.saveAsWorkflowToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
-            this.saveAsWorkflowToolStripMenuItem.Text = "Save As &Workflow...";
-            this.saveAsWorkflowToolStripMenuItem.Click += new System.EventHandler(this.saveAsWorkflowToolStripMenuItem_Click);
+            this.saveAsExtensionToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
+            this.saveAsExtensionToolStripMenuItem.Text = "Save As &Extension...";
+            this.saveAsExtensionToolStripMenuItem.Click += new System.EventHandler(this.saveAsExtensionToolStripMenuItem_Click);
             // 
             // toolStripSeparator6
             // 
@@ -1592,7 +1592,7 @@
         private System.Windows.Forms.ToolStripButton restartToolStripButton;
         private System.Windows.Forms.ToolStripMenuItem restartToolStripMenuItem;
         private System.Windows.Forms.ToolStripStatusLabel statusImageLabel;
-        private System.Windows.Forms.ToolStripMenuItem saveAsWorkflowToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveAsExtensionToolStripMenuItem;
         private System.Windows.Forms.ContextMenuStrip toolboxContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem insertAfterToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem insertBeforeToolStripMenuItem;

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1188,7 +1188,7 @@ namespace Bonsai.Editor
             }
         }
 
-        private void saveAsWorkflowToolStripMenuItem_Click(object sender, EventArgs e)
+        private void saveAsExtensionToolStripMenuItem_Click(object sender, EventArgs e)
         {
             editorSite.EnsureExtensionsDirectory();
             if (!extensionsPath.Exists) return;
@@ -1683,7 +1683,7 @@ namespace Bonsai.Editor
             var canEdit = selectedView != null && selectedView.CanEdit;
             var hasSelectableObjects = selectedView?.Workflow.Count > 0;
             var hasSelectedObjects = selectedObjects.Length > 0;
-            saveAsWorkflowToolStripMenuItem.Enabled = hasSelectedObjects;
+            saveAsExtensionToolStripMenuItem.Enabled = hasSelectedObjects;
             pasteToolStripMenuItem.Enabled = canEdit;
             copyToolStripMenuItem.Enabled = hasSelectedObjects;
             copyAsImageToolStripMenuItem.Enabled = hasSelectableObjects;
@@ -2719,7 +2719,7 @@ namespace Bonsai.Editor
                 HandleMenuItemShortcutKeys(e, siteForm.saveToolStripMenuItem, siteForm.saveToolStripMenuItem_Click);
                 HandleMenuItemShortcutKeys(e, siteForm.undoToolStripMenuItem, siteForm.undoToolStripMenuItem_Click);
                 HandleMenuItemShortcutKeys(e, siteForm.redoToolStripMenuItem, siteForm.redoToolStripMenuItem_Click);
-                HandleMenuItemShortcutKeys(e, siteForm.saveAsWorkflowToolStripMenuItem, siteForm.saveAsWorkflowToolStripMenuItem_Click);
+                HandleMenuItemShortcutKeys(e, siteForm.saveAsExtensionToolStripMenuItem, siteForm.saveAsExtensionToolStripMenuItem_Click);
                 HandleMenuItemShortcutKeys(e, siteForm.exportImageToolStripMenuItem, siteForm.exportImageToolStripMenuItem_Click);
                 HandleMenuItemShortcutKeys(e, siteForm.copyAsImageToolStripMenuItem, siteForm.copyAsImageToolStripMenuItem_Click);
                 HandleMenuItemShortcutKeys(e, siteForm.startWithoutDebuggingToolStripMenuItem, siteForm.startWithoutDebuggingToolStripMenuItem_Click);

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
@@ -58,7 +58,7 @@
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.groupToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ungroupToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveAsWorkflowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveAsExtensionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this.enableToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.disableToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -97,7 +97,7 @@
             this.toolStripSeparator5,
             this.groupToolStripMenuItem,
             this.ungroupToolStripMenuItem,
-            this.saveAsWorkflowToolStripMenuItem,
+            this.saveAsExtensionToolStripMenuItem,
             this.toolStripSeparator6,
             this.enableToolStripMenuItem,
             this.disableToolStripMenuItem});
@@ -332,15 +332,15 @@
             this.ungroupToolStripMenuItem.Text = "Ungroup";
             this.ungroupToolStripMenuItem.Click += new System.EventHandler(this.ungroupToolStripMenuItem_Click);
             // 
-            // saveAsWorkflowToolStripMenuItem
+            // saveAsExtensionToolStripMenuItem
             // 
-            this.saveAsWorkflowToolStripMenuItem.Enabled = false;
-            this.saveAsWorkflowToolStripMenuItem.Name = "saveAsWorkflowToolStripMenuItem";
-            this.saveAsWorkflowToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+            this.saveAsExtensionToolStripMenuItem.Enabled = false;
+            this.saveAsExtensionToolStripMenuItem.Name = "saveAsExtensionToolStripMenuItem";
+            this.saveAsExtensionToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.S)));
-            this.saveAsWorkflowToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
-            this.saveAsWorkflowToolStripMenuItem.Text = "Save As Workflow...";
-            this.saveAsWorkflowToolStripMenuItem.Click += new System.EventHandler(this.saveAsWorkflowToolStripMenuItem_Click);
+            this.saveAsExtensionToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
+            this.saveAsExtensionToolStripMenuItem.Text = "Save As Extension...";
+            this.saveAsExtensionToolStripMenuItem.Click += new System.EventHandler(this.saveAsExtensionToolStripMenuItem_Click);
             // 
             // toolStripSeparator6
             // 
@@ -427,7 +427,7 @@
         private System.Windows.Forms.ToolStripMenuItem disconnectToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem reconnectToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem defaultEditorToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem saveAsWorkflowToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveAsExtensionToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem ungroupToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem subjectTypeToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1155,9 +1155,9 @@ namespace Bonsai.Editor.GraphView
             LaunchWorkflowView(graphView.SelectedNodes, NavigationPreference.NewWindow);
         }
 
-        private void saveAsWorkflowToolStripMenuItem_Click(object sender, EventArgs e)
+        private void saveAsExtensionToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            editorService.OnKeyDown(new KeyEventArgs(saveAsWorkflowToolStripMenuItem.ShortcutKeys));
+            editorService.OnKeyDown(new KeyEventArgs(saveAsExtensionToolStripMenuItem.ShortcutKeys));
         }
 
         private void cutToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1682,7 +1682,7 @@ namespace Bonsai.Editor.GraphView
             {
                 copyToolStripMenuItem.Enabled = true;
                 toggleWatchToolStripMenuItem.Enabled = true;
-                saveAsWorkflowToolStripMenuItem.Enabled = true;
+                saveAsExtensionToolStripMenuItem.Enabled = true;
                 if (Array.Exists(selectedNodes, node => node.NestedCategory != null))
                 {
                     openNewTabToolStripMenuItem.Visible = true;


### PR DESCRIPTION
To avoid ambiguity with the meaning of **Save As Workflow** we rename the title of the menu item to **Save As Extension**.

Fixes #2356 