### PR TITLE
Reset toolbox search when renaming subjects

### DIFF
--- a/Bonsai.Editor/CueBannerTextBox.cs
+++ b/Bonsai.Editor/CueBannerTextBox.cs
@@ -12,6 +12,18 @@ namespace Bonsai.Editor
 
         public bool CueBannerVisible { get; private set; }
 
+        public override string Text
+        {
+            get => base.Text;
+            set
+            {
+                if (!CueBannerVisible || !string.IsNullOrEmpty(value))
+                {
+                    base.Text = value;
+                }
+            }
+        }
+
         protected override void OnPreviewKeyDown(PreviewKeyDownEventArgs e)
         {
             if (e.Control)
@@ -41,8 +53,8 @@ namespace Bonsai.Editor
         {
             if (CueBannerVisible)
             {
-                Text = string.Empty;
                 CueBannerVisible = false;
+                Text = string.Empty;
                 ForeColor = activeForeColor;
             }
         }

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2156,6 +2156,7 @@ namespace Bonsai.Editor
                     selectedBuilder is MulticastSubject)
                 {
                     var subjectName = ((INamedElement)selectedBuilder).Name;
+                    searchTextBox.Clear();
                     SelectTreeViewSubjectNode(subjectName);
                 }
             }


### PR DESCRIPTION
Pressing <kbd>F2</kbd> to rename a subject from the canvas now resets the toolbox search filter before locating the node, so the refactor works even when a filter is active. This addresses #2384. With a filter set, the matching toolbox node sits in a cached tree while the visible list holds filtered clones, so the lookup would miss and the rename would do nothing.

The reset exposed a second issue in the cue banner search box. Clearing it while the cue banner is shown would wipe the banner, because the empty write cleared the placeholder text while leaving the banner flag set. The box now ignores null or empty writes to its `Text` property while the banner is visible, so clearing it, including this reset, leaves a shown banner in place.

The `Text` guard relies on `HideCueBanner` clearing the banner flag before it clears the text, otherwise the guard would drop that clear and leave the placeholder showing as normal text. `HideCueBanner` is ordered accordingly.

Fixes #2384