### PR TITLE
Fix package manager keyboard and search interactions

### DIFF
--- a/Bonsai.NuGet.Design/PackageManagerDialog.Designer.cs
+++ b/Bonsai.NuGet.Design/PackageManagerDialog.Designer.cs
@@ -132,7 +132,7 @@
             this.browseButton.TabIndex = 0;
             this.browseButton.Text = "Browse";
             this.browseButton.UseVisualStyleBackColor = true;
-            this.browseButton.CheckedChanged += new System.EventHandler(this.refreshButton_Click);
+            this.browseButton.CheckedChanged += new System.EventHandler(this.tabButton_CheckedChanged);
             // 
             // installedButton
             // 
@@ -147,7 +147,7 @@
             this.installedButton.TabIndex = 1;
             this.installedButton.Text = "Installed";
             this.installedButton.UseVisualStyleBackColor = true;
-            this.installedButton.CheckedChanged += new System.EventHandler(this.refreshButton_Click);
+            this.installedButton.CheckedChanged += new System.EventHandler(this.tabButton_CheckedChanged);
             // 
             // updatesButton
             // 
@@ -162,7 +162,7 @@
             this.updatesButton.TabIndex = 2;
             this.updatesButton.Text = "Updates";
             this.updatesButton.UseVisualStyleBackColor = true;
-            this.updatesButton.CheckedChanged += new System.EventHandler(this.refreshButton_Click);
+            this.updatesButton.CheckedChanged += new System.EventHandler(this.tabButton_CheckedChanged);
             // 
             // packageViewLayoutPanel
             // 

--- a/Bonsai.NuGet.Design/PackageManagerDialog.cs
+++ b/Bonsai.NuGet.Design/PackageManagerDialog.cs
@@ -205,6 +205,14 @@ namespace Bonsai.NuGet.Design
             }
         }
 
+        private void tabButton_CheckedChanged(object sender, EventArgs e)
+        {
+            var tabButton = (RadioButton)sender;
+            if (!tabButton.Checked) return;
+            packageViewController.ClearSearch();
+            UpdateSelectedRepository();
+        }
+
         private void refreshButton_Click(object sender, EventArgs e)
         {
             UpdateSelectedRepository();

--- a/Bonsai.NuGet.Design/PackageView.cs
+++ b/Bonsai.NuGet.Design/PackageView.cs
@@ -163,21 +163,56 @@ namespace Bonsai.NuGet.Design
             if (e.Button == MouseButtons.Left &&
                 (result = OperationHitTest(e.Location, out TreeViewHitTestInfo hitTestInfo)) > 0)
             {
-                var packageInfo = new TreeNodePackageInfo(hitTestInfo.Node);
-                if (result == OperationHitTestLocation.Primary && packageInfo.HasLocalPackage)
-                {
-                    var metadataBuilder = PackageSearchMetadataBuilder.FromIdentity(packageInfo.LocalPackage.Identity);
-                    OnOperationClick(new PackageViewEventArgs(metadataBuilder.Build(), PackageOperationType.Uninstall));
-                }
-                else
-                {
-                    var operation = result == OperationHitTestLocation.Secondary
-                        ? PackageOperationType.Update
-                        : PackageOperationType.Install;
-                    OnOperationClick(new((IPackageSearchMetadata)hitTestInfo.Node.Tag, operation));
-                }
+                PerformOperation(hitTestInfo.Node, result);
             }
             base.OnMouseClick(e);
+        }
+
+        protected override bool IsInputKey(Keys keyData)
+        {
+            if ((keyData & Keys.KeyCode) == Keys.Enter)
+                return true;
+            return base.IsInputKey(keyData);
+        }
+
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter && SelectedNode?.Tag != null)
+            {
+                var packageInfo = new TreeNodePackageInfo(SelectedNode);
+                var location = packageInfo.HasPackageUpdates ? OperationHitTestLocation.Secondary
+                    : !packageInfo.HasLocalPackage ? OperationHitTestLocation.Primary
+                    : OperationHitTestLocation.None;
+                if (location != OperationHitTestLocation.None)
+                {
+                    PerformOperation(SelectedNode, location);
+                    e.Handled = e.SuppressKeyPress = true;
+                }
+            }
+            base.OnKeyDown(e);
+        }
+
+        protected override void OnBeforeExpand(TreeViewCancelEventArgs e)
+        {
+            e.Cancel = true;
+            base.OnBeforeExpand(e);
+        }
+
+        private void PerformOperation(TreeNode node, OperationHitTestLocation location)
+        {
+            var packageInfo = new TreeNodePackageInfo(node);
+            if (location == OperationHitTestLocation.Primary && packageInfo.HasLocalPackage)
+            {
+                var metadataBuilder = PackageSearchMetadataBuilder.FromIdentity(packageInfo.LocalPackage.Identity);
+                OnOperationClick(new PackageViewEventArgs(metadataBuilder.Build(), PackageOperationType.Uninstall));
+            }
+            else
+            {
+                var operation = location == OperationHitTestLocation.Secondary
+                    ? PackageOperationType.Update
+                    : PackageOperationType.Install;
+                OnOperationClick(new((IPackageSearchMetadata)node.Tag, operation));
+            }
         }
 
         private OperationHitTestLocation OperationHitTest(Point pt, out TreeViewHitTestInfo hitTestInfo)

--- a/Bonsai.NuGet.Design/PackageViewController.cs
+++ b/Bonsai.NuGet.Design/PackageViewController.cs
@@ -182,6 +182,11 @@ namespace Bonsai.NuGet.Design
             packagePageSelector.SelectedPage = 0;
         }
 
+        public void ClearSearch()
+        {
+            searchComboBox.Text = string.Empty;
+        }
+
         QueryContinuation<IEnumerable<IPackageSearchMetadata>> GetPackageQuery(string searchTerm, int pageSize, bool updateQuery)
         {
             if (PackageManager == null)


### PR DESCRIPTION
This groups three small, independent fixes to the package manager dialog, all found while making the dialog usable from the keyboard. They are in the same files and can be reviewed as one unit.

### Install or update from the keyboard (#2382)

Pressing Enter on the selected package now runs the primary acquisition: install when the package is not installed, update when an update is available. The dispatch reuses the existing mouse-click path, so the operation and its dependency handling are identical to clicking. Uninstall is deliberately left to the mouse, since the request is only about installing from the keyboard and a destructive action on Enter is easy to hit by accident.

### Reset search when switching tabs (#2383)

Switching between the Browse, Installed, and Updates tabs now clears the search box, so each tab opens on its full list. Carrying the previous term into Installed or Updates would silently filter those lists and silently hide packages. The refresh button and the package source selector keep the current term, since re-running the same query is their purpose.

### Avoid a crash when expanding a package node (#2588)

Package entries carry hidden child nodes that hold internal data, the installed version and any deprecation notice, rather than navigable content. Expanding an entry would reveal these children, and the node-drawing code would cast their value to `IPackageSearchMetadata` during paint and throw an unhandled `InvalidCastException`, crashing the editor. Package nodes no longer expand. This crash is present in the current release and is not introduced by the other changes here.

These are WinForms interaction changes with no automated coverage, so each was verified by hand in the dialog.

Fixes #2382
Fixes #2383
Fixes #2588