### PR TITLE
Await editor extensions before auto-starting a workflow

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -914,23 +914,23 @@ namespace Bonsai.Editor
 
             visualizerSettings.Clear();
             var layoutPath = LayoutHelper.GetCompatibleLayoutPath(settingsDirectory, fileName);
-            if (File.Exists(layoutPath))
+            try
             {
-                try
+                await initialization;
+                if (File.Exists(layoutPath))
                 {
                     var visualizerLayout = VisualizerLayout.Load(layoutPath);
-                    await initialization;
                     visualizerSettings.SetVisualizerLayout(workflowBuilder, visualizerLayout);
                 }
-                catch (Exception ex) when (ex is ArgumentException || ex is InvalidOperationException)
+            }
+            catch (Exception ex) when (ex is ArgumentException || ex is InvalidOperationException)
+            {
+                var icon = MessageBoxIcon.Error;
+                var caption = Resources.VisualizerLayout_Caption;
+                var message = string.Format(Resources.VisualizerLayoutCorrupt_Question, ex.Message);
+                if (MessageBox.Show(this, message, caption, MessageBoxButtons.YesNo, icon) == DialogResult.Yes)
                 {
-                    var icon = MessageBoxIcon.Error;
-                    var caption = Resources.VisualizerLayout_Caption;
-                    var message = string.Format(Resources.VisualizerLayoutCorrupt_Question, ex.Message);
-                    if (MessageBox.Show(this, message, caption, MessageBoxButtons.YesNo, icon) == DialogResult.Yes)
-                    {
-                        File.Delete(layoutPath);
-                    }
+                    File.Delete(layoutPath);
                 }
             }
 

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -913,24 +913,25 @@ namespace Bonsai.Editor
             }
 
             visualizerSettings.Clear();
+            await initialization;
+
             var layoutPath = LayoutHelper.GetCompatibleLayoutPath(settingsDirectory, fileName);
-            try
+            if (File.Exists(layoutPath))
             {
-                await initialization;
-                if (File.Exists(layoutPath))
+                try
                 {
                     var visualizerLayout = VisualizerLayout.Load(layoutPath);
                     visualizerSettings.SetVisualizerLayout(workflowBuilder, visualizerLayout);
                 }
-            }
-            catch (Exception ex) when (ex is ArgumentException || ex is InvalidOperationException)
-            {
-                var icon = MessageBoxIcon.Error;
-                var caption = Resources.VisualizerLayout_Caption;
-                var message = string.Format(Resources.VisualizerLayoutCorrupt_Question, ex.Message);
-                if (MessageBox.Show(this, message, caption, MessageBoxButtons.YesNo, icon) == DialogResult.Yes)
+                catch (Exception ex) when (ex is ArgumentException || ex is InvalidOperationException)
                 {
-                    File.Delete(layoutPath);
+                    var icon = MessageBoxIcon.Error;
+                    var caption = Resources.VisualizerLayout_Caption;
+                    var message = string.Format(Resources.VisualizerLayoutCorrupt_Question, ex.Message);
+                    if (MessageBox.Show(this, message, caption, MessageBoxButtons.YesNo, icon) == DialogResult.Yes)
+                    {
+                        File.Delete(layoutPath);
+                    }
                 }
             }
 


### PR DESCRIPTION
#2592 is a race condition in editor startup, not a bug in visualizer resolution. While opening a workflow, the editor populates its type-visualizer map asynchronously, but it only awaited that initialization when a layout file was present.

This was previously harmless. With no layout file, no visualizer windows were launched at startup, so the map was not needed. However, the newly added `VisualizerWindow` operator forces a visualizer window to open at workflow start regardless of any layout file. If such a workflow were to open without a layout file, the type-visualizer map would still be empty when the workflow auto-starts, and creating the visualizer window would throw.

The fix awaits initialization before the layout-file check, so it always completes when a workflow is opened, whether or not a layout file exists. The corrupt-layout error handler stays scoped to the layout load, so any initialization failures are no longer reported through a misleading "visualizer layout may be corrupt" prompt.

Closes #2592