### PR TITLE
Keep breadcrumb order on nested layout restore

### DIFF
--- a/Bonsai.Editor/GraphView/WorkflowPathNavigationControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowPathNavigationControl.cs
@@ -22,6 +22,13 @@ namespace Bonsai.Editor.GraphView
             themeRenderer = (ThemeRenderer)provider.GetService(typeof(ThemeRenderer));
             themeRenderer.ThemeChanged += ThemeRenderer_ThemeChanged;
             editorService = (IWorkflowEditorService)provider.GetService(typeof(IWorkflowEditorService));
+            flowLayoutPanel.HandleCreated += (sender, e) =>
+            {
+                // ensure child handles are created in collection order so changes in visibility never
+                // force an out-of-order CreateWindowEx, which would reorder the control collection
+                foreach (Control control in flowLayoutPanel.Controls)
+                    _ = control.Handle;
+            };
         }
 
         public string DisplayName


### PR DESCRIPTION
Previously, opening a workflow whose saved editor layout points at a nested path would draw the breadcrumb navigation with the first separator ahead of the root button, so the path reads `> root nested1 > nested2` instead of `root > nested1 > nested2`. The root button would still be shown, so this was not the auto-compression ellipsis but rather an existing separator being drawn out of place.

The breadcrumbs control is a `FlowLayoutPanel` whose buttons are added in `SetPath`. On a layout restore this runs inside `DockPanel.LoadFromXml`, before the layout panel even has a window handle, so in this case the child buttons start out without handles. During the docking layout that follows, `CompressPath` assigns `Visible` on the buttons. Setting `Visible` on a child control without a handle once the panel handle exists forces the creation of the button handle out of order, which ultimately makes the framework reorder the control collection and move the first separator ahead of the root.

This fix ensures that every breadcrumb child handle is created in collection order as soon as the panel handle is created, from a `HandleCreated` handler, so the later visibility changes reuse the existing handles instead of creating them out of order.

Closes #2618