### PR TITLE
Build CameraCapture observable in Generate

### DIFF
--- a/Bonsai.Vision/CameraCapture.cs
+++ b/Bonsai.Vision/CameraCapture.cs
@@ -2,6 +2,7 @@
 using OpenCV.Net;
 using System.Reactive.Linq;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace Bonsai.Vision
@@ -15,52 +16,8 @@ namespace Bonsai.Vision
     [Description("Generates a sequence of images acquired from the specified camera.")]
     public class CameraCapture : Source<IplImage>
     {
-        readonly IObservable<IplImage> source;
-        readonly object captureLock = new object();
+        static readonly ConditionalWeakTable<CameraCapture, object> captureLocks = new();
         readonly CapturePropertyCollection captureProperties = new CapturePropertyCollection();
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CameraCapture"/> class.
-        /// </summary>
-        public CameraCapture()
-        {
-            source = Observable.Create<IplImage>((observer, cancellationToken) =>
-            {
-                return Task.Factory.StartNew(() =>
-                {
-                    lock (captureLock)
-                    {
-                        using (var capture = Capture.CreateCameraCapture(Index))
-                        {
-                            foreach (var setting in captureProperties)
-                            {
-                                capture.SetProperty(setting.Property, setting.Value);
-                            }
-                            captureProperties.Capture = capture;
-                            try
-                            {
-                                while (!cancellationToken.IsCancellationRequested)
-                                {
-                                    var image = captureProperties.Capture.QueryFrame();
-                                    if (image == null)
-                                    {
-                                        observer.OnError(new InvalidOperationException("Unable to acquire camera frame."));
-                                        break;
-                                    }
-                                    else observer.OnNext(image.Clone());
-                                }
-                            }
-                            finally { captureProperties.Capture = null; }
-                        }
-                    }
-                },
-                cancellationToken,
-                TaskCreationOptions.LongRunning,
-                TaskScheduler.Default);
-            })
-            .PublishReconnectable()
-            .RefCount();
-        }
 
         /// <summary>
         /// Gets or sets the index of the camera from which to acquire images.
@@ -87,7 +44,43 @@ namespace Bonsai.Vision
         /// </returns>
         public override IObservable<IplImage> Generate()
         {
-            return source;
+            var captureLock = captureLocks.GetOrCreateValue(this);
+            return Observable.Create<IplImage>((observer, cancellationToken) =>
+            {
+                return Task.Factory.StartNew(() =>
+                {
+                    lock (captureLock)
+                    {
+                        using (var capture = Capture.CreateCameraCapture(Index))
+                        {
+                            foreach (var setting in captureProperties)
+                            {
+                                capture.SetProperty(setting.Property, setting.Value);
+                            }
+                            captureProperties.Capture = capture;
+                            try
+                            {
+                                while (!cancellationToken.IsCancellationRequested)
+                                {
+                                    var image = capture.QueryFrame();
+                                    if (image == null)
+                                    {
+                                        observer.OnError(new InvalidOperationException("Unable to acquire camera frame."));
+                                        break;
+                                    }
+                                    else observer.OnNext(image.Clone());
+                                }
+                            }
+                            finally { captureProperties.Capture = null; }
+                        }
+                    }
+                },
+                cancellationToken,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+            })
+            .PublishReconnectable()
+            .RefCount();
         }
     }
 }


### PR DESCRIPTION
Moved the observable construction from the constructor to `Generate` so the lambda reads operator properties at subscription time. The per-instance lock moves from an instance field to a static `ConditionalWeakTable` keyed on the operator, so the lock is shared across `Generate` calls on the same instance without the constructor needing to own it.

Finally, the acquisition loop is also fixed to query the frame from the local capture variable rather than `captureProperties.Capture`.