### PR TITLE
Fix stylesheet import in docs template

### DIFF
--- a/Bonsai.Templates/Bonsai.DocumentationTemplate/docs/template/public/main.css
+++ b/Bonsai.Templates/Bonsai.DocumentationTemplate/docs/template/public/main.css
@@ -1,1 +1,1 @@
-@import "workflow.css";
+@import "bonsai.css";


### PR DESCRIPTION
Update the documentation template stylesheet import from the removed workflow.css to bonsai.css, to match the latest version of docfx-tools.

Closes #2458