### PR TITLE
Sync dock tab and breadcrumb on save and rename

### DIFF
--- a/Bonsai.Editor/Docking/WorkflowDockContent.cs
+++ b/Bonsai.Editor/Docking/WorkflowDockContent.cs
@@ -13,8 +13,9 @@ namespace Bonsai.Editor.Docking
         readonly IWorkflowEditorService editorService;
         readonly WorkflowSelectionModel selectionModel;
         readonly CommandExecutor commandExecutor;
+        readonly WorkflowPathNavigationControl navigationControl;
 
-        public WorkflowDockContent(WorkflowGraphView graphView, WorkflowPathNavigationControl navigationControl, IServiceProvider provider)
+        public WorkflowDockContent(WorkflowGraphView graphView, IServiceProvider provider)
         {
             if (provider == null)
             {
@@ -23,15 +24,44 @@ namespace Bonsai.Editor.Docking
 
             InitializeComponent();
             WorkflowGraphView = graphView ?? throw new ArgumentNullException(nameof(graphView));
-            NavigationControl = navigationControl ?? throw new ArgumentNullException(nameof(navigationControl));
             editorService = (IWorkflowEditorService)provider.GetService(typeof(IWorkflowEditorService));
             selectionModel = (WorkflowSelectionModel)provider.GetService(typeof(WorkflowSelectionModel));
             commandExecutor = (CommandExecutor)provider.GetService(typeof(CommandExecutor));
+
+            SuspendLayout();
+            graphView.BackColorChanged += (sender, e) => BackColor = graphView.BackColor;
+            graphView.Margin = new Padding(0);
+            graphView.Dock = DockStyle.Fill;
+            graphView.Tag = this;
+
+            navigationControl = new WorkflowPathNavigationControl(provider);
+            navigationControl.Margin = new Padding(0);
+            navigationControl.WorkflowPath = null;
+            navigationControl.WorkflowPathMouseClick += (sender, e) => graphView.WorkflowPath = e.Path;
+            graphView.WorkflowPathChanged += (sender, e) => UpdateNavigation();
+
+            var navigationPanel = new TableLayoutPanel();
+            navigationPanel.Dock = DockStyle.Fill;
+            navigationPanel.ColumnCount = 1;
+            navigationPanel.RowCount = 2;
+            navigationPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, navigationControl.Height));
+            navigationPanel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            navigationPanel.Controls.Add(navigationControl);
+            navigationPanel.Controls.Add(graphView);
+            graphView.TabIndex = 0;
+            navigationControl.TabIndex = 1;
+
+            // TODO: This should be handled by docking, but some strange interaction prevents shrinking to min size
+            navigationPanel.Layout += (sender, e) => navigationControl.Width = navigationPanel.Width;
+            navigationControl.Width = navigationPanel.Width;
+
+            Controls.Add(navigationPanel);
+            BackColor = graphView.BackColor;
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         public WorkflowGraphView WorkflowGraphView { get; }
-
-        public WorkflowPathNavigationControl NavigationControl { get; }
 
         protected override string GetPersistString()
         {
@@ -140,8 +170,9 @@ namespace Bonsai.Editor.Docking
             return false;
         }
 
-        public void UpdateText()
+        public void UpdateNavigation()
         {
+            navigationControl.WorkflowPath = WorkflowGraphView.WorkflowPath;
             Text = (WorkflowGraphView.IsReadOnly ? ReadOnlyPrefix : string.Empty) + WorkflowGraphView.DisplayName;
         }
 

--- a/Bonsai.Editor/Docking/WorkflowDockContent.cs
+++ b/Bonsai.Editor/Docking/WorkflowDockContent.cs
@@ -14,7 +14,7 @@ namespace Bonsai.Editor.Docking
         readonly WorkflowSelectionModel selectionModel;
         readonly CommandExecutor commandExecutor;
 
-        public WorkflowDockContent(WorkflowGraphView graphView, IServiceProvider provider)
+        public WorkflowDockContent(WorkflowGraphView graphView, WorkflowPathNavigationControl navigationControl, IServiceProvider provider)
         {
             if (provider == null)
             {
@@ -23,12 +23,15 @@ namespace Bonsai.Editor.Docking
 
             InitializeComponent();
             WorkflowGraphView = graphView ?? throw new ArgumentNullException(nameof(graphView));
+            NavigationControl = navigationControl ?? throw new ArgumentNullException(nameof(navigationControl));
             editorService = (IWorkflowEditorService)provider.GetService(typeof(IWorkflowEditorService));
             selectionModel = (WorkflowSelectionModel)provider.GetService(typeof(WorkflowSelectionModel));
             commandExecutor = (CommandExecutor)provider.GetService(typeof(CommandExecutor));
         }
 
         public WorkflowGraphView WorkflowGraphView { get; }
+
+        public WorkflowPathNavigationControl NavigationControl { get; }
 
         protected override string GetPersistString()
         {

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -985,6 +985,7 @@ namespace Bonsai.Editor
 
             SaveWorkflowSettings(fileName);
             UpdateWorkflowDirectory(fileName);
+            editorControl.RefreshNavigation();
             UpdateTitle();
             return true;
         }

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -129,45 +129,10 @@ namespace Bonsai.Editor.GraphView
         private WorkflowDockContent CreateWorkflowDockContent(WorkflowEditorPath workflowPath, WorkflowEditor editor)
         {
             var workflowGraphView = new WorkflowGraphView(serviceProvider, this, editor);
-            var navigationControl = new WorkflowPathNavigationControl(serviceProvider);
-            var dockContent = new WorkflowDockContent(workflowGraphView, navigationControl, serviceProvider);
-            dockContent.DockAreas = DockAreas.Float | DockAreas.Document;
-            dockContent.SuspendLayout();
-
-            workflowGraphView.BackColorChanged += (sender, e) =>
-            {
-                dockContent.BackColor = workflowGraphView.BackColor;
-            };
-            workflowGraphView.Margin = new Padding(0);
-            workflowGraphView.Dock = DockStyle.Fill;
             workflowGraphView.Font = Font;
-            workflowGraphView.Tag = dockContent;
-
-            navigationControl.Margin = new Padding(0);
-            navigationControl.WorkflowPath = null;
-            navigationControl.WorkflowPathMouseClick += (sender, e) => workflowGraphView.WorkflowPath = e.Path;
-            workflowGraphView.WorkflowPathChanged += (sender, e) => UpdateNavigation(dockContent);
-
-            var navigationPanel = new TableLayoutPanel();
-            navigationPanel.Dock = DockStyle.Fill;
-            navigationPanel.ColumnCount = 1;
-            navigationPanel.RowCount = 2;
-            navigationPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, navigationControl.Height));
-            navigationPanel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-            navigationPanel.Controls.Add(navigationControl);
-            navigationPanel.Controls.Add(workflowGraphView);
-            workflowGraphView.TabIndex = 0;
-            navigationControl.TabIndex = 1;
-
-            // TODO: This should be handled by docking, but some strange interaction prevents shrinking to min size
-            navigationPanel.Layout += (sender, e) => navigationControl.Width = navigationPanel.Width;
-            navigationControl.Width = navigationPanel.Width;
+            var dockContent = new WorkflowDockContent(workflowGraphView, serviceProvider);
+            dockContent.DockAreas = DockAreas.Float | DockAreas.Document;
             workflowGraphView.Editor.ResetNavigation(workflowPath);
-
-            dockContent.Controls.Add(navigationPanel);
-            dockContent.BackColor = workflowGraphView.BackColor;
-            dockContent.ResumeLayout(false);
-            dockContent.PerformLayout();
             return dockContent;
         }
 
@@ -338,7 +303,7 @@ namespace Bonsai.Editor.GraphView
         {
             UpdateGraphView(selectedView, graphView => graphView.InvalidateGraphLayout(validateWorkflow: false));
             selectedView.RefreshSelection();
-            UpdateAllText();
+            RefreshNavigation();
         }
 
         internal void UpdateWatchLayout()
@@ -405,24 +370,6 @@ namespace Bonsai.Editor.GraphView
             }
         }
 
-        void UpdateAllText()
-        {
-            for (int i = dockPanel.Contents.Count - 1; i >= 0; i--)
-            {
-                if (dockPanel.Contents[i] is WorkflowDockContent workflowContent &&
-                    !workflowContent.WorkflowGraphView.IsDisposed)
-                {
-                    workflowContent.UpdateText();
-                }
-            }
-        }
-
-        void UpdateNavigation(WorkflowDockContent dockContent)
-        {
-            dockContent.NavigationControl.WorkflowPath = dockContent.WorkflowGraphView.WorkflowPath;
-            dockContent.UpdateText();
-        }
-
         internal void RefreshNavigation()
         {
             for (int i = dockPanel.Contents.Count - 1; i >= 0; i--)
@@ -430,7 +377,7 @@ namespace Bonsai.Editor.GraphView
                 if (dockPanel.Contents[i] is WorkflowDockContent workflowContent &&
                     !workflowContent.WorkflowGraphView.IsDisposed)
                 {
-                    UpdateNavigation(workflowContent);
+                    workflowContent.UpdateNavigation();
                 }
             }
         }

--- a/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowEditorControl.cs
@@ -129,7 +129,8 @@ namespace Bonsai.Editor.GraphView
         private WorkflowDockContent CreateWorkflowDockContent(WorkflowEditorPath workflowPath, WorkflowEditor editor)
         {
             var workflowGraphView = new WorkflowGraphView(serviceProvider, this, editor);
-            var dockContent = new WorkflowDockContent(workflowGraphView, serviceProvider);
+            var navigationControl = new WorkflowPathNavigationControl(serviceProvider);
+            var dockContent = new WorkflowDockContent(workflowGraphView, navigationControl, serviceProvider);
             dockContent.DockAreas = DockAreas.Float | DockAreas.Document;
             dockContent.SuspendLayout();
 
@@ -142,30 +143,25 @@ namespace Bonsai.Editor.GraphView
             workflowGraphView.Font = Font;
             workflowGraphView.Tag = dockContent;
 
-            var breadcrumbs = new WorkflowPathNavigationControl(serviceProvider);
-            breadcrumbs.Margin = new Padding(0);
-            breadcrumbs.WorkflowPath = null;
-            breadcrumbs.WorkflowPathMouseClick += (sender, e) => workflowGraphView.WorkflowPath = e.Path;
-            workflowGraphView.WorkflowPathChanged += (sender, e) =>
-            {
-                breadcrumbs.WorkflowPath = workflowGraphView.WorkflowPath;
-                dockContent.UpdateText();
-            };
+            navigationControl.Margin = new Padding(0);
+            navigationControl.WorkflowPath = null;
+            navigationControl.WorkflowPathMouseClick += (sender, e) => workflowGraphView.WorkflowPath = e.Path;
+            workflowGraphView.WorkflowPathChanged += (sender, e) => UpdateNavigation(dockContent);
 
             var navigationPanel = new TableLayoutPanel();
             navigationPanel.Dock = DockStyle.Fill;
             navigationPanel.ColumnCount = 1;
             navigationPanel.RowCount = 2;
-            navigationPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, breadcrumbs.Height));
+            navigationPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, navigationControl.Height));
             navigationPanel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-            navigationPanel.Controls.Add(breadcrumbs);
+            navigationPanel.Controls.Add(navigationControl);
             navigationPanel.Controls.Add(workflowGraphView);
             workflowGraphView.TabIndex = 0;
-            breadcrumbs.TabIndex = 1;
+            navigationControl.TabIndex = 1;
 
             // TODO: This should be handled by docking, but some strange interaction prevents shrinking to min size
-            navigationPanel.Layout += (sender, e) => breadcrumbs.Width = navigationPanel.Width;
-            breadcrumbs.Width = navigationPanel.Width;
+            navigationPanel.Layout += (sender, e) => navigationControl.Width = navigationPanel.Width;
+            navigationControl.Width = navigationPanel.Width;
             workflowGraphView.Editor.ResetNavigation(workflowPath);
 
             dockContent.Controls.Add(navigationPanel);
@@ -417,6 +413,24 @@ namespace Bonsai.Editor.GraphView
                     !workflowContent.WorkflowGraphView.IsDisposed)
                 {
                     workflowContent.UpdateText();
+                }
+            }
+        }
+
+        void UpdateNavigation(WorkflowDockContent dockContent)
+        {
+            dockContent.NavigationControl.WorkflowPath = dockContent.WorkflowGraphView.WorkflowPath;
+            dockContent.UpdateText();
+        }
+
+        internal void RefreshNavigation()
+        {
+            for (int i = dockPanel.Contents.Count - 1; i >= 0; i--)
+            {
+                if (dockPanel.Contents[i] is WorkflowDockContent workflowContent &&
+                    !workflowContent.WorkflowGraphView.IsDisposed)
+                {
+                    UpdateNavigation(workflowContent);
                 }
             }
         }

--- a/Bonsai.Editor/GraphView/WorkflowPathNavigationControl.cs
+++ b/Bonsai.Editor/GraphView/WorkflowPathNavigationControl.cs
@@ -46,11 +46,35 @@ namespace Bonsai.Editor.GraphView
             get { return workflowPath; }
             set
             {
-                workflowPath = value;
                 var workflowBuilder = (WorkflowBuilder)serviceProvider.GetService(typeof(WorkflowBuilder));
-                var pathElements = WorkflowEditorPath.GetPathDisplayElements(workflowPath, workflowBuilder);
-                SetPath(pathElements);
+                var pathElements = WorkflowEditorPath.GetPathDisplayElements(value, workflowBuilder);
+                if (workflowPath == value && flowLayoutPanel.Controls.Count > 1)
+                {
+                    RefreshDisplayNames(pathElements);
+                }
+                else
+                {
+                    workflowPath = value;
+                    SetPath(pathElements);
+                }
             }
+        }
+
+        private void RefreshDisplayNames(IEnumerable<KeyValuePair<string, WorkflowEditorPath>> pathElements)
+        {
+            SuspendLayout();
+            using var elementEnumerator = pathElements.GetEnumerator();
+            for (int i = 1; i < flowLayoutPanel.Controls.Count; i++)
+            {
+                var control = flowLayoutPanel.Controls[i];
+                if (i == 1)
+                    control.Text = editorService.GetProjectDisplayName();
+                else if (control.Tag is WorkflowEditorPath && elementEnumerator.MoveNext())
+                    control.Text = elementEnumerator.Current.Key;
+            }
+            UpdatePathWidth();
+            CompressPath();
+            ResumeLayout(true);
         }
 
         public event EventHandler<WorkflowPathMouseEventArgs> WorkflowPathMouseClick
@@ -67,7 +91,6 @@ namespace Bonsai.Editor.GraphView
         private void SetPath(IEnumerable<KeyValuePair<string, WorkflowEditorPath>> pathElements)
         {
             SuspendLayout();
-            totalPathWidth = 0;
             flowLayoutPanel.Controls.Clear();
             AddPathButton("...", null, createEvent: false, visible: false);
             AddPathButton(editorService.GetProjectDisplayName(), null);
@@ -76,8 +99,16 @@ namespace Bonsai.Editor.GraphView
                 AddPathButton(">", null, createEvent: false);
                 AddPathButton(path.Key, path.Value);
             }
+            UpdatePathWidth();
             CompressPath();
             ResumeLayout(true);
+        }
+
+        private void UpdatePathWidth()
+        {
+            totalPathWidth = 0;
+            for (int i = 1; i < flowLayoutPanel.Controls.Count; i++)
+                totalPathWidth += GetControlWidth(flowLayoutPanel.Controls[i]);
         }
 
         private void CompressPath()
@@ -90,8 +121,8 @@ namespace Bonsai.Editor.GraphView
             if (totalWidth > Width)
             {
                 // adjust for inserting the ellipsis button
-                totalWidth -= flowLayoutPanel.Controls[1].Width;
-                totalWidth += flowLayoutPanel.Controls[0].Width;
+                totalWidth -= flowLayoutPanel.Controls[1].PreferredSize.Width;
+                totalWidth += flowLayoutPanel.Controls[0].PreferredSize.Width;
                 compressPath = true;
             }
 
@@ -117,7 +148,7 @@ namespace Bonsai.Editor.GraphView
 
         private int GetControlWidth(Control control)
         {
-            return control.Width + control.Margin.Horizontal + flowLayoutPanel.Padding.Right;
+            return control.PreferredSize.Width + control.Margin.Horizontal + flowLayoutPanel.Padding.Right;
         }
 
         private BreadcrumbButtton AddPathButton(string text, WorkflowEditorPath path, bool createEvent = true, bool visible = true)
@@ -136,8 +167,6 @@ namespace Bonsai.Editor.GraphView
             breadcrumbButton.ParentChanged += BreadcrumbButton_ParentChanged;
             SetBreadcrumbTheme(breadcrumbButton, themeRenderer);
             flowLayoutPanel.Controls.Add(breadcrumbButton);
-            if (flowLayoutPanel.Controls.Count > 1)
-                totalPathWidth += GetControlWidth(breadcrumbButton);
             return breadcrumbButton;
         }
 


### PR DESCRIPTION
After a Save As, only the window title and explorer root would refresh, leaving the dock tab caption and breadcrumb root button on the old workflow name. Every open document now refreshes its tab caption and breadcrumb on save, so both follow the renamed workflow.

Breadcrumb composition also moves out of `WorkflowEditorControl` and into `WorkflowDockContent`, which now creates and owns its breadcrumb navigation control and panel and exposes a single `UpdateNavigation` entry point; `WorkflowEditorControl` only constructs the content and resets its path.

Two related display issues are fixed on top of that:

- Re-assigning the current path updates the breadcrumb labels in place rather than rebuilding the buttons, so an idempotent save will not flicker the breadcrumb.
- A node rename now updates the breadcrumb and tab caption in every open tab, where it would otherwise appear only after navigating to that tab.

Closes #2330