### PR TITLE
Improve package manager keyboard navigation

### DIFF
--- a/Bonsai.NuGet.Design/PackageManagerDialog.Designer.cs
+++ b/Bonsai.NuGet.Design/PackageManagerDialog.Designer.cs
@@ -130,7 +130,7 @@
             this.browseButton.Name = "browseButton";
             this.browseButton.Size = new System.Drawing.Size(52, 23);
             this.browseButton.TabIndex = 0;
-            this.browseButton.Text = "Browse";
+            this.browseButton.Text = "&Browse";
             this.browseButton.UseVisualStyleBackColor = true;
             this.browseButton.CheckedChanged += new System.EventHandler(this.tabButton_CheckedChanged);
             // 
@@ -145,7 +145,7 @@
             this.installedButton.Name = "installedButton";
             this.installedButton.Size = new System.Drawing.Size(56, 23);
             this.installedButton.TabIndex = 1;
-            this.installedButton.Text = "Installed";
+            this.installedButton.Text = "&Installed";
             this.installedButton.UseVisualStyleBackColor = true;
             this.installedButton.CheckedChanged += new System.EventHandler(this.tabButton_CheckedChanged);
             // 
@@ -160,7 +160,7 @@
             this.updatesButton.Name = "updatesButton";
             this.updatesButton.Size = new System.Drawing.Size(57, 23);
             this.updatesButton.TabIndex = 2;
-            this.updatesButton.Text = "Updates";
+            this.updatesButton.Text = "&Updates";
             this.updatesButton.UseVisualStyleBackColor = true;
             this.updatesButton.CheckedChanged += new System.EventHandler(this.tabButton_CheckedChanged);
             // 
@@ -215,6 +215,7 @@
             this.refreshButton.Name = "refreshButton";
             this.refreshButton.Size = new System.Drawing.Size(18, 19);
             this.refreshButton.TabIndex = 1;
+            this.refreshButton.TabStop = false;
             this.refreshButton.UseVisualStyleBackColor = true;
             this.refreshButton.Click += new System.EventHandler(this.refreshButton_Click);
             // 
@@ -226,7 +227,8 @@
             this.prereleaseCheckBox.Name = "prereleaseCheckBox";
             this.prereleaseCheckBox.Size = new System.Drawing.Size(113, 17);
             this.prereleaseCheckBox.TabIndex = 2;
-            this.prereleaseCheckBox.Text = "Include prerelease";
+            this.prereleaseCheckBox.TabStop = false;
+            this.prereleaseCheckBox.Text = "Include &prerelease";
             this.prereleaseCheckBox.UseVisualStyleBackColor = true;
             // 
             // dependencyCheckBox
@@ -237,7 +239,8 @@
             this.dependencyCheckBox.Name = "dependencyCheckBox";
             this.dependencyCheckBox.Size = new System.Drawing.Size(123, 17);
             this.dependencyCheckBox.TabIndex = 3;
-            this.dependencyCheckBox.Text = "Show advanced";
+            this.dependencyCheckBox.TabStop = false;
+            this.dependencyCheckBox.Text = "Show &advanced";
             this.dependencyCheckBox.UseVisualStyleBackColor = true;
             this.dependencyCheckBox.CheckedChanged += new System.EventHandler(this.dependencyCheckBox_CheckedChanged);
             // 

--- a/Bonsai.NuGet.Design/PackageManagerDialog.cs
+++ b/Bonsai.NuGet.Design/PackageManagerDialog.cs
@@ -98,7 +98,18 @@ namespace Bonsai.NuGet.Design
                 case PackageManagerTab.Updates: updatesButton.PerformClick(); break;
                 default: browseButton.PerformClick(); break;
             }
+            packageViewController.FocusSearch();
             base.OnLoad(e);
+        }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (keyData == Keys.F5)
+            {
+                UpdateSelectedRepository();
+                return true;
+            }
+            return base.ProcessCmdKey(ref msg, keyData);
         }
 
         protected override void ScaleControl(SizeF factor, BoundsSpecified specified)

--- a/Bonsai.NuGet.Design/PackageViewController.cs
+++ b/Bonsai.NuGet.Design/PackageViewController.cs
@@ -187,6 +187,11 @@ namespace Bonsai.NuGet.Design
             searchComboBox.Text = string.Empty;
         }
 
+        public void FocusSearch()
+        {
+            searchComboBox.Select();
+        }
+
         QueryContinuation<IEnumerable<IPackageSearchMetadata>> GetPackageQuery(string searchTerm, int pageSize, bool updateQuery)
         {
             if (PackageManager == null)


### PR DESCRIPTION
This implements the improvements proposed in #2590, so the package manager dialog supports its primary flow from the keyboard: type a search term, Tab into the results, navigate with the arrow keys, and install or update with Enter.

- Focus starts on the search box when the dialog opens, rather than on the operation tab buttons.
- The refresh button and the prerelease and advanced checkboxes are no longer tab stops, so a single Tab moves from the search box into the package list.
- Those options are reachable by access keys instead: <kbd>Alt</kbd>+<kbd>P</kbd> and <kbd>Alt</kbd>+<kbd>A</kbd> for the checkboxes and <kbd>F5</kbd> for refresh.
- The Browse, Installed, and Updates tabs gain <kbd>Alt</kbd>+<kbd>B</kbd>, <kbd>Alt</kbd>+<kbd>I</kbd>, and <kbd>Alt</kbd>+<kbd>U</kbd> mnemonics for direct switching. The existing <kbd>Ctrl</kbd>+<kbd>L</kbd> jump-to-search is unchanged.

The deliberate tradeoff is that the filters are no longer reachable by Tab, only by their access keys. Tapping <kbd>Alt</kbd> reveals the underlined mnemonics on the controls, so the access keys stay discoverable rather than hidden.

Closes #2590