### PR TITLE
Modify PropertyMap operator to access nested members

### DIFF
--- a/Bonsai.Core/Expressions/NestedPropertyMappingNode.cs
+++ b/Bonsai.Core/Expressions/NestedPropertyMappingNode.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bonsai.Expressions
+{
+    internal class NestedPropertyMappingNode
+    {
+        public List<NestedPropertyMappingNode> Children { get; } = new List<NestedPropertyMappingNode>();
+        public string Name { get; set; }
+        public string Selector { get; set; }
+
+        internal static List<NestedPropertyMappingNode> BuildNodeTree(PropertyMappingCollection propertyMappings)
+        {
+            List<NestedPropertyMappingNode> tree = new List<NestedPropertyMappingNode>();
+            foreach (var mapping in propertyMappings)
+            {
+                string[] targetPath = mapping.Name.Split(new[] { ExpressionHelper.MemberSeparator }, StringSplitOptions.RemoveEmptyEntries);
+                string selector = mapping.Selector;
+                BuildNodeBranch(tree, targetPath, selector);
+
+            }
+            return tree;
+        }
+
+        internal static void BuildNodeBranch(List<NestedPropertyMappingNode> nodes, string[] targetPath, string selector)
+        {
+            NestedPropertyMappingNode node = nodes.Find(n => n.Name == targetPath[0]);
+            if (node == null)
+            {
+                NestedPropertyMappingNode newNode = new NestedPropertyMappingNode();
+                newNode.Name = targetPath[0];
+                nodes.Add(newNode);
+                if (targetPath.Length > 1)
+                {
+                    BuildNodeBranch(newNode.Children, targetPath.Skip(1).ToArray(), selector);
+                }
+                else //Tip of the branch, this is the member we want to update
+                {
+                    newNode.Selector = selector;
+                }
+
+            }
+            else
+            {
+                if (targetPath.Length == 0 || node.Children.Count != 0)
+                {
+                    //This means that the target member of an assignment has been assigned before
+                    //This should not happen, so we throw an error
+                    throw new InvalidOperationException(string.Format("Trying to assign member {0} more than once", string.Join(".", targetPath)));
+                }
+                else
+                {
+                    BuildNodeBranch(node.Children, targetPath.Skip(1).ToArray(), selector);
+                }
+            }
+        }
+    }
+}

--- a/Bonsai.Core/Expressions/PropertyMapping.cs
+++ b/Bonsai.Core/Expressions/PropertyMapping.cs
@@ -38,7 +38,9 @@ namespace Bonsai.Expressions
         /// Gets or sets the name of the property that will be assigned by this mapping.
         /// </summary>
         [XmlAttribute]
-        [TypeConverter(typeof(PropertyMappingNameConverter))]
+        //[TypeConverter(typeof(PropertyMappingNameConverter))]
+        [DefaultValue("")]
+        [Editor("Bonsai.Design.TypeMemberSelectorEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         [Description("The name of the property that will be assigned by this mapping.")]
         public string Name { get; set; }
 

--- a/Bonsai.Core/Expressions/PropertyMapping.cs
+++ b/Bonsai.Core/Expressions/PropertyMapping.cs
@@ -38,7 +38,6 @@ namespace Bonsai.Expressions
         /// Gets or sets the name of the property that will be assigned by this mapping.
         /// </summary>
         [XmlAttribute]
-        //[TypeConverter(typeof(PropertyMappingNameConverter))]
         [DefaultValue("")]
         [Editor("Bonsai.Design.TypeMemberSelectorEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         [Description("The name of the property that will be assigned by this mapping.")]

--- a/Bonsai.Core/Expressions/PropertyMappingBuilder.cs
+++ b/Bonsai.Core/Expressions/PropertyMappingBuilder.cs
@@ -64,11 +64,12 @@ namespace Bonsai.Expressions
         internal virtual bool BuildArgument(Expression source, Edge<ExpressionBuilder, ExpressionBuilderArgument> successor, out Expression argument)
         {
             argument = source;
+            var nodeTree = NestedPropertyMappingNode.BuildNodeTree(PropertyMappings);
             var workflowElement = GetWorkflowElement(successor.Target.Value);
             var instance = Expression.Constant(workflowElement);
-            foreach (var mapping in PropertyMappings)
+            foreach (var node in nodeTree)
             {
-                argument = BuildPropertyMapping(argument, instance, mapping.Name, mapping.Selector);
+                argument = BuildNestedPropertyMapping(argument, instance, node.Name, node);
             }
 
             return false;

--- a/Bonsai.Design/ExternalizedPropertyInfo.cs
+++ b/Bonsai.Design/ExternalizedPropertyInfo.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Bonsai.Expressions;
+
+namespace Bonsai.Design
+{
+    internal class ExternalizedPropertyInfo : MemberInfo, IExtendedVisitableMemberInfo
+    {
+        readonly ExternalizedPropertyDescriptor property;
+        internal ExternalizedPropertyInfo(ExternalizedPropertyDescriptor property)
+        {
+            this.property = property;
+        }
+        public override string Name => property.Name;
+
+        public Type ExtendedVisitableMemberType => property.PropertyType;
+
+        public override Type DeclaringType => property.ComponentType;
+
+        public override Type ReflectedType => property.ComponentType;
+
+        public override MemberTypes MemberType => MemberTypes.Custom;
+
+        public override object[] GetCustomAttributes(bool inherit)
+        {
+            return property.Attributes.Cast<Attribute>().ToArray();
+        }
+        public override object[] GetCustomAttributes(Type attributeType, bool inherit)
+        {
+            return property.Attributes.Cast<Attribute>().Where(attributeType.IsInstanceOfType).ToArray();
+        }
+        public override bool IsDefined(Type attributeType, bool inherit)
+        {
+            return property.Attributes.Cast<Attribute>().Any(attributeType.IsInstanceOfType);
+        }
+
+        public override int MetadataToken => 0;
+
+
+
+    }
+}

--- a/Bonsai.Design/IExtendedVisitableMemberInfo.cs
+++ b/Bonsai.Design/IExtendedVisitableMemberInfo.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bonsai.Design
+{
+    internal interface IExtendedVisitableMemberInfo
+    {
+        Type ExtendedVisitableMemberType { get; }
+    }
+}

--- a/Bonsai.Design/IExtendedVisitableType.cs
+++ b/Bonsai.Design/IExtendedVisitableType.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bonsai.Design
+{
+    internal interface IExtendedVisitableType
+    {
+        IEnumerable<MemberInfo> GetExtendedMembers();
+        MemberInfo GetExtendedMember(string name);
+    }
+}

--- a/Bonsai.Design/MemberCollection.cs
+++ b/Bonsai.Design/MemberCollection.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Bonsai.Design
+{
+    /// <summary>
+    /// Allows to create an emulated type with a custom list of members.
+    /// This is useful for editors that show list of members and accept a Type parameter
+    /// </summary>
+    internal class MemberCollection : TypeDelegator, IExtendedVisitableType
+    {
+        /// <summary>
+        /// Represents a member on the emulated type
+        /// </summary>
+        public class MemberCollectionElement
+        {
+            /// <summary>
+            /// True if the member should be treated as non public, false otherwise
+            /// </summary>
+            public bool IsNonPublic { get; }
+            /// <summary>
+            /// True if the member should be treated as static, false otherwise
+            /// </summary>
+            public bool IsStatic { get; }
+            /// <summary>
+            /// The <see cref="MemberInfo"/> that this object represents
+            /// </summary>
+            public MemberInfo Member { get; }
+            /// <summary>
+            /// Creates an instance of <see cref="MemberCollectionElement"/>
+            /// </summary>
+            /// <param name="member">The <see cref="MemberInfo"/> that this object represents</param>
+            /// <param name="isNonPublic">True if the member should be treated as non public, false otherwise</param>
+            /// <param name="isStatic">True if the member should be treated as static, false otherwise</param>
+            public MemberCollectionElement (MemberInfo member, bool isNonPublic = false, bool isStatic = false)
+            {
+                IsNonPublic = isNonPublic;
+                IsStatic = isStatic;    
+                Member = member;
+            }
+        }
+
+        readonly IReadOnlyList<MemberCollectionElement> members;
+        readonly string name;
+
+        ///<inheritdoc/>
+        public override string Name => name;
+        ///<inheritdoc/>
+        public override string FullName => name;
+        ///<inheritdoc/>
+        public override string Namespace => null;
+
+
+        /// <summary>
+        /// Creates an instance of <see cref="MemberCollection"/> from a list of <see cref="MemberCollectionElement"/>
+        /// Members must be properties or fields
+        /// </summary>
+        /// <param name="members">List of <see cref="MemberCollectionElement"/> representing the members of the emulated type</param>
+        /// <param name="name">Name of the emulated type</param>
+        /// <param name="fullName">Fully qualified name of the emulated type</param>
+        /// <exception cref="ArgumentException">Throws if members contain others than proeprties or fields</exception>
+        public MemberCollection(IEnumerable<MemberCollectionElement> members, string name) : base(typeof(object))
+        {
+            if (members.Any((m) => !(m.Member is PropertyInfo || m.Member is FieldInfo || m.Member is IExtendedVisitableMemberInfo)))
+            {
+                throw new ArgumentException("Only Properties and Fields are supported", nameof(members));
+            }
+            this.members = members.ToArray();
+            this.name = name;
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="MemberCollection"/> from a list of <see cref="MemberInfo"/>
+        /// Members must be properties or fields
+        /// All memebers are set as instanced and public
+        /// </summary>
+        /// <param name="members">List of <see cref="MemberInfo"/> representing the members of the emulated type</param>
+        /// <param name="name">Name of the emulated type</param>
+        /// <param name="fullName">Fully qualified name of the emulated type</param>
+        /// <exception cref="ArgumentException">Throws if members contain others than proeprties or fields</exception>
+        public MemberCollection(IEnumerable<MemberInfo> members, string name)
+            : this(members.Select(m => new MemberCollectionElement(m)), name) { }
+        
+        ///<inheritdoc/>
+        public override PropertyInfo[] GetProperties(BindingFlags bindingAttr)
+        {
+            return members.Where(m => m.Member is PropertyInfo && CheckBindingFlags(m, bindingAttr)).Select(m => (PropertyInfo)m.Member).ToArray();
+        }
+
+        ///<inheritdoc/>
+        public override FieldInfo[] GetFields(BindingFlags bindingAttr)
+        {
+            return members.Where(m => m.Member is FieldInfo && CheckBindingFlags(m, bindingAttr)).Select(m => (FieldInfo)m.Member).ToArray();
+        }
+
+        protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers)
+        {
+            StringComparer comparer = (bindingAttr & BindingFlags.IgnoreCase) != 0 ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+            return (from member in members where member.Member is PropertyInfo
+                   let p = (PropertyInfo)member.Member
+                   where comparer.Equals(p.Name, name) && CheckBindingFlags(member, bindingAttr)
+                   select p).FirstOrDefault();
+        }
+
+        ///<inheritdoc/>
+        public override FieldInfo GetField(string name, BindingFlags bindingAttr)
+        {
+            StringComparer comparer = (bindingAttr & BindingFlags.IgnoreCase) != 0 ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+            return (from member in members
+                    where member.Member is FieldInfo
+                    let f = (FieldInfo)member.Member
+                    where comparer.Equals(f.Name, name) && CheckBindingFlags(member, bindingAttr)
+                    select f).FirstOrDefault();
+        }
+
+        ///<inheritdoc/>
+        public override MemberInfo[] GetDefaultMembers()
+        {
+            return Array.Empty<MemberInfo>();
+        }
+
+
+        static bool CheckBindingFlags(MemberCollectionElement member, BindingFlags flags)
+        {
+            if ((flags & BindingFlags.Public) != 0 && member.IsNonPublic) return false;
+            if ((flags & BindingFlags.NonPublic) != 0 && !member.IsNonPublic) return false;
+            if ((flags & BindingFlags.Instance) != 0 && member.IsStatic) return false;
+            if ((flags & BindingFlags.Static) != 0 && !member.IsStatic) return false;
+            return true;
+        }
+
+        public IEnumerable<MemberInfo> GetExtendedMembers()
+        {
+            return members.Where(m => m.Member is IExtendedVisitableMemberInfo).Select(m => m.Member);
+        }
+
+        public MemberInfo GetExtendedMember(string name)
+        {
+            return members.Where(m => m.Member is IExtendedVisitableMemberInfo && m.Member.Name == name).Select(m => m.Member).FirstOrDefault();
+        }
+    }
+}

--- a/Bonsai.Design/TypeMemberSelectorEditor.cs
+++ b/Bonsai.Design/TypeMemberSelectorEditor.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bonsai.Expressions;
+
+namespace Bonsai.Design
+{
+    /// <summary>
+    /// Provides a user interface editor that displays a dialog for selecting
+    /// members of an operator type.
+    /// </summary>
+    public class TypeMemberSelectorEditor : MemberSelectorEditor
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TypeMemberSelectorEditor"/> class.
+        /// </summary>
+        TypeMemberSelectorEditor() : base(false, false)
+        { }
+
+
+    }
+}

--- a/Bonsai.Design/TypeVisitor.cs
+++ b/Bonsai.Design/TypeVisitor.cs
@@ -37,6 +37,17 @@ namespace Bonsai.Design
             {
                 visitor(property, property.PropertyType);
             }
+
+            if (type is IExtendedVisitableType extendedType)
+            {
+                foreach (var member in extendedType.GetExtendedMembers())
+                {
+                    if (member is IExtendedVisitableMemberInfo extendedMemberInfo)
+                    {
+                        visitor(member, extendedMemberInfo.ExtendedVisitableMemberType);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Modifies the PropertyMap operator so it can be used to set inner members instead of just top-level properties of nodes, addressing #1879.

The Expression Builder creates a recursive assignment until it reaches the target member. For each intermediate type, it either does immediate asignment for reference types, or does a copy-modify-copyback for value types. We discussed these workings on the Dev Club meeting.

The editor for selecting the target property was more challenging than I thought, and I would like some feedback on it, as I am not sure I went through the best approach.

The issues is as following: The `MemberSelectorEditor` creates a dialog of class `MemberSelectorEditorDialog` which, in turn, creates a `MemberSelectorEditorController` which creates the actual tree view from a `Type`

This works with little modification from a normal object, i.e., directly interfacing with a single operator object. It gets complicated in the following two scenarios:
1. When the PropertyMapper is connected to several nodes. The common behavior for NameConverters in similar situations (and the previous behavior of the mapper) is to allow selection only of those properties that are common to all successors, so a custom list must be made.
2. When the PropertyMapper is connected to an encapsulated workflow with externalized properties, as this is no longer a Type.

I decided against adding multiple cases to `MemberSelectorEditorController` which would have had to be propagated, seemed too muddy. What I did is create a `MemberCollection` class inheriting from `TypeDelegator` which allows me to return an arbitrary list of `PropertyInfo` or  `FieldInfo` objects when asked, so I could store the custom list and pass that object as  `Type`

This solves issue number 1, but not completely 2. Externalized properties use component model `PropertyDescriptor`, however the controller is heavily designed towards using reflection so they cannot be used directly. My solution for this, which I am not sure is the best option, is to create a class deriving from `MemberInfo` which includes the type and name of these properties and add some extra logic to `TypeVisitor` to get them from types that implement these custom info objects. Originally I tried just creating a `PropertyInfo` object from the `PropertyDesciptor` but it cannot be fully mapped and, since only name and type are required by the editor, decided to go towards a simpler object even if it required some extra logic than creating an incomplete and potentially dangerous object.

A perhaps better approach would be if there were a way to obtain the underlying real property that an externalized property represents, but I admit I am not familiar enough yet with the workings of the workflow graph to get it properly. Also, while `PropertyDescriptor` has a `ComponentType` that points to the underlying type exposing the original property, and reflection could be used to get its `ProeprtyInfo`, the issue arises when the externalized property has a custom name. When this happens, the original property name is lost, at least through the public interface. If it were possible to add a way for `ExternalizedPropertyDescriptor` to get the original name, we could just use reflection to get the `PropertyInfo`, which would make things easier.

In any case, I welcome any and all advice on any potential changes to the editor code, or any other code.

Also, my naming sense for classes is terrible, so any suggestions on name changes or XMLcomments changes will be appreciated.
