### PR TITLE
Avoid repeating CLI property assignments on reload

### DIFF
--- a/Bonsai.Configuration.Tests/CommandLineParserTests.cs
+++ b/Bonsai.Configuration.Tests/CommandLineParserTests.cs
@@ -1,0 +1,112 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Configuration.Tests;
+
+[TestClass]
+public sealed class CommandLineParserTests
+{
+    const string PropertyCommand = "--property";
+
+    static CommandLineParser CreateParser(out List<string> values)
+    {
+        var captured = new List<string>();
+        values = captured;
+        var parser = new CommandLineParser();
+        parser.RegisterCommand(PropertyCommand, captured.Add);
+        return parser;
+    }
+
+    [TestMethod]
+    public void GetArgumentIndices_InlineValue_ReturnsOptionIndex()
+    {
+        var parser = CreateParser(out var values);
+        parser.Parse(["--property:Foo=Bar"]);
+        CollectionAssert.AreEqual((int[])[0], parser.GetArgumentIndices(PropertyCommand).ToArray());
+        CollectionAssert.AreEqual((string[])["Foo=Bar"], values.ToArray());
+    }
+
+    [TestMethod]
+    public void GetArgumentIndices_SeparateValueToken_ReturnsOptionAndValueIndices()
+    {
+        var parser = CreateParser(out var values);
+        parser.Parse(["--property", "Foo=Bar"]);
+        CollectionAssert.AreEqual((int[])[0, 1], parser.GetArgumentIndices(PropertyCommand).ToArray());
+        CollectionAssert.AreEqual((string[])["Foo=Bar"], values.ToArray());
+    }
+
+    [TestMethod]
+    public void GetArgumentIndices_ShorthandAlias_ResolvesToSameCommand()
+    {
+        var parser = CreateParser(out var values);
+        parser.Parse(["-p:Foo=Bar"]);
+        CollectionAssert.AreEqual((int[])[0], parser.GetArgumentIndices(PropertyCommand).ToArray());
+        CollectionAssert.AreEqual((string[])["Foo=Bar"], values.ToArray());
+    }
+
+    [TestMethod]
+    public void GetArgumentIndices_QueriedByAlias_ReturnsSameIndices()
+    {
+        var parser = CreateParser(out _);
+        parser.Parse(["--property:Foo=Bar"]);
+        CollectionAssert.AreEqual((int[])[0], parser.GetArgumentIndices("-p").ToArray());
+    }
+
+    [TestMethod]
+    public void GetArgumentIndices_RepeatedOccurrences_AccumulatesIndices()
+    {
+        var parser = CreateParser(out var values);
+        parser.RegisterCommand("--start", () => { });
+        parser.Parse(["--property:A=1", "--start", "--property", "B=2"]);
+        CollectionAssert.AreEqual((int[])[0, 2, 3], parser.GetArgumentIndices(PropertyCommand).ToArray());
+        CollectionAssert.AreEqual((string[])["A=1", "B=2"], values.ToArray());
+    }
+
+    [TestMethod]
+    public void GetArgumentIndices_InterleavedWithOtherArguments_ReturnsOnlyOwnTokens()
+    {
+        var parser = CreateParser(out _);
+        parser.RegisterCommand("--editor-scale", scale => { });
+        parser.RegisterCommand((argument, index) => { });
+        parser.Parse(["workflow.bonsai", "--property:Foo=Bar", "--editor-scale:2"]);
+        CollectionAssert.AreEqual((int[])[1], parser.GetArgumentIndices(PropertyCommand).ToArray());
+    }
+
+    [TestMethod]
+    public void GetArgumentIndices_ValueTokenLooksLikeCommand_NotConsumedAsValue()
+    {
+        var parser = CreateParser(out var values);
+        parser.RegisterCommand("--start", () => { });
+        parser.Parse(["--property", "--start"]);
+        CollectionAssert.AreEqual((int[])[0], parser.GetArgumentIndices(PropertyCommand).ToArray());
+        CollectionAssert.AreEqual((int[])[1], parser.GetArgumentIndices("--start").ToArray());
+        CollectionAssert.AreEqual((string[])[""], values.ToArray());
+    }
+
+    [TestMethod]
+    public void GetArgumentIndices_CommandNotSpecified_ReturnsEmpty()
+    {
+        var parser = CreateParser(out _);
+        parser.Parse([]);
+        Assert.AreEqual(0, parser.GetArgumentIndices(PropertyCommand).Count());
+    }
+
+    [TestMethod]
+    public void GetArgumentIndices_UnregisteredOrNullCommand_ReturnsEmpty()
+    {
+        var parser = CreateParser(out _);
+        parser.Parse(["--property:Foo=Bar"]);
+        Assert.AreEqual(0, parser.GetArgumentIndices("--does-not-exist").Count());
+        Assert.AreEqual(0, parser.GetArgumentIndices(null).Count());
+    }
+
+    [TestMethod]
+    public void GetArgumentIndices_Reparse_ResetsState()
+    {
+        var parser = CreateParser(out _);
+        parser.Parse(["--property:Foo=Bar"]);
+        parser.Parse([]);
+        Assert.AreEqual(0, parser.GetArgumentIndices(PropertyCommand).Count());
+    }
+}

--- a/Bonsai.Configuration/CommandLineParser.cs
+++ b/Bonsai.Configuration/CommandLineParser.cs
@@ -9,6 +9,7 @@ namespace Bonsai.Configuration
         const char OptionSeparator = ':';
         const string CommandPrefix = "--";
         readonly Dictionary<string, Delegate> commands = new Dictionary<string, Delegate>();
+        readonly Dictionary<Delegate, HashSet<int>> argumentIndices = new Dictionary<Delegate, HashSet<int>>();
         Action<string, int> defaultHandler;
 
         public void RegisterCommand(Action<string, int> handler)
@@ -59,9 +60,11 @@ namespace Bonsai.Configuration
 
         public void Parse(string[] args)
         {
+            argumentIndices.Clear();
             var hasDefaultArgument = false;
             for (int i = 0; i < args.Length; i++)
             {
+                var startIndex = i;
                 var options = args[i].Split(new[] { OptionSeparator }, 2, StringSplitOptions.RemoveEmptyEntries);
                 if (commands.TryGetValue(options[0], out Delegate handler))
                 {
@@ -76,6 +79,11 @@ namespace Bonsai.Configuration
                         }
                         command(argument);
                     }
+
+                    if (!argumentIndices.TryGetValue(handler, out HashSet<int> indices))
+                        argumentIndices.Add(handler, indices = new HashSet<int>());
+                    for (int index = startIndex; index <= i; index++)
+                        indices.Add(index);
                 }
                 else if (hasDefaultArgument)
                 {
@@ -87,6 +95,14 @@ namespace Bonsai.Configuration
                     defaultHandler?.Invoke(args[i], i);
                 }
             }
+        }
+
+        public HashSet<int> GetArgumentIndices(string command)
+        {
+            return command != null
+                && commands.TryGetValue(command, out Delegate handler)
+                && argumentIndices.TryGetValue(handler, out HashSet<int> indices)
+                ? indices : new HashSet<int>();
         }
     }
 }

--- a/Bonsai/Program.cs
+++ b/Bonsai/Program.cs
@@ -261,7 +261,9 @@ namespace Bonsai
 
                 var startScreen = launchEditor;
                 var pipeName = Guid.NewGuid().ToString();
-                args = args.Where((arg, i) => arg != DebugScriptCommand && i != fileNameIndex).ToArray();
+                var propertyIndices = parser.GetArgumentIndices(PropertyCommand);
+                args = args.Where((arg, i) =>
+                    arg != DebugScriptCommand && i != fileNameIndex && !propertyIndices.Contains(i)).ToArray();
                 do
                 {
                     var editorArgs = new List<string>(args);
@@ -278,6 +280,11 @@ namespace Bonsai
                     else
                     {
                         if (debugScripts) editorArgs.Add(DebugScriptCommand);
+                        if (propertyAssignments.Count > 0)
+                        {
+                            foreach (var assignment in propertyAssignments)
+                                editorArgs.Add($"{PropertyCommand}:{assignment.Key}={assignment.Value}");
+                        }
                         if (launchResult == EditorResult.ReloadEditor) editorArgs.Add(ReloadEditorCommand);
                         else editorArgs.Add(SuppressBootstrapCommand);
                         if (!string.IsNullOrEmpty(initialFileName))
@@ -344,6 +351,7 @@ namespace Bonsai
                         if (!string.IsNullOrEmpty(initialFileName) && !File.Exists(initialFileName))
                             initialFileName = null;
                         launchResult = (EditorResult)AppResult.GetResult<int>();
+                        propertyAssignments.Clear();
                     }
                 }
                 while (launchResult != EditorResult.Exit);


### PR DESCRIPTION
Property assignments passed on the command line with `--property` would be re-applied every time the editor reloaded, for example when updating extensions, so any edit made to those properties in the editor would be overwritten on the next reload. They are now applied only when the editor first launches. Other startup arguments such as `--editor-scale` and `--lib` still persist across reloads.

The bootstrapper builds the editor argument list for each relaunch from the original arguments. Property assignments are now dropped from that list and instead re-applied once from the parsed values on the first launch. To identify which tokens belong to `--property`, across its inline and separate-value forms and the `-p` alias, `CommandLineParser` now records the argument indices each command consumes and exposes them through a new `GetArgumentIndices` method.

### Verification

- Launching with `bonsai workflow.bonsai --property:Name=Value`, editing that property in the editor, then reloading extensions keeps the edited value instead of reverting to the command line value.
- The inline `--property:Name=Value`, separate `--property Name=Value`, and `-p` alias forms are all dropped from the relaunch arguments.
- `--editor-scale` and `--lib` still take effect after a reload.
- Unit tests cover `GetArgumentIndices` for each argument form.

Closes #2437