### PR TITLE
Apply visualizer window state independently of saved bounds

### DIFF
--- a/Bonsai.Editor/Layout/WindowLauncher.cs
+++ b/Bonsai.Editor/Layout/WindowLauncher.cs
@@ -35,11 +35,11 @@ namespace Bonsai.Design
                 VisualizerWindow.Load += delegate
                 {
                     var bounds = Bounds;
-                    if (!bounds.IsEmpty && (SystemInformation.VirtualScreen.IntersectsWith(bounds) || WindowState != FormWindowState.Normal))
+                    if (!bounds.IsEmpty && SystemInformation.VirtualScreen.IntersectsWith(bounds))
                     {
                         VisualizerWindow.LayoutBounds = bounds;
-                        VisualizerWindow.WindowState = WindowState;
                     }
+                    VisualizerWindow.WindowState = WindowState;
                 };
 
                 VisualizerWindow.FormClosed += delegate


### PR DESCRIPTION
On a fresh workflow with `WindowState` set to `Maximized` but no saved `Location` or `Size`, the maximized state is ignored on first run. The restore logic in `WindowLauncher.Show` applied both the layout bounds and the window state inside a single block guarded by `!bounds.IsEmpty`, so empty bounds skipped the whole block and the state was never assigned. As noted in #2431, setting any `Size` worked around it, since non-empty bounds let the block run.

This change decouples the two. The layout bounds stay guarded by the on-screen check, and the window state is applied unconditionally:

```csharp
var bounds = Bounds;
if (!bounds.IsEmpty && SystemInformation.VirtualScreen.IntersectsWith(bounds))
    VisualizerWindow.LayoutBounds = bounds;
VisualizerWindow.WindowState = WindowState;
```

### Why the old condition existed

The dropped `|| WindowState != FormWindowState.Normal` clause was an escape hatch for a stricter geometry test. It was added in 2014 alongside the original WindowState restore, when the screen test was `VirtualScreen.Contains`, which requires the whole rectangle to lie on screen and so rejects edge-snapped layouts and the overhanging bounds of maximized windows. The clause let a maximized or minimized window still restore its state and its off-screen `RestoreBounds` despite that strict test. In 2025 the test was loosened to `IntersectsWith`, which admits any layout that touches the screen for every window state, so the clause was already mostly redundant. Pulling the state assignment out removes what remained of it.

### Behavioral change to watch

There is one intentional divergence from the previous behavior. A maximized window whose restore bounds fall fully off the virtual screen, for example after a monitor is disconnected between sessions, no longer re-applies those off-screen bounds. It still opens maximized, but un-maximizing returns it to a default visible location instead of the saved off-screen geometry. Every other case is unchanged.

### Consistency with the main editor window

This matches what the main editor window has always done. `EditorForm` applies its saved bounds only when they intersect a screen, then sets `WindowState` unconditionally, with no equivalent escape hatch. The change aligns the visualizer window with that long-standing policy rather than introducing a new one, and the unconditional state assignment is already proven there.

Closes #2431
