### PR TITLE
Reject extra command line arguments

### DIFF
--- a/Bonsai.Configuration/CommandLineParser.cs
+++ b/Bonsai.Configuration/CommandLineParser.cs
@@ -59,6 +59,7 @@ namespace Bonsai.Configuration
 
         public void Parse(string[] args)
         {
+            var hasDefaultArgument = false;
             for (int i = 0; i < args.Length; i++)
             {
                 var options = args[i].Split(new[] { OptionSeparator }, 2, StringSplitOptions.RemoveEmptyEntries);
@@ -76,8 +77,13 @@ namespace Bonsai.Configuration
                         command(argument);
                     }
                 }
+                else if (hasDefaultArgument)
+                {
+                    throw new ArgumentException("Unrecognized command or argument '" + args[i] + "'.");
+                }
                 else
                 {
+                    hasDefaultArgument = true;
                     defaultHandler?.Invoke(args[i], i);
                 }
             }

--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -261,7 +261,7 @@ namespace Bonsai
 
                 var startScreen = launchEditor;
                 var pipeName = Guid.NewGuid().ToString();
-                args = Array.FindAll(args, arg => arg != DebugScriptCommand);
+                args = args.Where((arg, i) => arg != DebugScriptCommand && i != fileNameIndex).ToArray();
                 do
                 {
                     var editorArgs = new List<string>(args);


### PR DESCRIPTION
The command line parser now accepts a single positional argument and rejects any additional one with an `Unrecognized command or argument` error, matching the validation in `System.CommandLine`.

This required a companion change in the bootstrapper relaunch, which builds the editor argument list from the original arguments and then appends the resolved workflow path. Those two positional arguments together would now be rejected by the stricter parser, so the original positional token is dropped when rebuilding the list, leaving only the resolved path. Registered options and value-taking commands like `--visualizer-layout` are consumed before the positional check, so only genuine extra arguments are rejected.

### Verification

- `bonsai workflow.bonsai` and `bonsai workflow.bonsai --start` open as before.
- `bonsai workflow.bonsai --strat` and `bonsai workflow.bonsai extra.bonsai` now fail with `Unrecognized command or argument`.
- `bonsai --strat` on its own is still treated as the file path, matching `System.CommandLine`.
- Reload, export image, export package, and opening the gallery or package manager from within the editor still launch with the correct workflow.

Fixes #2407