### PR TITLE
Fix toolbox search cue banner and focus race

### DIFF
--- a/Bonsai.Editor/CueBannerTextBox.cs
+++ b/Bonsai.Editor/CueBannerTextBox.cs
@@ -41,8 +41,8 @@ namespace Bonsai.Editor
         {
             if (CueBannerVisible)
             {
-                CueBannerVisible = false;
                 Text = string.Empty;
+                CueBannerVisible = false;
                 ForeColor = activeForeColor;
             }
         }
@@ -70,6 +70,7 @@ namespace Bonsai.Editor
             if (!CueBannerVisible)
             {
                 base.OnTextChanged(e);
+                if (!Focused) ShowCueBanner();
             }
         }
     }

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2741,9 +2741,22 @@ namespace Bonsai.Editor
                 {
                     if (char.IsLetter(e.KeyChar))
                     {
-                        siteForm.searchTextBox.Focus();
-                        siteForm.searchTextBox.Clear();
-                        siteForm.searchTextBox.AppendText(e.KeyChar.ToString());
+                        var keyChar = e.KeyChar.ToString();
+                        var searchTextBox = siteForm.searchTextBox;
+                        if (searchTextBox.Focus())
+                        {
+                            searchTextBox.Clear();
+                            searchTextBox.AppendText(keyChar);
+                        }
+                        else
+                        {
+                            siteForm.BeginInvoke((Action)(() =>
+                            {
+                                searchTextBox.Focus();
+                                searchTextBox.Clear();
+                                searchTextBox.AppendText(keyChar);
+                            }));
+                        }
                         e.Handled = true;
                     }
                 }


### PR DESCRIPTION
This fixes two bugs in the toolbox search box and its cue banner. The first, reported in #2608, is that clearing the box while it is unfocused would leave it empty without bringing the cue banner back. The second is a race in type-to-search, where a letter typed during a pending focus change could appear in the search box while it was still unfocused.

The cue banner now reappears whenever the box is cleared while it is unfocused, for example when using Enter to create the highlighted node.

Type-to-search now defers the focus, clear, and append for the search box when the focus request is rejected, so they can all be applied after the pending focus transition resolves. When focus succeeds immediately, which is the common case, nothing is deferred.

Fixes #2608