### PR TITLE
Add --debug flag to enable headless debugger

### DIFF
--- a/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
+++ b/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
@@ -3,9 +3,9 @@
     <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="**\*.bonsai">
+    <EmbeddedResource Include="**\*.bonsai">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />

--- a/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
+++ b/Bonsai.Editor.Tests/Bonsai.Editor.Tests.csproj
@@ -3,7 +3,9 @@
     <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Include="**\*.bonsai" />
+    <Content Include="**\*.bonsai">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />

--- a/Bonsai.Editor.Tests/EditorHelper.cs
+++ b/Bonsai.Editor.Tests/EditorHelper.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Xml;
 using Bonsai.Editor.GraphModel;
 using Bonsai.Expressions;
 
@@ -10,27 +8,6 @@ namespace Bonsai.Editor.Tests
 {
     static class EditorHelper
     {
-        static Stream LoadEmbeddedResource(string name)
-        {
-            var qualifierType = typeof(WorkflowEditorTests);
-            var embeddedWorkflowStream = qualifierType.Namespace + "." + name;
-            return qualifierType.Assembly.GetManifestResourceStream(embeddedWorkflowStream);
-        }
-
-        internal static WorkflowBuilder LoadEmbeddedWorkflow(string name)
-        {
-            using var workflowStream = LoadEmbeddedResource(name);
-            using var reader = XmlReader.Create(workflowStream);
-            return ElementStore.LoadWorkflow(reader);
-        }
-
-        internal static void SaveEmbeddedResource(string name, string fileName)
-        {
-            using var resourceStream = LoadEmbeddedResource(name);
-            using var fileStream = File.Create(fileName);
-            resourceStream.CopyTo(fileStream);
-        }
-
         static ExpressionBuilder CreateBuilder(string name)
         {
             var nestedGraph = new ExpressionBuilderGraph();

--- a/Bonsai.Editor.Tests/IncludeEmbeddedWorkflowBuildException.bonsai
+++ b/Bonsai.Editor.Tests/IncludeEmbeddedWorkflowBuildException.bonsai
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.5"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.Editor.Tests:NestedWorkflowBuildException.bonsai">
+      </Expression>
+    </Nodes>
+    <Edges />
+  </Workflow>
+</WorkflowBuilder>

--- a/Bonsai.Editor.Tests/IncludeEmbeddedWorkflowRuntimeException.bonsai
+++ b/Bonsai.Editor.Tests/IncludeEmbeddedWorkflowRuntimeException.bonsai
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.5"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.Editor.Tests:NestedWorkflowRuntimeException.bonsai">
+      </Expression>
+    </Nodes>
+    <Edges />
+  </Workflow>
+</WorkflowBuilder>

--- a/Bonsai.Editor.Tests/IncludeWorkflowBuildException.bonsai
+++ b/Bonsai.Editor.Tests/IncludeWorkflowBuildException.bonsai
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.5"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="IncludeWorkflow" Path="NestedWorkflowBuildException.bonsai">
+      </Expression>
+    </Nodes>
+    <Edges />
+  </Workflow>
+</WorkflowBuilder>

--- a/Bonsai.Editor.Tests/IncludeWorkflowRuntimeException.bonsai
+++ b/Bonsai.Editor.Tests/IncludeWorkflowRuntimeException.bonsai
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.5"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="IncludeWorkflow" Path="NestedWorkflowRuntimeException.bonsai">
+      </Expression>
+    </Nodes>
+    <Edges />
+  </Workflow>
+</WorkflowBuilder>

--- a/Bonsai.Editor.Tests/NestedWorkflowBuildException.bonsai
+++ b/Bonsai.Editor.Tests/NestedWorkflowBuildException.bonsai
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.5"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Timer">
+          <rx:DueTime>PT0S</rx:DueTime>
+          <rx:Period>PT0S</rx:Period>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>NestedGroup</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+                <Name>GlobalSubject</Name>
+            </Expression>
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/Bonsai.Editor.Tests/NestedWorkflowRuntimeException.bonsai
+++ b/Bonsai.Editor.Tests/NestedWorkflowRuntimeException.bonsai
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.5"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Timer">
+          <rx:DueTime>PT0S</rx:DueTime>
+          <rx:Period>PT0S</rx:Period>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>NestedGroup</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="Divide">
+              <Operand xsi:type="WorkflowProperty" TypeArguments="sys:Int64">
+                <Value>0</Value>
+              </Operand>
+            </Expression>
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/Bonsai.Editor.Tests/WorkflowEditorDefinitionTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorDefinitionTests.cs
@@ -9,7 +9,7 @@ namespace Bonsai.Editor.Tests
         [TestMethod]
         public void GetSubjectDefinition_NestedSubscribeSubject_ReturnsClosestDefinition()
         {
-            var workflowBuilder = EditorHelper.LoadEmbeddedWorkflow("NestedSubscribeSubjectWithClosestRedefinition.bonsai");
+            var workflowBuilder = ElementStore.LoadWorkflow("NestedSubscribeSubjectWithClosestRedefinition.bonsai");
             var deferBuilder = workflowBuilder.Workflow.FindExpressionBuilder<Defer>();
             Assert.IsNotNull(deferBuilder);
             var selectManyBuilder = deferBuilder.Workflow.FindExpressionBuilder<SelectMany>();

--- a/Bonsai.Editor.Tests/WorkflowEditorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowEditorTests.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Xml;
 using Bonsai.Core.Tests;
 using Bonsai.Dag;
 using Bonsai.Editor.GraphModel;
@@ -87,7 +85,7 @@ namespace Bonsai.Editor.Tests
         [TestMethod]
         public void ReorderGraphNode_DanglingBranchWithPredecessors_KeepPredecessorEdges()
         {
-            var workflowBuilder = EditorHelper.LoadEmbeddedWorkflow("ReorderDanglingBranchWithPredecessors.bonsai");
+            var workflowBuilder = ElementStore.LoadWorkflow("ReorderDanglingBranchWithPredecessors.bonsai");
             var (editor, assertIsReversible) = CreateMockEditor(workflowBuilder.Workflow);
 
             var branchLead = editor.Workflow[2];
@@ -107,7 +105,7 @@ namespace Bonsai.Editor.Tests
         [TestMethod]
         public void ReorderGraphNode_ComponentWithHigherIndexIntoLowerIndex_ReorderComponentNodes()
         {
-            var workflowBuilder = EditorHelper.LoadEmbeddedWorkflow("ReorderComponentWithHigherIndexIntoLowerIndex.bonsai");
+            var workflowBuilder = ElementStore.LoadWorkflow("ReorderComponentWithHigherIndexIntoLowerIndex.bonsai");
             var (editor, assertIsReversible) = CreateMockEditor(workflowBuilder.Workflow);
 
             // reorder D onto C
@@ -124,7 +122,7 @@ namespace Bonsai.Editor.Tests
         [TestMethod]
         public void ConnectGraphNode_ComponentWithHigherIndexIntoLowerIndex_ReorderComponentNodes()
         {
-            var workflowBuilder = EditorHelper.LoadEmbeddedWorkflow("ConnectComponentWithHigherIndexIntoLowerIndex.bonsai");
+            var workflowBuilder = ElementStore.LoadWorkflow("ConnectComponentWithHigherIndexIntoLowerIndex.bonsai");
             var (editor, assertIsReversible) = CreateMockEditor(workflowBuilder.Workflow);
 
             // connect D onto C

--- a/Bonsai.Editor.Tests/WorkflowExporterTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowExporterTests.cs
@@ -10,7 +10,6 @@ namespace Bonsai.Editor.Tests
     {
         static void ExportImage(string fileName)
         {
-            EditorHelper.SaveEmbeddedResource(fileName, fileName);
             try
             {
                 WorkflowExporter.ExportImage(fileName, Path.ChangeExtension(fileName, ".svg"));

--- a/Bonsai.Editor.Tests/WorkflowRunnerTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowRunnerTests.cs
@@ -17,8 +17,8 @@ namespace Bonsai.Editor.Tests
         public void Run_NestedWorkflowException_ErrorMessageIncludesLineNumbers(string fileName, string nestedPath)
         {
             var output = RunAndCaptureError(fileName);
-            StringAssert.Matches(output, new Regex($@"at .+ in {Regex.Escape(fileName)}:line \d+"));
             StringAssert.Matches(output, new Regex($@"at .+ in {Regex.Escape(nestedPath)}:line \d+"));
+            StringAssert.Matches(output, new Regex($@"at .+ in {Regex.Escape(fileName)}:line \d+"));
         }
 
         static string RunAndCaptureError(string fileName)

--- a/Bonsai.Editor.Tests/WorkflowRunnerTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowRunnerTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Editor.Tests
+{
+    [TestClass]
+    [DoNotParallelize]
+    public class WorkflowRunnerTests
+    {
+        [TestMethod]
+        [DataRow("IncludeWorkflowBuildException.bonsai", "NestedWorkflowBuildException.bonsai")]
+        [DataRow("IncludeWorkflowRuntimeException.bonsai", "NestedWorkflowRuntimeException.bonsai")]
+        [DataRow("IncludeEmbeddedWorkflowBuildException.bonsai", "Bonsai.Editor.Tests:NestedWorkflowBuildException.bonsai")]
+        [DataRow("IncludeEmbeddedWorkflowRuntimeException.bonsai", "Bonsai.Editor.Tests:NestedWorkflowRuntimeException.bonsai")]
+        public void Run_NestedWorkflowException_ErrorMessageIncludesLineNumbers(string fileName, string nestedPath)
+        {
+            var output = RunAndCaptureError(fileName);
+            StringAssert.Matches(output, new Regex($@"at .+ in {Regex.Escape(fileName)}:line \d+"));
+            StringAssert.Matches(output, new Regex($@"at .+ in {Regex.Escape(nestedPath)}:line \d+"));
+        }
+
+        static string RunAndCaptureError(string fileName)
+        {
+            var originalError = Console.Error;
+            var writer = new StringWriter();
+            Console.SetError(writer);
+            try
+            {
+                WorkflowRunner.Run(fileName, new(), visualizerProvider: null);
+            }
+            finally
+            {
+                Console.SetError(originalError);
+            }
+            return writer.ToString();
+        }
+    }
+}

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -1472,8 +1472,7 @@ namespace Bonsai.Editor
             else
             {
                 using var shutdown = Interlocked.Exchange(ref building, null);
-                if (e is WorkflowException workflowException && workflowException.Builder != null ||
-                    exceptionCache.TryGetValue(e, out workflowException))
+                if (exceptionCache.TryGetWorkflowException(e, out var workflowException))
                 {
                     workflowError = workflowException;
                     HighlightExceptionBuilderNode(workflowException, showMessageBox: shutdown != null);

--- a/Bonsai.Editor/GraphModel/UpgradeHelper.cs
+++ b/Bonsai.Editor/GraphModel/UpgradeHelper.cs
@@ -57,7 +57,7 @@ namespace Bonsai.Editor.GraphModel
             }
         }
 
-        static Stream GetWorkflowStream(string path)
+        internal static Stream GetWorkflowStream(string path)
         {
             //TODO: Consider refactoring into core API
             const char AssemblySeparator = ':';

--- a/Bonsai.Editor/Project.cs
+++ b/Bonsai.Editor/Project.cs
@@ -42,7 +42,7 @@ namespace Bonsai.Editor
 
         public static string GetWorkflowBaseDirectory(string fileName)
         {
-            return Path.GetFullPath(Path.GetDirectoryName(fileName));
+            return Path.GetDirectoryName(Path.GetFullPath(fileName));
         }
 
         private static string GetParentRelativePath(DirectoryInfo appDirectory, string path)

--- a/Bonsai.Editor/WorkflowRunner.cs
+++ b/Bonsai.Editor/WorkflowRunner.cs
@@ -213,7 +213,7 @@ namespace Bonsai.Editor
                     }
 
                     var name = ExpressionBuilder.GetElementDisplayName(ex.Builder);
-                    builder.AppendLine($"   at {name} in {path}:line {lineInfo.LineNumber}");
+                    var lineNumber = lineInfo.LineNumber;
 
                     if (ex.InnerException is WorkflowException innerException)
                     {
@@ -222,6 +222,8 @@ namespace Bonsai.Editor
                         else
                             WriteWorkflowExceptionStackTrace(path, reader, innerException, workflowBuilder, builder);
                     }
+
+                    builder.AppendLine($"   at {name} in {path}:line {lineNumber}");
                 }
             }
         }

--- a/Bonsai.Editor/WorkflowRunner.cs
+++ b/Bonsai.Editor/WorkflowRunner.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Text;
 using System.Threading;
 using System.Windows.Forms;
 using System.Xml;
@@ -16,6 +17,7 @@ namespace Bonsai.Editor
     {
         static void RunLayout(
             WorkflowBuilder workflowBuilder,
+            WorkflowRuntimeExceptionCache exceptionCache,
             Dictionary<string, string> propertyAssignments,
             IObservable<TypeVisualizerDescriptor> visualizerProvider,
             VisualizerLayout layout,
@@ -29,18 +31,17 @@ namespace Bonsai.Editor
                                    select (targetType, visualizerType))
                                    .Do(entry => typeVisualizers.Add(entry.targetType, entry.visualizerType))
                                    .ToEnumerable().ToList();
-
-            workflowBuilder = new WorkflowBuilder(workflowBuilder.Workflow.ToInspectableGraph());
             BuildAssignProperties(workflowBuilder, propertyAssignments);
 
             var visualizerSettings = VisualizerLayoutMap.FromVisualizerLayout(workflowBuilder, layout, typeVisualizers);
             var visualizerWindows = visualizerSettings.CreateVisualizerWindows(workflowBuilder);
-            LayoutHelper.SetWorkflowNotifications(workflowBuilder.Workflow, publishNotifications: false);
+            LayoutHelper.SetWorkflowNotifications(workflowBuilder.Workflow, publishNotifications: true);
             LayoutHelper.SetLayoutNotifications(workflowBuilder.Workflow, visualizerWindows);
 
             var services = new System.ComponentModel.Design.ServiceContainer();
             services.AddService(typeof(WorkflowBuilder), workflowBuilder);
             var runtimeWorkflow = workflowBuilder.Workflow.BuildObservable();
+            using var exceptionSubscription = SubscribeRuntimeExceptionCache(workflowBuilder, exceptionCache);
 
             var cts = new CancellationTokenSource();
             var contextMenu = new ContextMenuStrip();
@@ -74,22 +75,44 @@ namespace Bonsai.Editor
                 synchronizationContext.Post(_ => Application.Exit(), null);
             }).Subscribe(
                 unit => { },
-                ex => { Console.Error.WriteLine(ex); },
+                ex => LogWorkflowExceptionStackTrace(fileName, workflowBuilder, exceptionCache, ex),
                 () => { },
                 cts.Token);
 
             Application.Run();
         }
 
-        static void RunHeadless(WorkflowBuilder workflowBuilder, Dictionary<string, string> propertyAssignments)
+        static void RunHeadless(
+            WorkflowBuilder workflowBuilder,
+            WorkflowRuntimeExceptionCache exceptionCache,
+            Dictionary<string, string> propertyAssignments,
+            string fileName)
         {
             BuildAssignProperties(workflowBuilder, propertyAssignments);
+            var runtimeWorkflow = workflowBuilder.Workflow.BuildObservable();
+            using var exceptionSubscription = SubscribeRuntimeExceptionCache(workflowBuilder, exceptionCache);
+
             var workflowCompleted = new ManualResetEvent(false);
-            workflowBuilder.Workflow.BuildObservable().Subscribe(
+            runtimeWorkflow.Subscribe(
                 unit => { },
-                ex => { Console.Error.WriteLine(ex); workflowCompleted.Set(); },
+                ex =>
+                {
+                    LogWorkflowExceptionStackTrace(fileName, workflowBuilder, exceptionCache, ex);
+                    workflowCompleted.Set();
+                },
                 () => workflowCompleted.Set());
             workflowCompleted.WaitOne();
+        }
+
+        static IDisposable SubscribeRuntimeExceptionCache(WorkflowBuilder workflowBuilder, WorkflowRuntimeExceptionCache exceptionCache)
+        {
+            return workflowBuilder.Workflow.InspectErrorsEx().Synchronize().Subscribe(ex =>
+            {
+                if (ex is WorkflowRuntimeException workflowException)
+                {
+                    exceptionCache.TryAdd(workflowException);
+                }
+            });
         }
 
         static void BuildAssignProperties(WorkflowBuilder workflowBuilder, Dictionary<string, string> propertyAssignments)
@@ -103,7 +126,7 @@ namespace Bonsai.Editor
 
         public static void Run(string fileName, Dictionary<string, string> propertyAssignments, IObservable<TypeVisualizerDescriptor> visualizerProvider = null)
         {
-            Run(fileName, propertyAssignments, visualizerProvider);
+            Run(fileName, propertyAssignments, visualizerProvider, layoutPath: null);
         }
 
         public static void Run(
@@ -123,14 +146,84 @@ namespace Bonsai.Editor
             }
 
             var workflowBuilder = ElementStore.LoadWorkflow(fileName);
+            workflowBuilder = new WorkflowBuilder(workflowBuilder.Workflow.ToInspectableGraph());
             var settingsPath = Project.GetWorkflowSettingsDirectory(fileName);
             layoutPath ??= LayoutHelper.GetCompatibleLayoutPath(settingsPath, fileName);
-            if (visualizerProvider != null && File.Exists(layoutPath))
+            var exceptionCache = new WorkflowRuntimeExceptionCache();
+            try
             {
-                var layout = VisualizerLayout.Load(layoutPath);
-                RunLayout(workflowBuilder, propertyAssignments, visualizerProvider, layout, fileName);
+                if (visualizerProvider != null && File.Exists(layoutPath))
+                {
+                    var layout = VisualizerLayout.Load(layoutPath);
+                    RunLayout(workflowBuilder, exceptionCache, propertyAssignments, visualizerProvider, layout, fileName);
+                }
+                else RunHeadless(workflowBuilder, exceptionCache, propertyAssignments, fileName);
             }
-            else RunHeadless(workflowBuilder, propertyAssignments);
+            catch (WorkflowException ex)
+            {
+                LogWorkflowExceptionStackTrace(fileName, workflowBuilder, exceptionCache, ex);
+            }
+        }
+
+        static void LogWorkflowExceptionStackTrace(
+            string fileName,
+            WorkflowBuilder workflowBuilder,
+            WorkflowRuntimeExceptionCache exceptionCache,
+            Exception ex)
+        {
+            if (exceptionCache.TryGetWorkflowException(ex, out var workflowException))
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine(ex.Message);
+                WriteWorkflowExceptionStackTrace(fileName, workflowException, workflowBuilder, sb);
+                Console.Error.WriteLine(sb);
+                Console.Error.WriteLine("   --- Runtime exception stack trace ---");
+            }
+            Console.Error.WriteLine(ex);
+        }
+
+        static void WriteWorkflowExceptionStackTrace(
+            string path,
+            WorkflowException ex,
+            WorkflowBuilder workflowBuilder,
+            StringBuilder builder)
+        {
+            using var stream = UpgradeHelper.GetWorkflowStream(path);
+            using var reader = XmlReader.Create(stream, new XmlReaderSettings { CloseInput = true });
+            WriteWorkflowExceptionStackTrace(path, reader, ex, workflowBuilder, builder);
+        }
+
+        static void WriteWorkflowExceptionStackTrace(
+            string path,
+            XmlReader reader,
+            WorkflowException ex,
+            WorkflowBuilder workflowBuilder,
+            StringBuilder builder)
+        {
+            if (reader is IXmlLineInfo lineInfo)
+            {
+                var workflowPath = WorkflowEditorPath.GetBuilderPath(workflowBuilder, ex.Builder);
+                if (reader.ReadToDescendant(nameof(ExpressionBuilderGraphDescriptor.Nodes)))
+                {
+                    reader.ReadStartElement();
+                    for (var i = 0; i <= workflowPath.Index; i++)
+                    {
+                        if (!reader.ReadToNextSibling("Expression"))
+                            return;
+                    }
+
+                    var name = ExpressionBuilder.GetElementDisplayName(ex.Builder);
+                    builder.AppendLine($"   at {name} in {path}:line {lineInfo.LineNumber}");
+
+                    if (ex.InnerException is WorkflowException innerException)
+                    {
+                        if (ExpressionBuilder.Unwrap(ex.Builder) is IncludeWorkflowBuilder includeBuilder)
+                            WriteWorkflowExceptionStackTrace(includeBuilder.Path, innerException, workflowBuilder, builder);
+                        else
+                            WriteWorkflowExceptionStackTrace(path, reader, innerException, workflowBuilder, builder);
+                    }
+                }
+            }
         }
     }
 }

--- a/Bonsai.Editor/WorkflowRunner.cs
+++ b/Bonsai.Editor/WorkflowRunner.cs
@@ -21,7 +21,8 @@ namespace Bonsai.Editor
             Dictionary<string, string> propertyAssignments,
             IObservable<TypeVisualizerDescriptor> visualizerProvider,
             VisualizerLayout layout,
-            string fileName)
+            string fileName,
+            bool debugger)
         {
             var typeVisualizers = new TypeVisualizerMap();
             var loadVisualizers = (from typeVisualizer in visualizerProvider
@@ -35,7 +36,7 @@ namespace Bonsai.Editor
 
             var visualizerSettings = VisualizerLayoutMap.FromVisualizerLayout(workflowBuilder, layout, typeVisualizers);
             var visualizerWindows = visualizerSettings.CreateVisualizerWindows(workflowBuilder);
-            LayoutHelper.SetWorkflowNotifications(workflowBuilder.Workflow, publishNotifications: true);
+            LayoutHelper.SetWorkflowNotifications(workflowBuilder.Workflow, publishNotifications: debugger);
             LayoutHelper.SetLayoutNotifications(workflowBuilder.Workflow, visualizerWindows);
 
             var services = new System.ComponentModel.Design.ServiceContainer();
@@ -135,6 +136,16 @@ namespace Bonsai.Editor
             IObservable<TypeVisualizerDescriptor> visualizerProvider = null,
             string layoutPath = null)
         {
+            Run(fileName, propertyAssignments, visualizerProvider, layoutPath, debugger: true);
+        }
+
+        public static void Run(
+            string fileName,
+            Dictionary<string, string> propertyAssignments,
+            IObservable<TypeVisualizerDescriptor> visualizerProvider,
+            string layoutPath,
+            bool debugger)
+        {
             if (string.IsNullOrEmpty(fileName))
             {
                 throw new ArgumentNullException(nameof(fileName));
@@ -146,16 +157,19 @@ namespace Bonsai.Editor
             }
 
             var workflowBuilder = ElementStore.LoadWorkflow(fileName);
-            workflowBuilder = new WorkflowBuilder(workflowBuilder.Workflow.ToInspectableGraph());
+            var runLayout = visualizerProvider != null && File.Exists(layoutPath);
+            if (debugger || runLayout)
+                workflowBuilder = new WorkflowBuilder(workflowBuilder.Workflow.ToInspectableGraph());
+
             var settingsPath = Project.GetWorkflowSettingsDirectory(fileName);
             layoutPath ??= LayoutHelper.GetCompatibleLayoutPath(settingsPath, fileName);
             var exceptionCache = new WorkflowRuntimeExceptionCache();
             try
             {
-                if (visualizerProvider != null && File.Exists(layoutPath))
+                if (runLayout)
                 {
                     var layout = VisualizerLayout.Load(layoutPath);
-                    RunLayout(workflowBuilder, exceptionCache, propertyAssignments, visualizerProvider, layout, fileName);
+                    RunLayout(workflowBuilder, exceptionCache, propertyAssignments, visualizerProvider, layout, fileName, debugger);
                 }
                 else RunHeadless(workflowBuilder, exceptionCache, propertyAssignments, fileName);
             }

--- a/Bonsai.Editor/WorkflowRunner.cs
+++ b/Bonsai.Editor/WorkflowRunner.cs
@@ -186,11 +186,11 @@ namespace Bonsai.Editor
             string path,
             WorkflowException ex,
             WorkflowBuilder workflowBuilder,
-            StringBuilder builder)
+            StringBuilder stringBuilder)
         {
             using var stream = UpgradeHelper.GetWorkflowStream(path);
             using var reader = XmlReader.Create(stream, new XmlReaderSettings { CloseInput = true });
-            WriteWorkflowExceptionStackTrace(path, reader, ex, workflowBuilder, builder);
+            WriteWorkflowExceptionStackTrace(path, reader, ex, workflowBuilder, stringBuilder);
         }
 
         static void WriteWorkflowExceptionStackTrace(
@@ -198,7 +198,7 @@ namespace Bonsai.Editor
             XmlReader reader,
             WorkflowException ex,
             WorkflowBuilder workflowBuilder,
-            StringBuilder builder)
+            StringBuilder stringBuilder)
         {
             if (reader is IXmlLineInfo lineInfo)
             {
@@ -212,18 +212,25 @@ namespace Bonsai.Editor
                             return;
                     }
 
-                    var name = ExpressionBuilder.GetElementDisplayName(ex.Builder);
+                    var builder = ExpressionBuilder.Unwrap(ex.Builder);
+                    var element = ExpressionBuilder.GetWorkflowElement(builder);
+                    var typeName = element.GetType().FullName;
+                    var elementName = (element as INamedElement)?.Name;
                     var lineNumber = lineInfo.LineNumber;
 
                     if (ex.InnerException is WorkflowException innerException)
                     {
-                        if (ExpressionBuilder.Unwrap(ex.Builder) is IncludeWorkflowBuilder includeBuilder)
-                            WriteWorkflowExceptionStackTrace(includeBuilder.Path, innerException, workflowBuilder, builder);
+                        if (builder is IncludeWorkflowBuilder includeBuilder)
+                            WriteWorkflowExceptionStackTrace(includeBuilder.Path, innerException, workflowBuilder, stringBuilder);
                         else
-                            WriteWorkflowExceptionStackTrace(path, reader, innerException, workflowBuilder, builder);
+                            WriteWorkflowExceptionStackTrace(path, reader, innerException, workflowBuilder, stringBuilder);
                     }
 
-                    builder.AppendLine($"   at {name} in {path}:line {lineNumber}");
+                    var location = $"in {path}:line {lineNumber}";
+                    if (string.IsNullOrEmpty(elementName))
+                        stringBuilder.AppendLine($"   at {typeName} {location}");
+                    else
+                        stringBuilder.AppendLine($"   at {typeName} named {elementName} {location}");
                 }
             }
         }

--- a/Bonsai.Editor/WorkflowRuntimeExceptionCache.cs
+++ b/Bonsai.Editor/WorkflowRuntimeExceptionCache.cs
@@ -57,22 +57,28 @@ namespace Bonsai.Editor
             return null;
         }
 
-        public bool TryGetValue(Exception key, out WorkflowException value)
+        public bool TryGetWorkflowException(Exception exception, out WorkflowException value)
         {
-            if (key == null)
+            if (exception == null)
             {
-                throw new ArgumentNullException(nameof(key));
+                throw new ArgumentNullException(nameof(exception));
+            }
+
+            if (exception is WorkflowException workflowException && workflowException.Builder != null)
+            {
+                value = workflowException;
+                return true;
             }
 
             value = null;
-            var weakKey = new WeakKey<Exception>(key);
+            var weakKey = new WeakKey<Exception>(exception);
             var result = exceptions.TryGetValue(weakKey, out Queue<ExpressionBuilder> callStack);
             if (result)
             {
                 while (callStack.Count > 0)
                 {
                     var builder = callStack.Dequeue();
-                    value = new WorkflowRuntimeException(key.Message, builder, value ?? key);
+                    value = new WorkflowRuntimeException(exception.Message, builder, value ?? exception);
                 }
             }
 

--- a/Bonsai/Launcher.cs
+++ b/Bonsai/Launcher.cs
@@ -141,7 +141,8 @@ namespace Bonsai
             string fileName,
             string layoutPath,
             PackageConfiguration packageConfiguration,
-            Dictionary<string, string> propertyAssignments)
+            Dictionary<string, string> propertyAssignments,
+            bool debugger)
         {
             if (string.IsNullOrEmpty(fileName))
             {
@@ -154,7 +155,7 @@ namespace Bonsai
                 EditorBootstrapper.EnableVisualStyles();
                 return TypeVisualizerLoader.GetVisualizerTypes(packageConfiguration);
             });
-            WorkflowRunner.Run(fileName, propertyAssignments, visualizerProvider, layoutPath);
+            WorkflowRunner.Run(fileName, propertyAssignments, visualizerProvider, layoutPath, debugger);
             return Program.NormalExitCode;
         }
 

--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -33,6 +33,7 @@ namespace Bonsai
         const string ExportImageCommand = "--export-image";
         const string ReloadEditorCommand = "--reload-editor";
         const string GalleryCommand = "--gallery";
+        const string DebugCommand = "--debug";
         const string PipeCommand = "--@pipe";
         const string RepositoryPath = "Packages";
         const string ExtensionsPath = "Extensions";
@@ -68,6 +69,7 @@ namespace Bonsai
             var libFolders = new List<string>();
             var propertyAssignments = new Dictionary<string, string>();
             var parser = new CommandLineParser();
+            parser.RegisterCommand(DebugCommand, () => debugging = true);
             parser.RegisterCommand(StartCommand, () => start = debugging = true);
             parser.RegisterCommand(StartWithoutDebugging, () => start = true);
             parser.RegisterCommand(LibraryCommand, path => libFolders.Add(Path.GetFullPath(path)));
@@ -176,7 +178,7 @@ namespace Bonsai
                     using var scriptExtensions = ScriptExtensionsProvider.CompileAssembly(Launcher.ProjectFramework, packageConfiguration, editorRepositoryPath, debugScripts);
                     ConfigurationHelper.SetAssemblyResolve(packageConfiguration);
                     if (exportImage) return Launcher.LaunchExportImage(initialFileName, imageFileName, packageConfiguration);
-                    if (!launchEditor) return Launcher.LaunchWorkflowPlayer(initialFileName, layoutPath, packageConfiguration, propertyAssignments);
+                    if (!launchEditor) return Launcher.LaunchWorkflowPlayer(initialFileName, layoutPath, packageConfiguration, propertyAssignments, debugging);
                     else return Launcher.LaunchWorkflowEditor(
                         packageConfiguration,
                         scriptExtensions,


### PR DESCRIPTION
Avoids having headless runs pay the inspectable-graph cost by default; --debug opts in to the verbose runtime trace. Layout mode still forces inspection regardless, since visualizers depend on it.

[Add operator type and name to exception trace](https://github.com/bonsai-rx/bonsai/commit/72c7babbea5185b48e96201e10522fcc9db055a0) 

Trace entries now show the fully-qualified operator type, with an optional "named X" suffix from INamedElement when a name is set. Type-first format mirrors the .NET stack trace convention.

[Reverse nesting order in exception trace](https://github.com/bonsai-rx/bonsai/commit/38671b70e6f79e26fb1e43b3c6aa6364c029efeb) 

To follow programming language conventions for error traces we display operator provenance from innermost to outermost.

[Log workflow exception trace when running from CLI](https://github.com/bonsai-rx/bonsai/commit/b670b3a0b6e2d8cc0e6baa74772e31591d9037c5) 

Builder-level exceptions are captured via the exception cache and logged to stderr entries ahead of the raw exception.

[Add tests for workflow exception logging](https://github.com/bonsai-rx/bonsai/commit/df787d205cd10a11b43cd925bd66dcff986ba77f) 

Captures stderr on a workflow error and asserts that the formatted trace lists each level with file path and line number, including the nested workflow reached via an include operator.

We embed test workflows again as the format of traces differs in ways we would like to keep track of.

[Move WorkflowException lookup logic into the cache](https://github.com/bonsai-rx/bonsai/commit/f47a3c98f8ba95ff34cd559f6a3a6d62009aa988) 

TryGetWorkflowException now also handles the case where the input already carries a builder, so callers no longer need to combine the type check with the cache lookup themselves.

Fixes https://github.com/bonsai-rx/bonsai/issues/2143