### PR TITLE
Fix tooltip for `New` workflow button on toolbar

### DIFF
--- a/Bonsai.Editor/EditorForm.Designer.cs
+++ b/Bonsai.Editor/EditorForm.Designer.cs
@@ -747,7 +747,7 @@
             this.newToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.newToolStripButton.Name = "newToolStripButton";
             this.newToolStripButton.Size = new System.Drawing.Size(23, 22);
-            this.newToolStripButton.Text = "&New (Ctrl+N)";
+            this.newToolStripButton.Text = "&New (Ctrl+Shift+N)";
             this.newToolStripButton.Click += new System.EventHandler(this.newToolStripMenuItem_Click);
             // 
             // openToolStripButton


### PR DESCRIPTION
Still has the old keyboard shortcut rather than the new one.