### PR TITLE
Add bug report and feature request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,36 @@
+name: Bug report
+description: Report something that is not working as expected
+type: Bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Bug reports are always welcome as issues here. Fill in what you can; only a description is required.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened, and what did you expect to happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the problem? A small workflow that reproduces it is ideal.
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: Bonsai version
+      description: Which version of Bonsai are you running?
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that might help, such as error messages, screenshots, or your operating system.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,36 @@
+name: Feature request or informal proposal
+description: Suggest an idea, an improvement, or an early-stage language proposal
+type: Feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for feature requests and early-stage ideas, including informal language proposals. There is no need for a fully worked out design; a rough idea is fine. Detailed, design-stage language specifications have their own template.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What would you like to see?
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this useful? What problem does it solve, or what does it make possible?
+    validations:
+      required: false
+  - type: textarea
+    id: solution
+    attributes:
+      label: Possible solution
+      description: If you have an idea of how this could work, describe it here.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: Any other approaches you have considered, or current workarounds.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/3-specification-proposal.md
+++ b/.github/ISSUE_TEMPLATE/3-specification-proposal.md
@@ -1,6 +1,6 @@
 ---
-name: Create a language specification
-about: For proposals that have been invited by a team member
+name: Specification proposal
+about: For detailed, design-stage language specifications
 title: 'Feature name'
 labels: proposal
 assignees: ''
@@ -8,9 +8,9 @@ assignees: ''
 ---
 
 <!--
-Hello, and thanks for your interest in contributing to the Bonsai visual reactive programming language! If you haven't been invited by a team member to open an issue, please instead open a discussion marked [proposal] at https://github.com/bonsai-rx/bonsai/discussions and we'll try to give you feedback on how to get to an issue-ready proposal.
+Thanks for your interest in helping develop the Bonsai visual reactive programming language. This template is for detailed specifications of language features that have been brought to design. For an early-stage idea or an informal proposal, please use the Feature request or informal proposal template instead; a specification can grow out of that discussion later.
 
-New language proposals should aim to fully fill out this template, at least up to and including detailed design. The sections on drawbacks, alternatives and unresolved questions may be omitted from the initial proposal.
+A specification should aim to fully fill out this template, at least up to and including detailed design. The sections on drawbacks, alternatives and unresolved questions may be omitted from the initial proposal.
 -->
 
 * [x] Proposed

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions and announcements
+    url: https://github.com/bonsai-rx/bonsai/discussions
+    about: For questions, help, and community announcements. For bug reports and feature ideas, please use the templates above.


### PR DESCRIPTION
Add issue forms for bug reports and for feature requests and informal proposals, both setting a GitHub issue type and requiring only a description. Add a template chooser config that keeps blank issues enabled and links to discussions for questions and announcements. Rename the specification template so it sorts after the new forms, and reword its intro to point early-stage ideas at the feature request form.

Closes #1738 