### PR TITLE
Distinguish unknown operators from obsolete ones

### DIFF
--- a/Bonsai.Core/WorkflowBuilder.cs
+++ b/Bonsai.Core/WorkflowBuilder.cs
@@ -576,10 +576,7 @@ namespace Bonsai
                         var errorMessage = string.Format(message, typeBuilder.FullName);
                         var descriptionAttributeConstructor = typeof(DescriptionAttribute).GetConstructor(new[] { typeof(string) });
                         var descriptionAttributeBuilder = new CustomAttributeBuilder(descriptionAttributeConstructor, new[] { errorMessage });
-                        var obsoleteAttributeConstructor = typeof(ObsoleteAttribute).GetConstructor(Type.EmptyTypes);
-                        var obsoleteAttributeBuilder = new CustomAttributeBuilder(obsoleteAttributeConstructor, new object[0]);
                         typeBuilder.SetCustomAttribute(descriptionAttributeBuilder);
-                        typeBuilder.SetCustomAttribute(obsoleteAttributeBuilder);
                         type = typeBuilder.CreateTypeInfo();
                         dynamicTypes.Add(typeName, type);
                     }

--- a/Bonsai.Editor/GraphModel/GraphNode.cs
+++ b/Bonsai.Editor/GraphModel/GraphNode.cs
@@ -44,6 +44,7 @@ namespace Bonsai.Editor.GraphModel
                 }
 
                 if (obsolete) Flags |= NodeFlags.Obsolete;
+                if (workflowElement is UnknownTypeBuilder) Flags |= NodeFlags.Unknown;
                 if (expressionBuilder.IsBuildDependency()) Flags |= NodeFlags.BuildDependency;
                 Category = elementCategoryAttribute.Category;
                 Icon = new ElementIcon(workflowElement);
@@ -124,7 +125,7 @@ namespace Bonsai.Editor.GraphModel
         {
             get
             {
-                if ((Flags & NodeFlags.Obsolete) != 0) return ObsoleteBrush;
+                if ((Flags & (NodeFlags.Obsolete | NodeFlags.Unknown)) != 0) return ObsoleteBrush;
                 else if ((Flags & NodeFlags.Disabled) != 0) return DisabledBrush;
                 else return null;
             }
@@ -191,7 +192,8 @@ namespace Bonsai.Editor.GraphModel
             NestedScope = 0x10,
             NestedGroup = 0x20,
             Annotation = 0x40,
-            RangeUndefined = 0x80
+            RangeUndefined = 0x80,
+            Unknown = 0x100
         }
 
         static class CategoryColors


### PR DESCRIPTION
When the editor cannot resolve an operator, for example because its package is not installed, it shows a placeholder node. Since 2.9.0 the description panel for that node begins with "This operator is obsolete", which is misleading, since the operator is not deprecated but unresolved. The obsolete note was added in #2208 for genuinely deprecated operators and ended up applying to unknown ones as well.

This change removes the attribute from the placeholder, so the description shows only the unknown-type message, and preserves the hatched styling through a dedicated `NodeFlags.Unknown` set from the `UnknownTypeBuilder` base type. Genuinely obsolete operators are unaffected and still get both the obsolete note and the hatched styling.

Closes #2372