### PR TITLE
Report missing or invalid workflow file on launch

### DIFF
--- a/Bonsai.Editor.Tests/WorkflowLoadErrorTests.cs
+++ b/Bonsai.Editor.Tests/WorkflowLoadErrorTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Editor.Tests
+{
+    [TestClass]
+    [DoNotParallelize]
+    public class WorkflowLoadErrorTests
+    {
+        static string CreateTempWorkflowFile(string contents)
+        {
+            var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".bonsai");
+            File.WriteAllText(path, contents);
+            return path;
+        }
+
+        [TestMethod]
+        public void Run_NonXmlContent_ThrowsInvalidFormatWithInner()
+        {
+            var path = CreateTempWorkflowFile("this is not a workflow at all");
+            try
+            {
+                var exception = Assert.ThrowsException<InvalidOperationException>(
+                    () => WorkflowRunner.Run(path, new(), visualizerProvider: null));
+                Assert.IsNotNull(exception.InnerException);
+                Assert.IsTrue(WorkflowRunner.IsWorkflowFormatError(exception.InnerException));
+                StringAssert.Contains(exception.Message, Path.GetFileName(path));
+            }
+            finally { File.Delete(path); }
+        }
+
+        [TestMethod]
+        public void Run_WellFormedXmlWrongSchema_IsNotFormatError()
+        {
+            var path = CreateTempWorkflowFile("<NotAWorkflow><Element /></NotAWorkflow>");
+            try
+            {
+                var exception = Assert.ThrowsException<InvalidOperationException>(
+                    () => WorkflowRunner.Run(path, new(), visualizerProvider: null));
+                Assert.IsFalse(WorkflowRunner.IsWorkflowFormatError(exception));
+            }
+            finally { File.Delete(path); }
+        }
+
+        [TestMethod]
+        public void Run_MissingFile_ThrowsArgumentExceptionWithFileName()
+        {
+            var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".bonsai");
+            var exception = Assert.ThrowsException<ArgumentException>(
+                () => WorkflowRunner.Run(path, new(), visualizerProvider: null));
+            StringAssert.Contains(exception.Message, Path.GetFileName(path));
+        }
+    }
+}

--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -312,10 +312,8 @@ namespace Bonsai.Editor
         {
             RestoreEditorSettings();
             var initialFileName = FileName;
-            var validFileName =
-                !string.IsNullOrEmpty(initialFileName) &&
-                Path.GetExtension(initialFileName) == Project.BonsaiExtension &&
-                File.Exists(initialFileName);
+            var fileRequested = !string.IsNullOrEmpty(initialFileName);
+            var fileExists = fileRequested && File.Exists(initialFileName);
 
             Observable.Merge(
                 InitializeSubjectSourcesAsync(),
@@ -325,7 +323,7 @@ namespace Bonsai.Editor
                 .Subscribe(formCancellation.Token);
 
             var currentDirectory = Project.GetCurrentBaseDirectory(out bool currentDirectoryRestricted);
-            var workflowBaseDirectory = validFileName ? Project.GetWorkflowBaseDirectory(initialFileName) : currentDirectory;
+            var workflowBaseDirectory = fileExists ? Project.GetWorkflowBaseDirectory(initialFileName) : currentDirectory;
             if (currentDirectoryRestricted)
             {
                 currentDirectory = workflowBaseDirectory;
@@ -341,7 +339,13 @@ namespace Bonsai.Editor
             initialization = InitializeEditorExtensionsAsync(formCancellation.Token);
             base.OnLoad(e);
 
-            await InitializeWorkflowAsync(validFileName ? initialFileName : default);
+            if (fileRequested && !fileExists)
+            {
+                var fileNotFoundMessage = string.Format(Resources.OpenWorkflow_FileNotFound, Path.GetFileName(initialFileName));
+                MessageBox.Show(this, fileNotFoundMessage, Resources.OpenWorkflow_Error_Caption, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+
+            await InitializeWorkflowAsync(fileExists ? initialFileName : default);
         }
 
         protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
@@ -880,14 +884,23 @@ namespace Bonsai.Editor
             try { builderCandidate = ElementStore.LoadWorkflow(fileName, out workflowVersion); }
             catch (SystemException ex) when (ex is InvalidOperationException || ex is XmlException)
             {
-                var activeException = ex.InnerException ?? ex;
-                var errorMessage = activeException.Message;
-                if (activeException.InnerException != null)
+                string errorMessage;
+                if (WorkflowRunner.IsWorkflowFormatError(ex))
                 {
-                    errorMessage += Environment.NewLine + activeException.InnerException.Message;
+                    errorMessage = string.Format(Resources.OpenWorkflow_InvalidFormat, Path.GetFileName(fileName));
+                }
+                else
+                {
+                    var activeException = ex.InnerException ?? ex;
+                    errorMessage = activeException.Message;
+                    if (activeException.InnerException != null)
+                    {
+                        errorMessage += Environment.NewLine + activeException.InnerException.Message;
+                    }
+
+                    errorMessage = string.Format(Resources.OpenWorkflow_Error, Path.GetFileName(fileName), errorMessage);
                 }
 
-                errorMessage = string.Format(Resources.OpenWorkflow_Error, Path.GetFileName(fileName), errorMessage);
                 MessageBox.Show(this, errorMessage, Resources.OpenWorkflow_Error_Caption, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }

--- a/Bonsai.Editor/Properties/Resources.Designer.cs
+++ b/Bonsai.Editor/Properties/Resources.Designer.cs
@@ -493,6 +493,24 @@ namespace Bonsai.Editor.Properties {
                 return ResourceManager.GetString("OpenWorkflow_Error_Caption", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The workflow file &apos;{0}&apos; does not exist..
+        /// </summary>
+        internal static string OpenWorkflow_FileNotFound {
+            get {
+                return ResourceManager.GetString("OpenWorkflow_FileNotFound", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The file &apos;{0}&apos; is not a valid workflow..
+        /// </summary>
+        internal static string OpenWorkflow_InvalidFormat {
+            get {
+                return ResourceManager.GetString("OpenWorkflow_InvalidFormat", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Output.

--- a/Bonsai.Editor/Properties/Resources.resx
+++ b/Bonsai.Editor/Properties/Resources.resx
@@ -194,6 +194,12 @@ Copyright (c) .NET Foundation and Contributors</value>
   <data name="OpenWorkflow_Error_Caption" xml:space="preserve">
     <value>Open Error</value>
   </data>
+  <data name="OpenWorkflow_FileNotFound" xml:space="preserve">
+    <value>The workflow file '{0}' does not exist.</value>
+  </data>
+  <data name="OpenWorkflow_InvalidFormat" xml:space="preserve">
+    <value>The file '{0}' is not a valid workflow.</value>
+  </data>
   <data name="PasteFromClipboard_Error" xml:space="preserve">
     <value>There was an error pasting the selected elements from the clipboard:
 {0}</value>

--- a/Bonsai.Editor/WorkflowExporter.cs
+++ b/Bonsai.Editor/WorkflowExporter.cs
@@ -19,7 +19,7 @@ namespace Bonsai.Editor
 
             if (!File.Exists(fileName))
             {
-                throw new ArgumentException("Specified workflow file does not exist.", nameof(fileName));
+                throw new ArgumentException(string.Format(Resources.OpenWorkflow_FileNotFound, fileName), nameof(fileName));
             }
 
             if (string.IsNullOrEmpty(imageFileName))

--- a/Bonsai.Editor/WorkflowRunner.cs
+++ b/Bonsai.Editor/WorkflowRunner.cs
@@ -1,5 +1,6 @@
 ﻿using Bonsai.Design;
 using Bonsai.Editor.GraphModel;
+using Bonsai.Editor.Properties;
 using Bonsai.Expressions;
 using System;
 using System.Collections.Generic;
@@ -169,10 +170,17 @@ namespace Bonsai.Editor
 
             if (!File.Exists(fileName))
             {
-                throw new ArgumentException("Specified workflow file does not exist.", nameof(fileName));
+                throw new ArgumentException(string.Format(Resources.OpenWorkflow_FileNotFound, fileName), nameof(fileName));
             }
 
-            var workflowBuilder = ElementStore.LoadWorkflow(fileName);
+            WorkflowBuilder workflowBuilder;
+            try { workflowBuilder = ElementStore.LoadWorkflow(fileName); }
+            catch (Exception ex) when (IsWorkflowFormatError(ex))
+            {
+                throw new InvalidOperationException(
+                    string.Format(Resources.OpenWorkflow_InvalidFormat, fileName), ex);
+            }
+
             var settingsPath = Project.GetWorkflowSettingsDirectory(fileName);
             layoutPath ??= LayoutHelper.GetCompatibleLayoutPath(settingsPath, fileName);
 
@@ -196,6 +204,17 @@ namespace Bonsai.Editor
             {
                 LogWorkflowExceptionStackTrace(fileName, workflowBuilder, exceptionCache, ex);
             }
+        }
+
+        internal static bool IsWorkflowFormatError(Exception exception)
+        {
+            for (var error = exception; error != null; error = error.InnerException)
+            {
+                if (error is XmlException)
+                    return true;
+            }
+
+            return false;
         }
 
         static void LogWorkflowExceptionStackTrace(

--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -341,6 +341,8 @@ namespace Bonsai
                         debugScripts = editorFlags.HasFlag(EditorFlags.DebugScripts);
                         updatePackages = editorFlags.HasFlag(EditorFlags.UpdatesAvailable);
                         initialFileName = AppResult.GetResult<string>();
+                        if (!string.IsNullOrEmpty(initialFileName) && !File.Exists(initialFileName))
+                            initialFileName = null;
                         launchResult = (EditorResult)AppResult.GetResult<int>();
                     }
                 }


### PR DESCRIPTION
Launching the editor with a workflow file that does not exist, or that exists but cannot be parsed as a workflow, would open a blank editor with no indication of the problem. The editor now reports that the file is missing or not a valid workflow and still opens, instead of silently starting empty. Launching with no file or with a directory still opens empty as before.

The `--no-editor` player now reports an unparseable file with the same invalid-workflow message instead of a raw parser exception, and its missing-file message names the file. Both messages include the full path so a batch run can identify which file failed and the export-image path also shares the missing-file message.

Closes #2615