### PR TITLE
Make license dialog a true modal window

### DIFF
--- a/Bonsai.NuGet.Design/PackageViewController.cs
+++ b/Bonsai.NuGet.Design/PackageViewController.cs
@@ -127,14 +127,9 @@ namespace Bonsai.NuGet.Design
             else
             {
                 if (operationDialog == null) return;
-                operationDialog.Hide();
                 using (var licenseDialog = new LicenseAcceptanceDialog(e.LicensePackages))
                 {
-                    e.LicenseAccepted = licenseDialog.ShowDialog(control) == DialogResult.Yes;
-                    if (e.LicenseAccepted)
-                    {
-                        operationDialog.Show();
-                    }
+                    e.LicenseAccepted = licenseDialog.ShowDialog(operationDialog) == DialogResult.Yes;
                 }
             }
         }


### PR DESCRIPTION
Show the license acceptance dialog as a modal owned by the visible operation dialog, and stop hiding that dialog. It would otherwise be shown with the operation dialog hidden and owned by the package view, leaving it without a visible owner and able to slip behind other windows.

Closes #2332