### PR TITLE
Skip invalid operator icon when rendering

### DIFF
--- a/Bonsai.Editor/GraphView/SvgRenderer.cs
+++ b/Bonsai.Editor/GraphView/SvgRenderer.cs
@@ -666,16 +666,22 @@ namespace Bonsai.Editor.GraphView
 
             if (!rendererCache.TryGetValue(icon.Name, out renderer))
             {
-                using (var iconStream = icon.GetStream())
+                using var iconStream = icon.GetStream();
+                if (iconStream == null) return false;
+                try
                 {
-                    if (iconStream == null) return false;
                     var svgDocument = new XmlDocument();
                     svgDocument.XmlResolver = null;
                     svgDocument.Load(iconStream);
                     var element = SvgFactory.LoadFromXML(svgDocument, null);
                     renderer = CreateRenderer(element);
-                    rendererCache.Add(icon.Name, renderer);
                 }
+                catch (Exception ex)
+                {
+                    Trace.TraceWarning("Unable to create icon renderer '{0}'. {1}", icon.Name, ex);
+                    return false;
+                }
+                rendererCache.Add(icon.Name, renderer);
             }
 
             return true;


### PR DESCRIPTION
A custom operator icon that fails to load or parse now falls back to the default icon instead of aborting the workflow render. This addresses #2420. The exception raised while parsing the icon would propagate out of the paint handler, so a single malformed icon would stop the entire workflow from rendering.

The icon renderer factory now catches a failure to load or parse an icon, logs a warning to the trace listeners, and reports no renderer for that icon. The node falls back to its default icon, and the failed name is cached to that fallback so it is not parsed again on each paint.

### Steps to reproduce

1. Add an include workflow operator to the Extensions folder.
2. Export the current workflow as an SVG file with the same name as the include operator, also in the Extensions folder.
3. Reload the workflow.

Before this change, the reload would throw a `FormatException` during paint and the workflow would not render. With the fix, the operator shows the default icon and a warning naming the icon is written to the trace output.

Fixes #2420