### PR TITLE
Restore visualizer window bounds before Load

### DIFF
--- a/Bonsai.Design/TypeVisualizerWindow.cs
+++ b/Bonsai.Design/TypeVisualizerWindow.cs
@@ -18,7 +18,7 @@ namespace Bonsai.Design
         }
 
         /// <inheritdoc/>
-        public void AddControl(Control control)
+        public virtual void AddControl(Control control)
         {
             ClientSize = control.Size;
             if (control.MinimumSize != Size.Empty)

--- a/Bonsai.Editor/Layout/WindowLauncher.cs
+++ b/Bonsai.Editor/Layout/WindowLauncher.cs
@@ -32,15 +32,13 @@ namespace Bonsai.Design
             if (VisualizerWindow == null)
             {
                 VisualizerWindow = CreateVisualizerWindow(provider);
-                VisualizerWindow.Load += delegate
+
+                var bounds = Bounds;
+                if (!bounds.IsEmpty && (SystemInformation.VirtualScreen.IntersectsWith(bounds) || WindowState != FormWindowState.Normal))
                 {
-                    var bounds = Bounds;
-                    if (!bounds.IsEmpty && (SystemInformation.VirtualScreen.IntersectsWith(bounds) || WindowState != FormWindowState.Normal))
-                    {
-                        VisualizerWindow.LayoutBounds = bounds;
-                        VisualizerWindow.WindowState = WindowState;
-                    }
-                };
+                    VisualizerWindow.LayoutBounds = bounds;
+                    VisualizerWindow.WindowState = WindowState;
+                }
 
                 VisualizerWindow.FormClosed += delegate
                 {
@@ -82,6 +80,7 @@ namespace Bonsai.Design
 
         protected class LauncherWindow : TypeVisualizerWindow
         {
+            bool hasRestoredBounds;
             SizeF inverseScaleFactor;
             SizeF scaleFactor;
 
@@ -98,8 +97,18 @@ namespace Bonsai.Design
                     if (layoutBounds.Width > 0)
                     {
                         Bounds = layoutBounds;
+                        hasRestoredBounds = true;
                     }
                 }
+            }
+
+            public override void AddControl(Control control)
+            {
+                // Prefer restored bounds over base auto-size
+                var restoredBounds = Bounds;
+                base.AddControl(control);
+                if (hasRestoredBounds)
+                    Bounds = restoredBounds;
             }
 
             protected override void ScaleControl(SizeF factor, BoundsSpecified specified)


### PR DESCRIPTION
Move layout restore from the `Form.Load` event handler into the logic of the launcher `Show` method, before the window handle is created. Avoids resizing the control after handle creation, which can crash visualizers with native rendering contexts.

`TypeVisualizerWindow.AddControl` was marked as virtual so we can override its behavior in the launcher to preserve restored bounds against the default auto-size side effect.

Fixes #2558