### PR TITLE
Suppress toolbox search focus while running

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2737,7 +2737,7 @@ namespace Bonsai.Editor
             public void OnKeyPress(KeyPressEventArgs e)
             {
                 var selectedView = siteForm.selectionModel.SelectedView;
-                if (selectedView != null && selectedView.GraphView.Focused)
+                if (siteForm.running == null && selectedView != null && selectedView.GraphView.Focused)
                 {
                     if (char.IsLetter(e.KeyChar))
                     {


### PR DESCRIPTION
While a workflow is running, typing a letter over the graph view no longer moves focus to the toolbox search box. The explicit Ctrl+E shortcut still focuses it.

Closes #2349