### PR TITLE
Fix duplicate and missing package dependencies during environment initialization

### DIFF
--- a/Bonsai.Tests/Bonsai.Tests.csproj
+++ b/Bonsai.Tests/Bonsai.Tests.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="**\*.bonsai" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Bonsai\Bonsai.csproj" />
+    <ProjectReference Include="..\Bonsai.Configuration\Bonsai.Configuration.csproj" />
+  </ItemGroup>
+</Project>

--- a/Bonsai.Tests/DependencyInspectorTests.cs
+++ b/Bonsai.Tests/DependencyInspectorTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Bonsai.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Tests;
+
+// Stand-in type used only as the generic type argument in the test workflow, so its assembly
+// can be mapped to a package and asserted as a dependency.
+public sealed class GenericArgumentMarker
+{
+}
+
+[TestClass]
+public sealed class DependencyInspectorTests
+{
+    const string ArgumentAssembly = "Bonsai.Tests";
+    const string ArgumentPackageId = "Fake.ArgumentTypePackage";
+    const string ArgumentPackageVersion = "4.5.6";
+
+    // The workflow declares the closed generic WorkflowProperty<GenericArgumentMarker>. The open
+    // type lives in Bonsai.Core, while the generic argument GenericArgumentMarker lives in this test
+    // assembly, so the argument assembly is reachable only through the generic type argument.
+    const string WorkflowMarkup =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <WorkflowBuilder Version="2.8.5"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xmlns:test="clr-namespace:Bonsai.Tests;assembly=Bonsai.Tests"
+                         xmlns="https://bonsai-rx.org/2018/workflow">
+          <Workflow>
+            <Nodes>
+              <Expression xsi:type="WorkflowProperty" TypeArguments="test:GenericArgumentMarker">
+                <Value xsi:nil="true" />
+              </Expression>
+            </Nodes>
+            <Edges />
+          </Workflow>
+        </WorkflowBuilder>
+        """;
+
+    // A configuration file is loaded from disk so that ConfigurationFile is populated through the
+    // public Load entry point. The single assembly location maps the test assembly to a fake package
+    // following the default Packages\<id>.<version> layout that GetAssemblyPackageReference parses.
+    static readonly string ConfigurationMarkup =
+        $"""
+        <?xml version="1.0" encoding="utf-8"?>
+        <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <Packages>
+            <Package id="{ArgumentPackageId}" version="{ArgumentPackageVersion}" />
+          </Packages>
+          <AssemblyReferences>
+            <AssemblyReference assemblyName="{ArgumentAssembly}" />
+          </AssemblyReferences>
+          <AssemblyLocations>
+            <AssemblyLocation assemblyName="{ArgumentAssembly}" processorArchitecture="MSIL" location="Packages\{ArgumentPackageId}.{ArgumentPackageVersion}\lib\{ArgumentAssembly}.dll" />
+          </AssemblyLocations>
+          <LibraryFolders>
+          </LibraryFolders>
+        </PackageConfiguration>
+        """;
+
+    [TestMethod]
+    // Regression test for https://github.com/bonsai-rx/bonsai/issues/2338
+    public void GetPackageDependencies_GenericArgumentInDistinctAssembly_IncludesArgumentPackage()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"Bonsai.Tests.{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        try
+        {
+            var workflowPath = Path.Combine(tempDirectory, "GenericArgumentDependency.bonsai");
+            File.WriteAllText(workflowPath, WorkflowMarkup);
+
+            var configurationPath = Path.Combine(tempDirectory, "Bonsai.config");
+            File.WriteAllText(configurationPath, ConfigurationMarkup);
+            var configuration = ConfigurationHelper.Load(configurationPath);
+
+            var dependencies = DependencyInspector.GetPackageDependencies(new[] { workflowPath }, configuration);
+            var packageIds = dependencies.Select(package => package.Id).ToArray();
+
+            CollectionAssert.Contains(packageIds, ArgumentPackageId, "the generic argument package should be collected as a dependency");
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+}

--- a/Bonsai.Tests/DependencyInspectorTests.cs
+++ b/Bonsai.Tests/DependencyInspectorTests.cs
@@ -19,6 +19,56 @@ public sealed class DependencyInspectorTests
     const string ArgumentPackageId = "Fake.ArgumentTypePackage";
     const string ArgumentPackageVersion = "4.5.6";
 
+    const string CoreAssembly = "Bonsai.Core";
+    const string CorePackageId = "Bonsai.Core";
+    const string CorePackageVersion = "1.0.0";
+
+    // The workflow contains a single IncludeWorkflow element whose Path references the Bonsai.Core
+    // assembly. The inspector loads that assembly through the MetadataLoadContext, while Bonsai.Core
+    // is also auto-seeded as the runtime instance of typeof(WorkflowBuilder).Assembly, so the same
+    // logical assembly arrives twice as two distinct Assembly instances. The resource name does not
+    // exist, which is fine because ReadMetadata swallows the missing-resource failure and the
+    // inspector only needs the assembly name from the Path attribute.
+    const string IncludeWorkflowMarkup =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <WorkflowBuilder Version="2.8.5"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xmlns="https://bonsai-rx.org/2018/workflow">
+          <Workflow>
+            <Nodes>
+              <Expression xsi:type="IncludeWorkflow" Path="Bonsai.Core:DoesNotExist" />
+            </Nodes>
+            <Edges />
+          </Workflow>
+        </WorkflowBuilder>
+        """;
+
+    // The assembly location uses the default Packages\<id>.<version> layout so the package mapping
+    // resolves Bonsai.Core to its package id, using the realistic Bonsai.Core package id. The test
+    // also materializes the real Bonsai.Core.dll at this location so the MetadataLoadContext can load
+    // it when resolving the IncludeWorkflow reference, producing a metadata instance distinct from the
+    // auto-seeded runtime instance.
+    static readonly string CorePackageLocation = $@"Packages\{CorePackageId}.{CorePackageVersion}\lib\{CoreAssembly}.dll";
+
+    static readonly string CoreConfigurationMarkup =
+        $"""
+        <?xml version="1.0" encoding="utf-8"?>
+        <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <Packages>
+            <Package id="{CorePackageId}" version="{CorePackageVersion}" />
+          </Packages>
+          <AssemblyReferences>
+            <AssemblyReference assemblyName="{CoreAssembly}" />
+          </AssemblyReferences>
+          <AssemblyLocations>
+            <AssemblyLocation assemblyName="{CoreAssembly}" processorArchitecture="MSIL" location="{CorePackageLocation}" />
+          </AssemblyLocations>
+          <LibraryFolders>
+          </LibraryFolders>
+        </PackageConfiguration>
+        """;
+
     // The workflow declares the closed generic WorkflowProperty<GenericArgumentMarker>. The open
     // type lives in Bonsai.Core, while the generic argument GenericArgumentMarker lives in this test
     // assembly, so the argument assembly is reachable only through the generic type argument.
@@ -61,29 +111,56 @@ public sealed class DependencyInspectorTests
         </PackageConfiguration>
         """;
 
-    [TestMethod]
-    // Regression test for https://github.com/bonsai-rx/bonsai/issues/2338
-    public void GetPackageDependencies_GenericArgumentInDistinctAssembly_IncludesArgumentPackage()
+    // Writes the workflow and configuration markup to a fresh temporary directory, loads the
+    // configuration through the public Load entry point, and returns the collected package ids. The
+    // optional assemblyLocation materializes a real assembly file at that relative location so the
+    // MetadataLoadContext resolver can load it from disk.
+    static string[] GetWorkflowPackageIds(string workflowFileName, string workflowMarkup, string configurationMarkup, string assemblyLocation = null, string assemblySource = null)
     {
         var tempDirectory = Path.Combine(Path.GetTempPath(), $"Bonsai.Tests.{Guid.NewGuid():N}");
         Directory.CreateDirectory(tempDirectory);
         try
         {
-            var workflowPath = Path.Combine(tempDirectory, "GenericArgumentDependency.bonsai");
-            File.WriteAllText(workflowPath, WorkflowMarkup);
+            var workflowPath = Path.Combine(tempDirectory, workflowFileName);
+            File.WriteAllText(workflowPath, workflowMarkup);
 
             var configurationPath = Path.Combine(tempDirectory, "Bonsai.config");
-            File.WriteAllText(configurationPath, ConfigurationMarkup);
+            File.WriteAllText(configurationPath, configurationMarkup);
+
+            if (assemblyLocation != null)
+            {
+                var targetPath = Path.Combine(tempDirectory, assemblyLocation);
+                Directory.CreateDirectory(Path.GetDirectoryName(targetPath));
+                File.Copy(assemblySource, targetPath);
+            }
+
             var configuration = ConfigurationHelper.Load(configurationPath);
 
             var dependencies = DependencyInspector.GetPackageDependencies(new[] { workflowPath }, configuration);
-            var packageIds = dependencies.Select(package => package.Id).ToArray();
-
-            CollectionAssert.Contains(packageIds, ArgumentPackageId, "the generic argument package should be collected as a dependency");
+            return dependencies.Select(package => package.Id).ToArray();
         }
         finally
         {
             Directory.Delete(tempDirectory, recursive: true);
         }
+    }
+
+    [TestMethod]
+    // Regression test for https://github.com/bonsai-rx/bonsai/issues/2338
+    public void GetPackageDependencies_GenericArgumentInDistinctAssembly_IncludesArgumentPackage()
+    {
+        var packageIds = GetWorkflowPackageIds("GenericArgumentDependency.bonsai", WorkflowMarkup, ConfigurationMarkup);
+        CollectionAssert.Contains(packageIds, ArgumentPackageId, "the generic argument package should be collected as a dependency");
+    }
+
+    [TestMethod]
+    // Regression test for https://github.com/bonsai-rx/bonsai/issues/2336
+    public void GetPackageDependencies_AssemblyArrivesFromRuntimeAndMetadataContext_ReturnsPackageOnce()
+    {
+        var packageIds = GetWorkflowPackageIds("IncludeWorkflowDependency.bonsai", IncludeWorkflowMarkup, CoreConfigurationMarkup, CorePackageLocation, typeof(WorkflowBuilder).Assembly.Location);
+        var distinctCount = packageIds.Distinct(StringComparer.OrdinalIgnoreCase).Count();
+
+        Assert.AreEqual(distinctCount, packageIds.Length, "the collected package ids should contain no duplicates");
+        Assert.AreEqual(1, packageIds.Count(id => string.Equals(id, CorePackageId, StringComparison.OrdinalIgnoreCase)), "the core package should appear exactly once");
     }
 }

--- a/Bonsai.sln
+++ b/Bonsai.sln
@@ -74,6 +74,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tooling", "tooling", "{69C9
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Configuration.Tests", "Bonsai.Configuration.Tests\Bonsai.Configuration.Tests.csproj", "{024A09F4-7525-4EE3-B07F-4097A9415C89}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Tests", "Bonsai.Tests\Bonsai.Tests.csproj", "{546F2E19-B074-44CE-A0A9-B14BB313C2C4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -188,6 +190,10 @@ Global
 		{024A09F4-7525-4EE3-B07F-4097A9415C89}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{024A09F4-7525-4EE3-B07F-4097A9415C89}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{024A09F4-7525-4EE3-B07F-4097A9415C89}.Release|Any CPU.Build.0 = Release|Any CPU
+		{546F2E19-B074-44CE-A0A9-B14BB313C2C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{546F2E19-B074-44CE-A0A9-B14BB313C2C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{546F2E19-B074-44CE-A0A9-B14BB313C2C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{546F2E19-B074-44CE-A0A9-B14BB313C2C4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Bonsai/DependencyInspector.cs
+++ b/Bonsai/DependencyInspector.cs
@@ -53,6 +53,19 @@ namespace Bonsai
             }
         }
 
+        static IEnumerable<Assembly> GetTypeDependencies(Type type)
+        {
+            yield return type.Assembly;
+            if (type.IsGenericType)
+            {
+                foreach (var typeArgument in type.GetGenericArguments())
+                {
+                    foreach (var assembly in GetTypeDependencies(typeArgument))
+                        yield return assembly;
+                }
+            }
+        }
+
         static IEnumerable<Assembly> GetWorkflowDependencies(string path, MetadataLoadContext context)
         {
             var metadata = WorkflowBuilder.ReadMetadata(path);
@@ -81,7 +94,7 @@ namespace Bonsai
                 }
             }
 
-            foreach (var assembly in metadata.GetExtensionTypes().Select(type => type.Assembly))
+            foreach (var assembly in metadata.GetExtensionTypes().SelectMany(GetTypeDependencies))
                 yield return assembly;
         }
 
@@ -94,7 +107,8 @@ namespace Bonsai
                 if (typeName == null) continue;
                 if (visualizerMap.TryGetValue(typeName, out Type type))
                 {
-                    yield return type.Assembly;
+                    foreach (var assembly in GetTypeDependencies(type))
+                        yield return assembly;
                 }
             }
         }
@@ -133,7 +147,10 @@ namespace Bonsai
                     select configuration.Packages[id]);
             }
 
-            return dependencies.ToArray();
+            return dependencies
+                .GroupBy(package => package.Id, StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
+                .ToArray();
         }
 
         static Configuration.PackageReference[] GetPackageDependencies(IEnumerable<IPackageFile> files, PackageConfiguration configuration)


### PR DESCRIPTION
Environment initialization scans a workflow for its package dependencies through `DependencyInspector.GetPackageDependencies`. This fixes two bugs in that scan and adds the first test project for the bootstrapper to cover them through the public surface.

### Bugs

- **Duplicate dependencies, [#2336](https://github.com/bonsai-rx/bonsai/issues/2336).** The scan collects assemblies into a `HashSet<Assembly>` that compares by reference. The same logical assembly can arrive as two distinct instances: a runtime instance, e.g. a core assembly referenced by the bootstrapper or an extension type, and a `MetadataLoadContext` instance, e.g. from an `IncludeWorkflow` element. Both survive the set and map to the same package id, so the returned reference set would contain that id twice, which collided in a `SortedList` and threw during `bonsai --init`.
- **Missing dependency through a generic argument, [#2338](https://github.com/bonsai-rx/bonsai/issues/2338).** When scanning generic types, the scan would collect only the assembly of the generic type itself, and ignore assemblies from its own generic type arguments. A package referenced solely through a generic type argument, for example `TypeMapping<TimeSeriesVisualizer>`, was silently dropped from the dependency set.

### Fix

Both changes are in `DependencyInspector`:

- Group the returned package references by id, case-insensitively, so an id that arrives more than once collapses to a single reference. This is the same id-based collapse that `GalleryPackage` already applies; as [#2336](https://github.com/bonsai-rx/bonsai/issues/2336) notes, that filtering is what kept gallery export from hitting the same bug.
- Walk generic type arguments when gathering assemblies, through a new `GetTypeDependencies` helper that recurses into `GetGenericArguments`, mirroring `WorkflowBuilder.GetClrNamespaces`.

### Tests

Adds `Bonsai.Tests`, the first test project for the bootstrapper, with two regression tests that drive the public `GetPackageDependencies` and assert on the resulting package ids. The tests are committed before the fix, so each fails on the pre-fix commit and passes after it.

### Note

- `Bonsai.Tests` targets `net8.0-windows` and declares it through the plural `<TargetFrameworks>` form on purpose: that makes it a multi-targeting project, so the cross-platform `net8.0` CI test pass skips it, since it cannot run on non-Windows, while the Windows `net8.0-windows` pass runs it, matching how `Bonsai.Editor.Tests` already behaves.

Fixes #2336
Fixes #2338