### PR TITLE
Compare tuples by value in equality operators

### DIFF
--- a/Bonsai.Core.Tests/BinaryOperatorBuilderTests.cs
+++ b/Bonsai.Core.Tests/BinaryOperatorBuilderTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reactive.Linq;
+using Bonsai.Expressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Core.Tests
+{
+    [TestClass]
+    public class BinaryOperatorBuilderTests
+    {
+        static bool EvaluateEquality<TSource>(ExpressionBuilder builder, TSource value)
+        {
+            var source = Expression.Constant(Observable.Return(value), typeof(IObservable<TSource>));
+            var buildResult = builder.Build(new[] { source });
+            var lambda = Expression.Lambda<Func<IObservable<bool>>>(buildResult);
+            return lambda.Compile()().Wait();
+        }
+
+        [TestMethod]
+        public void Equal_StructurallyEqualTuples_ReturnsTrue()
+        {
+            var value = Tuple.Create(Tuple.Create(4, 4), Tuple.Create(4, 4));
+            Assert.IsTrue(EvaluateEquality(new EqualBuilder(), value));
+        }
+
+        [TestMethod]
+        public void Equal_StructurallyUnequalTuples_ReturnsFalse()
+        {
+            var value = Tuple.Create(Tuple.Create(4, 4), Tuple.Create(4, 5));
+            Assert.IsFalse(EvaluateEquality(new EqualBuilder(), value));
+        }
+
+        [TestMethod]
+        public void NotEqual_StructurallyEqualTuples_ReturnsFalse()
+        {
+            var value = Tuple.Create(Tuple.Create(4, 4), Tuple.Create(4, 4));
+            Assert.IsFalse(EvaluateEquality(new NotEqualBuilder(), value));
+        }
+
+        [TestMethod]
+        public void NotEqual_StructurallyUnequalTuples_ReturnsTrue()
+        {
+            var value = Tuple.Create(Tuple.Create(4, 4), Tuple.Create(4, 5));
+            Assert.IsTrue(EvaluateEquality(new NotEqualBuilder(), value));
+        }
+
+        [TestMethod]
+        public void Equal_EqualPrimitivePair_ReturnsTrue()
+        {
+            var value = Tuple.Create(4, 4);
+            Assert.IsTrue(EvaluateEquality(new EqualBuilder(), value));
+        }
+
+        [TestMethod]
+        public void NotEqual_EqualPrimitivePair_ReturnsFalse()
+        {
+            var value = Tuple.Create(4, 4);
+            Assert.IsFalse(EvaluateEquality(new NotEqualBuilder(), value));
+        }
+
+        [TestMethod]
+        public void Equal_NestedStructurallyEqualTuples_ReturnsTrue()
+        {
+            var value = Tuple.Create(
+                Tuple.Create(1, Tuple.Create(2, 3)),
+                Tuple.Create(1, Tuple.Create(2, 3)));
+            Assert.IsTrue(EvaluateEquality(new EqualBuilder(), value));
+        }
+
+        [TestMethod]
+        public void Equal_StructurallyEqualValueTuples_ReturnsTrue()
+        {
+            var value = Tuple.Create((1, 2), (1, 2));
+            Assert.IsTrue(EvaluateEquality(new EqualBuilder(), value));
+        }
+
+        [TestMethod]
+        public void Equal_TupleContainingReferenceArrays_ComparesArraysByReference()
+        {
+            // Tuple equality compares elements with ==, so array elements compare by reference and equal but distinct arrays are unequal.
+            var value = Tuple.Create(Tuple.Create(4, new[] { 1, 2, 3 }), Tuple.Create(4, new[] { 1, 2, 3 }));
+            Assert.IsFalse(EvaluateEquality(new EqualBuilder(), value));
+        }
+
+        [TestMethod]
+        public void Equal_TupleContainingNaN_ComparesNaNAsUnequal()
+        {
+            // Tuple equality compares elements with ==, so NaN is unequal, unlike Tuple.Equals which treats it as equal.
+            var value = Tuple.Create(Tuple.Create(double.NaN, 1.0), Tuple.Create(double.NaN, 1.0));
+            Assert.IsFalse(EvaluateEquality(new EqualBuilder(), value));
+        }
+    }
+}

--- a/Bonsai.Core/Expressions/EqualBuilder.cs
+++ b/Bonsai.Core/Expressions/EqualBuilder.cs
@@ -24,7 +24,7 @@ namespace Bonsai.Expressions
         /// </returns>
         protected override Expression BuildSelector(Expression left, Expression right)
         {
-            return Expression.Equal(left, right);
+            return TupleEqualityHelper.Equal(left, right);
         }
     }
 }

--- a/Bonsai.Core/Expressions/NotEqualBuilder.cs
+++ b/Bonsai.Core/Expressions/NotEqualBuilder.cs
@@ -24,7 +24,7 @@ namespace Bonsai.Expressions
         /// </returns>
         protected override Expression BuildSelector(Expression left, Expression right)
         {
-            return Expression.NotEqual(left, right);
+            return TupleEqualityHelper.NotEqual(left, right);
         }
     }
 }

--- a/Bonsai.Core/Expressions/TupleEqualityHelper.cs
+++ b/Bonsai.Core/Expressions/TupleEqualityHelper.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Bonsai.Expressions
+{
+    internal static class TupleEqualityHelper
+    {
+        static readonly HashSet<Type> TupleTypeDefinitions = new HashSet<Type>
+        {
+            typeof(Tuple<>), typeof(Tuple<,>), typeof(Tuple<,,>), typeof(Tuple<,,,>),
+            typeof(Tuple<,,,,>), typeof(Tuple<,,,,,>), typeof(Tuple<,,,,,,>),
+            typeof(ValueTuple<>), typeof(ValueTuple<,>), typeof(ValueTuple<,,>), typeof(ValueTuple<,,,>),
+            typeof(ValueTuple<,,,,>), typeof(ValueTuple<,,,,,>), typeof(ValueTuple<,,,,,,>)
+        };
+
+        public static Expression Equal(Expression left, Expression right)
+        {
+            return Build(left, right, Expression.Equal, Expression.AndAlso);
+        }
+
+        public static Expression NotEqual(Expression left, Expression right)
+        {
+            return Build(left, right, Expression.NotEqual, Expression.OrElse);
+        }
+
+        static Expression Build(
+            Expression left,
+            Expression right,
+            Func<Expression, Expression, Expression> comparison,
+            Func<Expression, Expression, Expression> combinator)
+        {
+            if (left.Type == right.Type && IsTuple(left.Type, out int itemCount))
+            {
+                Expression result = null;
+                for (int i = 1; i <= itemCount; i++)
+                {
+                    var name = "Item" + i;
+                    var itemComparison = Build(
+                        Expression.PropertyOrField(left, name),
+                        Expression.PropertyOrField(right, name),
+                        comparison,
+                        combinator);
+                    result = result == null ? itemComparison : combinator(result, itemComparison);
+                }
+
+                return result;
+            }
+
+            return comparison(left, right);
+        }
+
+        static bool IsTuple(Type type, out int itemCount)
+        {
+            if (type.IsGenericType && TupleTypeDefinitions.Contains(type.GetGenericTypeDefinition()))
+            {
+                itemCount = type.GetGenericArguments().Length;
+                return true;
+            }
+
+            itemCount = 0;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
The `Equal` and `NotEqual` operators compared `System.Tuple` values by reference, because `Expression.Equal` falls back to reference equality for a type with no `==` operator. So two structurally equal tuples, such as the pair produced by `CombineLatest`, would be reported as unequal.

The operators now compare tuples element-wise, matching the C# tuple `==` and `!=` operators: each element is compared with `Expression.Equal`/`Expression.NotEqual`, so it keeps its own operator, combined with `AndAlso`/`OrElse`, recursing through nested tuples. Both `System.Tuple` and `ValueTuple` are covered. `ValueTuple` cannot be compared by `Expression.Equal` directly either, since C# tuple `==` is a compiler rewrite rather than a `ValueTuple` operator, so it would otherwise throw at build time. The lowering lives in an internal `TupleEqualityHelper`, kept internal so it stays flexible for the planned `System.Tuple` to `ValueTuple` migration.

### Verification

- Comparing two structurally equal `System.Tuple` values, including nested tuples, now returns equal, and unequal tuples return not equal.
- `ValueTuple` values compare element-wise instead of throwing at build time.
- Tuple elements that are reference types, such as arrays, still compare by reference, matching the C# tuple `==` operator.
- A tuple containing `NaN` compares unequal, consistent with element-wise `==` and unlike `Tuple.Equals`.
- Scalar and other non-tuple comparisons are unchanged.

Closes #2517