### PR TITLE
Show updates for local package sources

### DIFF
--- a/Bonsai.NuGet/SourceRepositoryExtensions.cs
+++ b/Bonsai.NuGet/SourceRepositoryExtensions.cs
@@ -91,16 +91,33 @@ namespace Bonsai.NuGet
             VersionRange version = default,
             CancellationToken token = default)
         {
-            using var cacheContext = new SourceCacheContext { MaxAge = DateTimeOffset.UtcNow };
             var searchPackageResource = await repository.GetResourceAsync<PackageSearchResource>(token);
-            var tasks = packages.Select(package =>
+            if (repository.PackageSource.IsLocal)
             {
-                var updateRange = version ?? new VersionRange(package.Version, includeMinVersion: false);
-                return searchPackageResource.SearchAsync($"packageid:{package.Id}", filters, 0, 1, NullLogger.Instance, token);
-            }).ToArray();
+                var tasks = packages.Select(async package =>
+                {
+                    var updateRange = version ?? new VersionRange(package.Version, includeMinVersion: false);
+                    var results = await searchPackageResource.SearchAsync(package.Id, filters, 0, int.MaxValue, NullLogger.Instance, token);
+                    return results.Where(update =>
+                        string.Equals(update.Identity.Id, package.Id, StringComparison.OrdinalIgnoreCase)
+                        && updateRange.Satisfies(update.Identity.Version));
+                }).ToArray();
 
-            var packageUpdates = await Task.WhenAll(tasks);
-            return packageUpdates.SelectMany(package => package).ToList();
+                var localUpdates = await Task.WhenAll(tasks);
+                return localUpdates.SelectMany(update => update).ToList();
+            }
+            else
+            {
+                var tasks = packages.Select(async package =>
+                {
+                    var updateRange = version ?? new VersionRange(package.Version, includeMinVersion: false);
+                    var results = await searchPackageResource.SearchAsync($"packageid:{package.Id}", filters, 0, 1, NullLogger.Instance, token);
+                    return results.Where(update => updateRange.Satisfies(update.Identity.Version));
+                }).ToArray();
+
+                var packageUpdates = await Task.WhenAll(tasks);
+                return packageUpdates.SelectMany(update => update).ToList();
+            }
         }
 
         public static async Task<IPackageSearchMetadata> GetMetadataAsync(this SourceRepository repository, PackageIdentity identity, SourceCacheContext cacheContext, CancellationToken token = default)


### PR DESCRIPTION
The package manager Updates tab would not list updates for local package sources, even though the same packages appear as available updates under the Browse and Installed tabs. `GetUpdatesAsync` queried each installed package with the `packageid:` search qualifier, which the remote V3 search service parses but a local folder source does not. `LocalPackageSearchResource` treats the whole term as a plain substring match, so nothing matched. Local sources are now queried with the raw package id and matched exactly, so their updates appear.

The version range argument was also computed but never applied, so the query would return the latest version of every installed package regardless of whether it was newer than the installed one. This was masked by the local-source bug. Because the local `packageid:` query returned nothing, neither the Updates tab nor the startup check for available updates ever over-reported for a local source. Fixing the local query would unmask that over-reporting, so the version range is now applied in both the local and remote branches, and only packages with a version newer than the installed one are returned. The Uninstall tab passes an all-inclusive range and is unaffected.

### Verification

- On a local feed, a package with a newer version available now appears in the Updates tab, and opening its details shows the version dropdown.
- A package already at the newest version in the feed does not appear.
- The Browse and Installed tabs, and remote feeds, behave as before.

Closes #2565