### PR TITLE
Fix search filter to allow legacy package update

### DIFF
--- a/Bonsai.NuGet/UpdateQuery.cs
+++ b/Bonsai.NuGet/UpdateQuery.cs
@@ -42,9 +42,10 @@ namespace Bonsai.NuGet
         {
             try
             {
-                var localSearchFilter = QueryHelper.CreateSearchFilter(includePrerelease: true, PackageType);
+                var localSearchFilter = QueryHelper.CreateSearchFilter(includePrerelease: true, default);
                 var localPackages = await LocalRepository.SearchAsync(SearchTerm, localSearchFilter, token: token);
-                return QueryResult.Create(await RemoteRepository.GetUpdatesAsync(localPackages, IncludePrerelease, UpdateRange, token));
+                var updateSearchFilter = QueryHelper.CreateSearchFilter(IncludePrerelease, PackageType);
+                return QueryResult.Create(await RemoteRepository.GetUpdatesAsync(localPackages, updateSearchFilter, UpdateRange, token));
             }
             catch (NuGetProtocolException ex)
             {

--- a/Bonsai/Launcher.cs
+++ b/Bonsai/Launcher.cs
@@ -74,18 +74,19 @@ namespace Bonsai
             {
                 try
                 {
-                    var localSearchFilter = QueryHelper.CreateSearchFilter(includePrerelease: true, Constants.LibraryPackageType);
+                    var localSearchFilter = QueryHelper.CreateSearchFilter(includePrerelease: true, default);
                     var localPackages = await packageManager.LocalRepository.SearchAsync(
                         string.Empty,
                         localSearchFilter,
                         token: cancellation.Token);
 
+                    var updateSearchFilter = QueryHelper.CreateSearchFilter(includePrerelease: false, Constants.LibraryPackageType);
                     foreach (var repository in packageManager.SourceRepositoryProvider.GetRepositories())
                     {
                         try
                         {
                             if (cancellation.IsCancellationRequested) break;
-                            var updates = await repository.GetUpdatesAsync(localPackages, includePrerelease: false, token: cancellation.Token);
+                            var updates = await repository.GetUpdatesAsync(localPackages, updateSearchFilter, token: cancellation.Token);
                             if (updates.Any()) return true;
                         }
                         catch { continue; }


### PR DESCRIPTION
The package search resource is the only resource directly supporting package type filtering. We refactor update search using single exact matches against each specific package ID so we can defer filtering and allow legacy packages to update.

Fixes #2339 