### PR TITLE
Avoid coercing numeric values into arrays

### DIFF
--- a/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
+++ b/Bonsai.Core.Tests/ExpressionBuilderGraphTests.cs
@@ -311,6 +311,17 @@ namespace Bonsai.Core.Tests
         }
 
         [TestMethod]
+        [ExpectedException(typeof(WorkflowBuildException))]
+        public void Build_PropertyMappingScalarToArrayProperty_ThrowsWorkflowBuildException()
+        {
+            new TestWorkflow()
+                .AppendValue(1)
+                .AppendPropertyMapping(nameof(WorkflowProperty<int[]>.Value))
+                .AppendCombinator(new WorkflowProperty<int[]>())
+                .BuildObservable<Unit>();
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
         public void BuildObservable_InvalidWorkflowType_ThrowsInvalidOperationException()
         {

--- a/Bonsai.Core/Expressions/ExpressionBuilder.cs
+++ b/Bonsai.Core/Expressions/ExpressionBuilder.cs
@@ -1133,15 +1133,18 @@ namespace Bonsai.Expressions
                 }
                 else
                 {
-                    var arguments = ExpressionHelper.SelectMembers(expression, selector).ToArray();
                     var propertyType = Nullable.GetUnderlyingType(targetType) ?? targetType;
-                    var constructor = OverloadResolution(propertyType.GetConstructors(), arguments);
-                    if (constructor.method != null)
+                    if (!propertyType.IsArray)
                     {
-                        result = Expression.New((ConstructorInfo)constructor.method, constructor.arguments);
-                        if (propertyType != targetType)
+                        var arguments = ExpressionHelper.SelectMembers(expression, selector).ToArray();
+                        var constructor = OverloadResolution(propertyType.GetConstructors(), arguments);
+                        if (constructor.method != null)
                         {
-                            result = Expression.Convert(result, targetType);
+                            result = Expression.New((ConstructorInfo)constructor.method, constructor.arguments);
+                            if (propertyType != targetType)
+                            {
+                                result = Expression.Convert(result, targetType);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
A property mapping from a numeric value into an array property would build successfully and, at runtime, create a zero-filled array with length equal to the mapped value, for example the value `5` producing `[0, 0, 0, 0, 0]`. Every array type exposes a length constructor, and the property mapping type conversion would fall back to it when no direct conversion exists. This is almost never the intended result, so property mappings no longer construct arrays through that fallback, and such a mapping now fails to build.

Only array-typed targets are affected, including multidimensional and jagged arrays. Conversions into non-array types through a matching constructor are unchanged.

### Verification

- A property mapping from an `int` source into an `int[]` property, such as mapping into the `Channels` property of `SelectChannels`, now fails to build with a workflow build error instead of producing a zero-filled array.
- Existing property mappings and non-array constructor conversions still build.

Closes #2441