### PR TITLE
Clarify visualizer layout error messages

### DIFF
--- a/Bonsai.Editor.Tests/VisualizerLayoutMapTests.cs
+++ b/Bonsai.Editor.Tests/VisualizerLayoutMapTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Bonsai.Core.Tests;
 using Bonsai.Design;
@@ -31,6 +32,15 @@ namespace Bonsai.Editor.Tests
             return settings.TryGetValue(source, out _);
         }
 
+        static InvalidOperationException AssertThrowsForUnavailableVisualizer(ExpressionBuilder builder)
+        {
+            var workflowBuilder = BuildWorkflow(builder);
+            var typeVisualizers = new TypeVisualizerMap();
+            var layout = CreateLayoutForFirstNode("Missing.Visualizer.Type");
+            return Assert.ThrowsException<InvalidOperationException>(
+                () => VisualizerLayoutMap.FromVisualizerLayout(workflowBuilder, layout, typeVisualizers));
+        }
+
         [TestMethod]
         public void FromVisualizerLayout_UnavailableVisualizerOnDisabledNode_SkipsWithoutThrowing()
         {
@@ -40,6 +50,67 @@ namespace Bonsai.Editor.Tests
 
             var settings = VisualizerLayoutMap.FromVisualizerLayout(workflowBuilder, layout, typeVisualizers);
             Assert.IsFalse(HasWindowSettings(settings, workflowBuilder));
+        }
+
+        [TestMethod]
+        public void FromVisualizerLayout_UnavailableVisualizerOnVisualizerMappingBuilder_ReportsUnavailableType()
+        {
+            var exception = AssertThrowsForUnavailableVisualizer(new VisualizerMappingBuilder());
+            StringAssert.Contains(exception.Message, "is not available");
+        }
+
+        [TestMethod]
+        public void FromVisualizerLayout_UnavailableVisualizerOnRegularOperator_ReportsUnavailableType()
+        {
+            var exception = AssertThrowsForUnavailableVisualizer(
+                new CombinatorBuilder { Combinator = new WorkflowProperty<int>() });
+            StringAssert.Contains(exception.Message, "is not available");
+        }
+
+        [TestMethod]
+        public void FromVisualizerLayout_UnavailableVisualizer_MessageNamesElementWithoutIndex()
+        {
+            var exception = AssertThrowsForUnavailableVisualizer(new VisualizerWindow());
+            StringAssert.Contains(exception.Message, ExpressionBuilder.GetElementDisplayName(new VisualizerWindow()));
+            StringAssert.Contains(exception.Message, "is not available");
+            Assert.IsFalse(exception.Message.Contains('#'), "message should not expose a raw element index");
+        }
+
+        [TestMethod]
+        public void FromVisualizerLayout_UnavailableVisualizerInGroup_MessageShowsBreadcrumbPath()
+        {
+            var workflowBuilder = new WorkflowBuilder(new TestWorkflow()
+                .AppendNested(
+                    inner => inner.Append(new VisualizerWindow()),
+                    workflow => new GroupWorkflowBuilder(workflow) { Name = "MyGroup" })
+                .ToInspectableGraph());
+            var typeVisualizers = new TypeVisualizerMap();
+            var nestedLayout = new VisualizerLayout();
+            nestedLayout.WindowSettings.Add(new VisualizerWindowSettings
+            {
+                Index = 0,
+                VisualizerTypeName = "Missing.Visualizer.Type"
+            });
+            var layout = new VisualizerLayout();
+            layout.WindowSettings.Add(new VisualizerWindowSettings { Index = 0, NestedLayout = nestedLayout });
+
+            var exception = Assert.ThrowsException<InvalidOperationException>(
+                () => VisualizerLayoutMap.FromVisualizerLayout(workflowBuilder, layout, typeVisualizers));
+            StringAssert.Contains(exception.Message, "MyGroup > ");
+            StringAssert.Contains(exception.Message, "is not available");
+        }
+
+        [TestMethod]
+        public void FromVisualizerLayout_LayoutIndexOutOfRange_ReportsMissingElementWithoutIndex()
+        {
+            var workflowBuilder = BuildWorkflow(new VisualizerWindow());
+            var typeVisualizers = new TypeVisualizerMap();
+            var layout = new VisualizerLayout();
+            layout.WindowSettings.Add(new VisualizerWindowSettings { Index = 5 });
+
+            var exception = Assert.ThrowsException<InvalidOperationException>(
+                () => VisualizerLayoutMap.FromVisualizerLayout(workflowBuilder, layout, typeVisualizers));
+            Assert.IsFalse(exception.Message.Contains('#'), "message should not expose a raw element index");
         }
     }
 }

--- a/Bonsai.Editor.Tests/VisualizerLayoutMapTests.cs
+++ b/Bonsai.Editor.Tests/VisualizerLayoutMapTests.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using Bonsai.Core.Tests;
+using Bonsai.Design;
+using Bonsai.Expressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Editor.Tests
+{
+    [TestClass]
+    public class VisualizerLayoutMapTests
+    {
+        static WorkflowBuilder BuildWorkflow(ExpressionBuilder builder)
+        {
+            return new WorkflowBuilder(new TestWorkflow().Append(builder).ToInspectableGraph());
+        }
+
+        static VisualizerLayout CreateLayoutForFirstNode(string visualizerTypeName)
+        {
+            var layout = new VisualizerLayout();
+            layout.WindowSettings.Add(new VisualizerWindowSettings
+            {
+                Index = 0,
+                VisualizerTypeName = visualizerTypeName
+            });
+            return layout;
+        }
+
+        static bool HasWindowSettings(VisualizerLayoutMap settings, WorkflowBuilder workflowBuilder)
+        {
+            var source = (InspectBuilder)workflowBuilder.Workflow.First().Value;
+            return settings.TryGetValue(source, out _);
+        }
+
+        [TestMethod]
+        public void FromVisualizerLayout_UnavailableVisualizerOnDisabledNode_SkipsWithoutThrowing()
+        {
+            var workflowBuilder = BuildWorkflow(new DisableBuilder(new VisualizerWindow()));
+            var typeVisualizers = new TypeVisualizerMap();
+            var layout = CreateLayoutForFirstNode("Missing.Visualizer.Type");
+
+            var settings = VisualizerLayoutMap.FromVisualizerLayout(workflowBuilder, layout, typeVisualizers);
+            Assert.IsFalse(HasWindowSettings(settings, workflowBuilder));
+        }
+    }
+}

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -927,7 +927,7 @@ namespace Bonsai.Editor
                 {
                     var icon = MessageBoxIcon.Error;
                     var caption = Resources.VisualizerLayout_Caption;
-                    var message = string.Format(Resources.VisualizerLayoutCorrupt_Question, ex.Message);
+                    var message = string.Format(Resources.VisualizerLayout_Question, ex.Message);
                     if (MessageBox.Show(this, message, caption, MessageBoxButtons.YesNo, icon) == DialogResult.Yes)
                     {
                         File.Delete(layoutPath);

--- a/Bonsai.Editor/Layout/VisualizerLayoutMap.cs
+++ b/Bonsai.Editor/Layout/VisualizerLayoutMap.cs
@@ -122,6 +122,9 @@ namespace Bonsai.Design
             for (int i = 0; i < workflow.Count; i++)
             {
                 var builder = (InspectBuilder)workflow[i].Value;
+                if (ExpressionBuilder.Unwrap(builder) is DisableBuilder)
+                    continue;
+
                 var layoutSettings = new VisualizerWindowSettings { Index = i };
 
                 if (lookup.TryGetValue(builder, out VisualizerWindowSettings windowSettings))
@@ -177,6 +180,9 @@ namespace Bonsai.Design
                 else
                 {
                     var builder = (InspectBuilder)workflow[index].Value;
+                    if (ExpressionBuilder.Unwrap(builder) is DisableBuilder)
+                        continue;
+
                     var windowSettings = new VisualizerWindowSettings();
                     windowSettings.Tag = builder;
                     windowSettings.Bounds = layoutSettings.Bounds;

--- a/Bonsai.Editor/Layout/VisualizerLayoutMap.cs
+++ b/Bonsai.Editor/Layout/VisualizerLayoutMap.cs
@@ -176,11 +176,13 @@ namespace Bonsai.Design
                 var layoutSettings = layout.WindowSettings[i];
                 var index = layoutSettings.Index.GetValueOrDefault(i);
                 if (index < 0 || index >= workflow.Count)
-                    throw new InvalidOperationException($"Element #{index} does not exist in the workflow.");
+                    throw new InvalidOperationException(
+                        "The layout refers to an element that no longer exists in the workflow.");
                 else
                 {
                     var builder = (InspectBuilder)workflow[index].Value;
-                    if (ExpressionBuilder.Unwrap(builder) is DisableBuilder)
+                    var unwrapBuilder = ExpressionBuilder.Unwrap(builder);
+                    if (unwrapBuilder is DisableBuilder)
                         continue;
 
                     var windowSettings = new VisualizerWindowSettings();
@@ -193,45 +195,40 @@ namespace Bonsai.Design
                     {
                         if (typeVisualizerMap.GetVisualizerType(layoutSettings.VisualizerTypeName) is null)
                             throw new InvalidOperationException(
-                                $"Visualizer cannot be applied to element #{index}: " +
-                                $"{ExpressionBuilder.GetWorkflowElement(builder).GetType()}. The visualizer type " +
+                                $"{ExpressionBuilder.GetElementDisplayName(builder)}: The visualizer type " +
                                 $"'{layoutSettings.VisualizerTypeName}' is not available.");
 
                         var visualizerElement = ExpressionBuilder.GetVisualizerElement(builder);
                         var visualizerTypes = typeVisualizerMap.GetTypeVisualizers(visualizerElement);
                         if (!visualizerTypes.Any(type => type.FullName == layoutSettings.VisualizerTypeName))
                             throw new InvalidOperationException(
-                                $"Visualizer type '{layoutSettings.VisualizerTypeName}' cannot be applied " +
-                                $"to element #{index}: {ExpressionBuilder.GetWorkflowElement(builder).GetType()}.");
+                                $"{ExpressionBuilder.GetElementDisplayName(builder)}: The visualizer type " +
+                                $"'{layoutSettings.VisualizerTypeName}' is not compatible.");
                         windowSettings.VisualizerTypeName = layoutSettings.VisualizerTypeName;
                         Add(windowSettings);
                     }
 
                     if (layoutSettings.NestedLayout != null &&
-                        ExpressionBuilder.Unwrap(builder) is IWorkflowExpressionBuilder workflowBuilder)
+                        unwrapBuilder is IWorkflowExpressionBuilder workflowBuilder)
                     {
                         try { SetVisualizerLayout(workflowBuilder.Workflow, layoutSettings.NestedLayout); }
                         catch (InvalidOperationException innerException)
                         {
-                            throw new InvalidOperationException(
-                                $"Visualizer cannot be applied to an inner element of nested layout #{index}: " +
-                                $"{ExpressionBuilder.GetWorkflowElement(builder).GetType()}.",
-                                innerException);
+                            var location = $"{ExpressionBuilder.GetElementDisplayName(builder)} > ";
+                            throw new InvalidOperationException(location + innerException.Message, innerException);
                         }
                     }
 
 #pragma warning disable CS0612 // Type or member is obsolete
                     if (layoutSettings is WorkflowEditorSettings editorSettings &&
                         editorSettings.EditorVisualizerLayout is not null &&
-                        ExpressionBuilder.Unwrap(builder) is IWorkflowExpressionBuilder editorWorkflowBuilder)
+                        unwrapBuilder is IWorkflowExpressionBuilder editorWorkflowBuilder)
                     {
                         try { SetVisualizerLayout(editorWorkflowBuilder.Workflow, editorSettings.EditorVisualizerLayout); }
                         catch (InvalidOperationException innerException)
                         {
-                            throw new InvalidOperationException(
-                                $"Visualizer cannot be applied to an inner element of nested layout #{index}: " +
-                                $"{ExpressionBuilder.GetWorkflowElement(builder).GetType()}.",
-                                innerException);
+                            var location = $"{ExpressionBuilder.GetElementDisplayName(builder)} > ";
+                            throw new InvalidOperationException(location + innerException.Message, innerException);
                         }
                     }
 #pragma warning restore CS0612 // Type or member is obsolete

--- a/Bonsai.Editor/Properties/Resources.Designer.cs
+++ b/Bonsai.Editor/Properties/Resources.Designer.cs
@@ -990,14 +990,14 @@ namespace Bonsai.Editor.Properties {
         /// <summary>
         ///   Looks up a localized string similar to {0}
         ///
-        ///The visualizer layout may be corrupt. Do you want to delete the layout file?.
+        ///Do you want to delete the layout file?.
         /// </summary>
-        internal static string VisualizerLayoutCorrupt_Question {
+        internal static string VisualizerLayout_Question {
             get {
-                return ResourceManager.GetString("VisualizerLayoutCorrupt_Question", resourceCulture);
+                return ResourceManager.GetString("VisualizerLayout_Question", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Cannot set visualizer layout with a null workflow..
         /// </summary>

--- a/Bonsai.Editor/Properties/Resources.resx
+++ b/Bonsai.Editor/Properties/Resources.resx
@@ -346,13 +346,13 @@ NOTE: You will have to restart Bonsai for any changes to take effect.</value>
   <data name="SelectVisualizerMenuItem" xml:space="preserve">
     <value>Select Visualizer</value>
   </data>
-  <data name="VisualizerLayoutCorrupt_Question" xml:space="preserve">
-    <value>{0}
-
-The visualizer layout may be corrupt. Do you want to delete the layout file?</value>
-  </data>
   <data name="VisualizerLayout_Caption" xml:space="preserve">
     <value>Visualizer Layout</value>
+  </data>
+  <data name="VisualizerLayout_Question" xml:space="preserve">
+    <value>{0}
+
+Do you want to delete the layout file?</value>
   </data>
   <data name="PropertyAssignment_Error" xml:space="preserve">
     <value>There was an error assigning to property '{0}': {1}


### PR DESCRIPTION
When a visualizer named in a workflow layout cannot be applied, the editor would show a generic message stating the layout may be corrupt, even when the actual cause is a specific visualizer type that is unavailable or incompatible with its element, as described in #2334. This became more confusing once `VisualizerWindow` and `VisualizerMapping` allowed workflows to reference visualizers directly.

This replaces that message with one that names the target element by its display name and nested group path, and states the specific cause:

- the visualizer type is not available, e.g. when its package is not installed
- the visualizer type is not compatible with the element, e.g. after replacing an upstream operator
- the layout refers to an element that no longer exists

The prompt to delete the layout file is kept, since removing the layout resolves the error in each of these cases.

Disabled nodes are now skipped when applying and saving the layout, since a disabled node is inert and cannot display a visualizer.

This is the editor-side counterpart to the headless player guard added in #2603.

### Testing

Added `VisualizerLayoutMapTests` covering disabled-node skipping, the unavailable and incompatible visualizer cases, the absence of raw element indices in the message, and the nested breadcrumb path.

Closes #2334