### PR TITLE
Launch specified visualizers correctly without the debugger 

### DIFF
--- a/Bonsai.Editor/Layout/LayoutHelper.cs
+++ b/Bonsai.Editor/Layout/LayoutHelper.cs
@@ -48,7 +48,8 @@ namespace Bonsai.Design
                 var inspectBuilder = (InspectBuilder)node.Value;
                 if (lookup.TryGetValue(inspectBuilder, out VisualizerWindowLauncher _))
                 {
-                    SetVisualizerNotifications(inspectBuilder);
+                    var visualizerElement = ExpressionBuilder.GetVisualizerElement(inspectBuilder);
+                    SetVisualizerNotifications(visualizerElement);
                 }
             }
         }

--- a/Bonsai.Editor/WorkflowRunner.cs
+++ b/Bonsai.Editor/WorkflowRunner.cs
@@ -160,8 +160,6 @@ namespace Bonsai.Editor
             var settingsPath = Project.GetWorkflowSettingsDirectory(fileName);
             layoutPath ??= LayoutHelper.GetCompatibleLayoutPath(settingsPath, fileName);
 
-            // Run the visualizer layout if there is a layout file to restore, or if the workflow
-            // contains any VisualizerWindow operator forcing a window to be displayed on start.
             var hasLayout = File.Exists(layoutPath);
             var hasVisualizerWindow = workflowBuilder.Workflow.Descendants().OfType<VisualizerWindow>().Any();
             var runLayout = visualizerProvider != null && (hasLayout || hasVisualizerWindow);

--- a/Bonsai.Editor/WorkflowRunner.cs
+++ b/Bonsai.Editor/WorkflowRunner.cs
@@ -157,18 +157,23 @@ namespace Bonsai.Editor
             }
 
             var workflowBuilder = ElementStore.LoadWorkflow(fileName);
-            var runLayout = visualizerProvider != null && File.Exists(layoutPath);
+            var settingsPath = Project.GetWorkflowSettingsDirectory(fileName);
+            layoutPath ??= LayoutHelper.GetCompatibleLayoutPath(settingsPath, fileName);
+
+            // Run the visualizer layout if there is a layout file to restore, or if the workflow
+            // contains any VisualizerWindow operator forcing a window to be displayed on start.
+            var hasLayout = File.Exists(layoutPath);
+            var hasVisualizerWindow = workflowBuilder.Workflow.Descendants().OfType<VisualizerWindow>().Any();
+            var runLayout = visualizerProvider != null && (hasLayout || hasVisualizerWindow);
             if (debugger || runLayout)
                 workflowBuilder = new WorkflowBuilder(workflowBuilder.Workflow.ToInspectableGraph());
 
-            var settingsPath = Project.GetWorkflowSettingsDirectory(fileName);
-            layoutPath ??= LayoutHelper.GetCompatibleLayoutPath(settingsPath, fileName);
             var exceptionCache = new WorkflowRuntimeExceptionCache();
             try
             {
                 if (runLayout)
                 {
-                    var layout = VisualizerLayout.Load(layoutPath);
+                    var layout = hasLayout ? VisualizerLayout.Load(layoutPath) : new VisualizerLayout();
                     RunLayout(workflowBuilder, exceptionCache, propertyAssignments, visualizerProvider, layout, fileName, debugger);
                 }
                 else RunHeadless(workflowBuilder, exceptionCache, propertyAssignments, fileName);


### PR DESCRIPTION
#2560 reports two failures when running a workflow that contains a `VisualizerWindow` in the player, with `--no-editor`: with no layout file the player would hang without opening a window, and behind a mashup visualizer such as `TableLayoutPanel` it would crash. The two have separate causes, and this PR addresses both.

### Running the layout when a VisualizerWindow is present

`WorkflowRunner.Run` chose between the visualizer layout and headless execution based only on whether a layout file existed, and it resolved the default layout path only after that decision. A workflow with a `VisualizerWindow` but no layout file would therefore run headless and never open its window. It now resolves the default layout path first and runs the visualizer layout whenever a layout file exists or the workflow contains a `VisualizerWindow`, loading an empty layout when no file is present.

### Visualizer notifications for forwarded elements

Even with the layout running, the hosted visualizer would fail whenever the workflow ran without the debugger. The player always runs this way, and so does starting without the debugger in the editor. `SetLayoutNotifications` enabled visualizer notifications on each operator listed in the layout map, but a `VisualizerWindow` forwards its visualizer element from an upstream operator, as `VisualizerMapping` and pass-through operators such as `PublishSubject` also do. The forwarded element would be left without its visualizer notifications, and dependent visualizers could not resolve it, which would produce the `InvalidCastException` in `TableLayoutPanelVisualizer` and, in other cases, a fallback to `ObjectTextVisualizer`. The notification recursion now begins from the resolved visualizer element rather than the listed operator, so forwarded elements receive their notifications.

With both changes, a workflow containing a `VisualizerWindow` opens and displays its visualizer when run in the player, with or without a layout file.

Closes #2560