### PR TITLE
Implement `TryGetValue` operator

### DIFF
--- a/Bonsai.Core/Expressions/TryGetValue.cs
+++ b/Bonsai.Core/Expressions/TryGetValue.cs
@@ -11,7 +11,7 @@ namespace Bonsai.Expressions
     /// Represents an expression builder for an operator that determines the existence of a specific key,
     /// and returns its value, if it exists.
     /// </summary>
-    [XmlType("Value", Namespace = Constants.XmlNamespace)]
+    [XmlType("TryGetValue", Namespace = Constants.XmlNamespace)]
     [Description("Applies an operator to an observable sequence, that determines the existence of a specific key, and returns its value, if it exists.")]
     public class TryGetValue : BinaryOperatorBuilder
     {
@@ -68,43 +68,49 @@ namespace Bonsai.Expressions
         /// <param name="left">The left input parameter.</param>
         /// <param name="right">The right input parameter.</param>
         /// <returns>
-        /// The <see cref="Expression"/> that applies an index operator to
+        /// The <see cref="Expression"/> that applies a TryGetValue operation to
         /// the left and right parameters.
         /// </returns>
         protected override Expression BuildSelector(Expression left, Expression right)
         {
-            MethodInfo containsKeyMethod =
-                left.Type.GetMethod("ContainsKey", new[] { right.Type });
+            // We could grab the TryGetValue method directly, but we need the indexer type anyway
+            PropertyInfo indexer = left.Type.GetProperty("Item", new[] { right.Type });
 
-            PropertyInfo indexer =
-                left.Type.GetProperty("Item", new[] { right.Type });
-
-            if (containsKeyMethod == null || indexer == null)
+            if (indexer == null)
             {
                 throw new Exception(
-                    $"Type {left.Type.Name} does not support ContainsKey({right.Type.Name}) with an indexer"
+                    $"Type {left.Type.Name} does not support indexing with {right.Type.Name}"
                 );
             }
 
             var valueType = indexer.PropertyType;
 
+            MethodInfo tryGetValueMethod = left.Type.GetMethod(
+                "TryGetValue",
+                new[] { right.Type, valueType.MakeByRefType() }
+            );
+
+            if (tryGetValueMethod == null)
+            {
+                throw new Exception(
+                    $"Type {left.Type.Name} does not support TryGetValue({right.Type.Name}, out {valueType.Name})"
+                );
+            }
+
             var outputTupleType = typeof(Tuple<,>).MakeGenericType(typeof(bool), valueType);
             var outputConstructor = outputTupleType.GetConstructor(new[] { typeof(bool), valueType });
 
+            var valueVariable = Expression.Variable(valueType, "value");
 
-            return Expression.Condition(
-                Expression.Call(left, containsKeyMethod, right),
-                MakeTuple(outputConstructor, Expression.Constant(true), Expression.Property(left, indexer, right)),
-                MakeTuple(outputConstructor, Expression.Constant(false), Expression.Default(valueType))
+            return Expression.Block(
+                outputTupleType,
+                new[] { valueVariable },
+                Expression.New(
+                    outputConstructor,
+                    Expression.Call(left, tryGetValueMethod, right, valueVariable),
+                    valueVariable
+                )
             );
-        }
-
-        private static Expression MakeTuple(
-            ConstructorInfo constructor,
-            Expression resultFlag,
-            Expression outputValue)
-        {
-            return Expression.New(constructor, resultFlag, outputValue);
         }
     }
 }

--- a/Bonsai.Core/Expressions/TryGetValue.cs
+++ b/Bonsai.Core/Expressions/TryGetValue.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Xml.Serialization;
+using Bonsai.Properties;
+
+namespace Bonsai.Expressions
+{
+    /// <summary>
+    /// Represents an expression builder for an operator that determines the existance of a specific key,
+    /// and returns its value, if it exists.
+    /// </summary>
+    [XmlType("Value", Namespace = Constants.XmlNamespace)]
+    [Description("Applies an operator to an observable sequence, that determines the existance of a specific key, and returns its value, if it exists.")]
+    public class TryGetValue : BinaryOperatorBuilder
+    {
+        /// <summary>
+        /// Returns the expression that maps the specified input parameter to the selector result.
+        /// </summary>
+        /// <param name="expression">The input parameter to the selector.</param>
+        /// <returns>
+        /// The <see cref="Expression"/> that maps the input parameter to the
+        /// selector result.
+        /// </returns>
+        protected override Expression BuildSelector(Expression expression)
+        {
+            Expression left, right;
+            var expressionTypeDefinition = expression.Type.IsGenericType ? expression.Type.GetGenericTypeDefinition() : null;
+            if (expressionTypeDefinition == typeof(Tuple<,>))
+            {
+                Operand = null;
+                left = ExpressionHelper.MemberAccess(expression, "Item1");
+                right = ExpressionHelper.MemberAccess(expression, "Item2");
+                return BuildSelector(left, right);
+            }
+            else
+            {
+                var operand = Operand;
+                var operandType = ExpressionHelper.GetIndexerTypes(expression, 1)[0];
+                if (operand == null || operand.PropertyType != operandType)
+                {
+                    var propertyType = GetWorkflowPropertyType(operandType);
+                    try
+                    {
+                        Operand = operand = (WorkflowProperty)Activator.CreateInstance(propertyType);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new InvalidOperationException(
+                            string.Format(Resources.Exception_UnsupportedMinArgumentCount, 2),
+                            ex);
+                    }
+                }
+
+                left = expression;
+                var operandExpression = Expression.Constant(operand);
+                right = ExpressionHelper.Property(operandExpression, "Value");
+            }
+
+            return BuildSelector(left, right);
+        }
+
+        /// <summary>
+        /// Returns the expression that applies the operator to
+        /// the left and right parameters.
+        /// </summary>
+        /// <param name="left">The left input parameter.</param>
+        /// <param name="right">The right input parameter.</param>
+        /// <returns>
+        /// The <see cref="Expression"/> that applies an index operator to
+        /// the left and right parameters.
+        /// </returns>
+        protected override Expression BuildSelector(Expression left, Expression right)
+        {
+            MethodInfo containsKeyMethod =
+                left.Type.GetMethod("ContainsKey", new[] { right.Type });
+
+            PropertyInfo indexer =
+                left.Type.GetProperty("Item", new[] { right.Type });
+
+            if (containsKeyMethod == null || indexer == null)
+            {
+                throw new Exception(
+                    $"Type {left.Type.Name} does not support ContainsKey({right.Type.Name}) with an indexer"
+                );
+            }
+
+            var valueType = indexer.PropertyType;
+
+            var outputTupleType = typeof(Tuple<,>).MakeGenericType(typeof(bool), valueType);
+            var outputConstructor = outputTupleType.GetConstructor(new[] { typeof(bool), valueType });
+
+
+            return Expression.Condition(
+                Expression.Call(left, containsKeyMethod, right),
+                MakeTuple(outputConstructor, Expression.Constant(true), Expression.Property(left, indexer, right)),
+                MakeTuple(outputConstructor, Expression.Constant(false), Expression.Default(valueType))
+            );
+        }
+
+        private static Expression MakeTuple(
+            ConstructorInfo constructor,
+            Expression resultFlag,
+            Expression outputValue)
+        {
+            return Expression.New(constructor, resultFlag, outputValue);
+        }
+    }
+}

--- a/Bonsai.Core/Expressions/TryGetValue.cs
+++ b/Bonsai.Core/Expressions/TryGetValue.cs
@@ -8,11 +8,11 @@ using Bonsai.Properties;
 namespace Bonsai.Expressions
 {
     /// <summary>
-    /// Represents an expression builder for an operator that determines the existance of a specific key,
+    /// Represents an expression builder for an operator that determines the existence of a specific key,
     /// and returns its value, if it exists.
     /// </summary>
     [XmlType("Value", Namespace = Constants.XmlNamespace)]
-    [Description("Applies an operator to an observable sequence, that determines the existance of a specific key, and returns its value, if it exists.")]
+    [Description("Applies an operator to an observable sequence, that determines the existence of a specific key, and returns its value, if it exists.")]
     public class TryGetValue : BinaryOperatorBuilder
     {
         /// <summary>

--- a/Bonsai.Core/Expressions/TryGetValueBuilder.cs
+++ b/Bonsai.Core/Expressions/TryGetValueBuilder.cs
@@ -13,7 +13,7 @@ namespace Bonsai.Expressions
     /// </summary>
     [XmlType("TryGetValue", Namespace = Constants.XmlNamespace)]
     [Description("Applies an operator to an observable sequence, that determines the existence of a specific key, and returns its value, if it exists.")]
-    public class TryGetValue : BinaryOperatorBuilder
+    public class TryGetValueBuilder : BinaryOperatorBuilder
     {
         /// <summary>
         /// Returns the expression that maps the specified input parameter to the selector result.


### PR DESCRIPTION
This PR attempts to close #1829 

As per the discussion in the original post, a new operator was added that implements the functionality of the [Dictionary<TKey, TValue>.TryGetValue](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.trygetvalue?view=net-10.0) method. 

In order to implement the functionality corresponding to `out Value`, the output of this operator is of type `Tuple<bool, TValue>`. The first element will represent whether the key exists or not (using `ContainsKey` method via reflection), and the value will be fetched. In cases where the key does not exist, the default constructor will be used instead.

A few open questions:

- For ref types, the default constructor is ok since it will return "null", for value types, we will return the default instead of the corresponding nullable type. I think this preferred than to build the nullable type.

- I believe it would be better to call the "Value", "Key" to make it identical to the c# docs, but I couldnt find a way to override the property name
