### PR TITLE
Skip invalid visualizer layout on headless launch

### DIFF
--- a/Bonsai.Editor.Tests/WorkflowRunnerVisualizerTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowRunnerVisualizerTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Linq;
+using Bonsai.Core.Tests;
+using Bonsai.Design;
+using Bonsai.Expressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Editor.Tests
+{
+    [TestClass]
+    public class WorkflowRunnerVisualizerTests
+    {
+        static WorkflowBuilder BuildWorkflow<T>(T value)
+        {
+            var workflowBuilder = new WorkflowBuilder(new TestWorkflow().AppendValue(value).ToInspectableGraph());
+            workflowBuilder.Workflow.Build();
+            return workflowBuilder;
+        }
+
+        static VisualizerLayout CreateLayoutForFirstNode(string visualizerTypeName)
+        {
+            var layout = new VisualizerLayout();
+            layout.WindowSettings.Add(new VisualizerWindowSettings
+            {
+                Index = 0,
+                VisualizerTypeName = visualizerTypeName
+            });
+            return layout;
+        }
+
+        static bool HasWindowSettings(VisualizerLayoutMap settings, WorkflowBuilder workflowBuilder)
+        {
+            var source = (InspectBuilder)workflowBuilder.Workflow.First().Value;
+            return settings.TryGetValue(source, out _);
+        }
+
+        [TestMethod]
+        public void CreateVisualizerSettings_CompatibleVisualizer_AppliesLayout()
+        {
+            var workflowBuilder = BuildWorkflow(0);
+            var typeVisualizers = new TypeVisualizerMap();
+            typeVisualizers.Add(typeof(int), typeof(TestVisualizer));
+            var layout = CreateLayoutForFirstNode(typeof(TestVisualizer).FullName);
+
+            var settings = WorkflowRunner.CreateVisualizerSettings(workflowBuilder, layout, typeVisualizers);
+            Assert.IsTrue(HasWindowSettings(settings, workflowBuilder));
+        }
+
+        [TestMethod]
+        public void CreateVisualizerSettings_UnavailableVisualizer_SkipsLayoutWithoutThrowing()
+        {
+            var workflowBuilder = BuildWorkflow(0);
+            var typeVisualizers = new TypeVisualizerMap();
+            var layout = CreateLayoutForFirstNode("Missing.Visualizer.Type");
+
+            var settings = WorkflowRunner.CreateVisualizerSettings(workflowBuilder, layout, typeVisualizers);
+            Assert.IsFalse(HasWindowSettings(settings, workflowBuilder));
+        }
+
+        [TestMethod]
+        public void CreateVisualizerSettings_IncompatibleVisualizer_SkipsLayoutWithoutThrowing()
+        {
+            var workflowBuilder = BuildWorkflow("text");
+            var typeVisualizers = new TypeVisualizerMap();
+            typeVisualizers.Add(typeof(int), typeof(TestVisualizer));
+            var layout = CreateLayoutForFirstNode(typeof(TestVisualizer).FullName);
+
+            var settings = WorkflowRunner.CreateVisualizerSettings(workflowBuilder, layout, typeVisualizers);
+            Assert.IsFalse(HasWindowSettings(settings, workflowBuilder));
+        }
+
+        class TestVisualizer : DialogTypeVisualizer
+        {
+            public override void Load(IServiceProvider provider) { }
+
+            public override void Show(object value) { }
+
+            public override void Unload() { }
+        }
+    }
+}

--- a/Bonsai.Editor/WorkflowRunner.cs
+++ b/Bonsai.Editor/WorkflowRunner.cs
@@ -34,7 +34,7 @@ namespace Bonsai.Editor
                                    .ToEnumerable().ToList();
             BuildAssignProperties(workflowBuilder, propertyAssignments);
 
-            var visualizerSettings = VisualizerLayoutMap.FromVisualizerLayout(workflowBuilder, layout, typeVisualizers);
+            var visualizerSettings = CreateVisualizerSettings(workflowBuilder, layout, typeVisualizers);
             var visualizerWindows = visualizerSettings.CreateVisualizerWindows(workflowBuilder);
             LayoutHelper.SetWorkflowNotifications(workflowBuilder.Workflow, publishNotifications: debugger);
             LayoutHelper.SetLayoutNotifications(workflowBuilder.Workflow, visualizerWindows);
@@ -81,6 +81,22 @@ namespace Bonsai.Editor
                 cts.Token);
 
             Application.Run();
+        }
+
+        internal static VisualizerLayoutMap CreateVisualizerSettings(
+            WorkflowBuilder workflowBuilder,
+            VisualizerLayout layout,
+            TypeVisualizerMap typeVisualizers)
+        {
+            try
+            {
+                return VisualizerLayoutMap.FromVisualizerLayout(workflowBuilder, layout, typeVisualizers);
+            }
+            catch (Exception ex) when (ex is ArgumentException || ex is InvalidOperationException)
+            {
+                Console.Error.WriteLine($"The visualizer layout could not be applied and was skipped. {ex.Message}");
+                return VisualizerLayoutMap.FromVisualizerLayout(workflowBuilder, new VisualizerLayout(), typeVisualizers);
+            }
         }
 
         static void RunHeadless(


### PR DESCRIPTION
#2375 reports a player crash when launching a workflow whose saved layout assigns a visualizer to an operator that was later replaced; applying an incompatible or unavailable visualizer would throw and abort startup. The editor already handles this at load with the "layout may be corrupt" dialog; the `--no-editor` player had no such guard.

The player now skips the layout and launches anyway when it cannot be applied, reporting the mismatch on standard error. Operators that embed their own window, such as `VisualizerWindow`, still open, since those come from the workflow rather than the layout. A blocking dialog was avoided to keep `--no-editor` non-interactive. The incompatible layout can be cleared by opening the workflow in the editor, and accepting the prompt to delete the layout.

Tested with regression coverage for the compatible, unavailable, and incompatible cases, plus manual runs across the editor and player paths confirming a `VisualizerWindow` still opens alongside a skipped layout.

Closes #2375