### PR TITLE
Avoid blocking WithLatestFrom value updates

### DIFF
--- a/Bonsai.Core.Tests/WithLatestFromTests.cs
+++ b/Bonsai.Core.Tests/WithLatestFromTests.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Bonsai.Reactive;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Core.Tests
+{
+    [TestClass]
+    public class WithLatestFromTests
+    {
+        static IObservable<Tuple<TSource, TOther>> Process<TSource, TOther>(
+            IObservable<TSource> source,
+            IObservable<TOther> other)
+        {
+            return new WithLatestFrom().Process(source, other);
+        }
+
+        [TestMethod]
+        public void Process_SourceEmitsAfterValueSeen_EmitsPairWithLatestValue()
+        {
+            var source = new Subject<int>();
+            var other = new Subject<string>();
+            var results = new List<Tuple<int, string>>();
+            using (Process(source, other).Subscribe(results.Add))
+            {
+                other.OnNext("a");
+                source.OnNext(1);
+                other.OnNext("b");
+                source.OnNext(2);
+            }
+
+            CollectionAssert.AreEqual(
+                new[] { Tuple.Create(1, "a"), Tuple.Create(2, "b") },
+                results);
+        }
+
+        [TestMethod]
+        public void Process_SourceCompletes_CompletesResult()
+        {
+            var source = new Subject<int>();
+            var other = new Subject<string>();
+            var completed = false;
+            using (Process(source, other).Subscribe(_ => { }, () => completed = true))
+            {
+                other.OnNext("a");
+                source.OnCompleted();
+            }
+
+            Assert.IsTrue(completed);
+        }
+
+        [TestMethod]
+        public void Process_ValueSequenceCompletes_ContinuesWithLastValue()
+        {
+            var source = new Subject<int>();
+            var other = new Subject<string>();
+            var results = new List<Tuple<int, string>>();
+            var completed = false;
+            using (Process(source, other).Subscribe(results.Add, () => completed = true))
+            {
+                other.OnNext("a");
+                other.OnCompleted();
+                source.OnNext(1);
+                source.OnNext(2);
+            }
+
+            Assert.IsFalse(completed);
+            CollectionAssert.AreEqual(
+                new[] { Tuple.Create(1, "a"), Tuple.Create(2, "a") },
+                results);
+        }
+
+        [TestMethod]
+        public void Process_SourceEmitsBeforeAnyValue_DropsNotification()
+        {
+            var source = new Subject<int>();
+            var other = new Subject<string>();
+            var results = new List<Tuple<int, string>>();
+            using (Process(source, other).Subscribe(results.Add))
+            {
+                source.OnNext(1);
+                other.OnNext("a");
+                source.OnNext(2);
+            }
+
+            CollectionAssert.AreEqual(
+                new[] { Tuple.Create(2, "a") },
+                results);
+        }
+
+        [TestMethod]
+        public void Process_SourceErrors_FaultsDownstream()
+        {
+            var source = new Subject<int>();
+            var other = new Subject<string>();
+            var error = new InvalidOperationException();
+            Exception observed = null;
+            using (Process(source, other).Subscribe(_ => { }, ex => observed = ex))
+            {
+                other.OnNext("a");
+                source.OnError(error);
+            }
+
+            Assert.AreSame(error, observed);
+        }
+
+        [TestMethod]
+        public void Process_ValueSequenceErrors_FaultsDownstream()
+        {
+            var source = new Subject<int>();
+            var other = new Subject<string>();
+            var error = new InvalidOperationException();
+            Exception observed = null;
+            using (Process(source, other).Subscribe(_ => { }, ex => observed = ex))
+            {
+                other.OnError(error);
+            }
+
+            Assert.AreSame(error, observed);
+        }
+
+        [TestMethod]
+        public void Process_ValueAvailableSynchronously_EmitsOnImmediateSourceElement()
+        {
+            var source = Observable.Return(1);
+            var other = Observable.Return("a");
+            var results = new List<Tuple<int, string>>(Process(source, other).ToList().Wait());
+
+            CollectionAssert.AreEqual(
+                new[] { Tuple.Create(1, "a") },
+                results);
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/WithLatestFrom.cs
+++ b/Bonsai.Core/Reactive/WithLatestFrom.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Threading;
 using System.Xml.Serialization;
 
 namespace Bonsai.Reactive
@@ -35,10 +38,70 @@ namespace Bonsai.Reactive
             IObservable<TSource> source,
             IObservable<TOther> other)
         {
-            return source.Publish(ps =>
-                ps.CombineLatest(other, (xs, ys) => Tuple.Create(xs, ys))
-                  .Sample(ps)
-                  .TakeUntil(ps.IgnoreElements().LastOrDefaultAsync()));
+            return Observable.Create<Tuple<TSource, TOther>>(observer =>
+            {
+                var gate = new object();
+                var latestGate = new object();
+                var hasLatest = false;
+                var latest = default(TOther);
+                var otherDisposable = new SingleAssignmentDisposable();
+                var otherObserver = Observer.Create<TOther>(
+                    value =>
+                    {
+                        lock (latestGate)
+                        {
+                            latest = value;
+                        }
+
+                        if (!Volatile.Read(ref hasLatest))
+                        {
+                            Volatile.Write(ref hasLatest, true);
+                        }
+                    },
+                    error =>
+                    {
+                        lock (gate)
+                        {
+                            observer.OnError(error);
+                        }
+                    },
+                    otherDisposable.Dispose);
+                otherDisposable.Disposable = other.SubscribeSafe(otherObserver);
+
+                var sourceObserver = Observer.Create<TSource>(
+                    value =>
+                    {
+                        if (Volatile.Read(ref hasLatest))
+                        {
+                            TOther latestValue;
+                            lock (latestGate)
+                            {
+                                latestValue = latest;
+                            }
+
+                            lock (gate)
+                            {
+                                observer.OnNext(Tuple.Create(value, latestValue));
+                            }
+                        }
+                    },
+                    error =>
+                    {
+                        lock (gate)
+                        {
+                            observer.OnError(error);
+                        }
+                    },
+                    () =>
+                    {
+                        lock (gate)
+                        {
+                            observer.OnCompleted();
+                        }
+                    });
+                var sourceDisposable = source.SubscribeSafe(sourceObserver);
+                return new CompositeDisposable(otherDisposable, sourceDisposable);
+            });
         }
     }
 }


### PR DESCRIPTION
`WithLatestFrom` pairs each source element with the latest value from a second sequence. It was initially built on top of `CombineLatest`, which serializes both sequences and downstream delivery behind a single lock. With that one lock held for the duration of the downstream `OnNext`, an incoming element on the value sequence could not refresh the cached latest value until the call returned, so a slow downstream observer would stall the value sequence for as long as it ran. This is common when software-timestamping a data sequence against a high-rate clock, where a slow consumer of the timestamped element stalls the shared clock sequence, blocking its producer so the device input buffer can overflow.

This change reimplements the operator on the two-lock strategy from the current `WithLatestFrom` in dotnet/reactive. One lock serializes downstream delivery, and a separate lock guards only the cached latest value. The value sequence now updates the cached value under its own lock without waiting on downstream work, so a slow observer delays only further source elements, not value updates.

### Validation

Observable behavior is otherwise unchanged. The value sequence is subscribed before the source, so a synchronously available value is ready when the source emits immediately. The source observer forwards completion directly, so the result sequence completes with the source and no longer needs the `TakeUntil` clause the previous composition added to fix #670. A completed value sequence retains its last value, and an error on either sequence faults downstream.

`WithLatestFromTests` was added to guard the behavior-preservation dimensions against regression: pairing with the latest value, source completion, value-sequence completion retaining the last value, dropping a source element that arrives before any value, faulting on either sequence, and synchronous value availability.

Closes #2600