### PR TITLE
Hide non-browsable members in member selector

### DIFF
--- a/Bonsai.Design/TypeVisitor.cs
+++ b/Bonsai.Design/TypeVisitor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 
@@ -19,6 +20,12 @@ namespace Bonsai.Design
             return properties;
         }
 
+        static bool IsBrowsableMember(MemberInfo member)
+        {
+            return !member.IsDefined(typeof(ObsoleteAttribute)) &&
+                   !member.GetCustomAttributes<BrowsableAttribute>().Contains(BrowsableAttribute.No);
+        }
+
         internal static void VisitMember(this Type type, Action<MemberInfo, Type> visitor)
         {
             if (type == null)
@@ -27,12 +34,14 @@ namespace Bonsai.Design
             }
 
             foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.Public)
+                                               .Where(IsBrowsableMember)
                                                .OrderBy(member => member.MetadataToken))
             {
                 visitor(field, field.FieldType);
             }
 
             foreach (var property in GetProperties(type, BindingFlags.Instance | BindingFlags.Public)
+                                                  .Where(IsBrowsableMember)
                                                   .OrderBy(member => member.MetadataToken))
             {
                 visitor(property, property.PropertyType);


### PR DESCRIPTION
The member selector dialog and the `InputMapping` selector now hide members marked `Browsable(false)` or `Obsolete`. These surfaces list members through `TypeVisitor`, which applied no attribute filter, so a member not meant to be selected would appear in the tree and drop-downs, for example the XML helper property `Bonsai.Sgen` generates for `TimeSpan` and `DateTimeOffset`.

The filter mirrors the `IsBrowsableMember` predicate the output-member context menu already uses, by name and behavior, so both member-selection surfaces offer the same members. Excluding `Obsolete` members goes slightly beyond the `Browsable` case in the issue, but keeps the two surfaces aligned.

### Verification

With a type that has a `Browsable(false)` member, such as a `Bonsai.Sgen`-generated `TimeSpan` property, open a `MemberSelector` node directly, or the `Selector` property of an `InputMapping` on the output side. The member would previously appear in the tree; it is now hidden, while normal members still show, matching the right-click output-member context menu.

Fixes #2453