### PR TITLE
Update workflow actions to Node 24 majors

### DIFF
--- a/.github/workflows/Bonsai.yml
+++ b/.github/workflows/Bonsai.yml
@@ -37,9 +37,9 @@ jobs:
       matrix: ${{steps.create-matrix.outputs.matrix}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Create build matrix
@@ -65,28 +65,28 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{matrix.checkout-ref}}
 
       # ----------------------------------------------------------------------- Setup tools
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       # Legacy .NET command line tools are only used for building the installer
       - name: Setup MSBuild command line
         if: matrix.create-installer
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
       - name: Setup NuGet command line
         if: matrix.create-installer
-        uses: NuGet/setup-nuget@v2
+        uses: NuGet/setup-nuget@v4
         with:
           nuget-version: 6.x
 
@@ -157,7 +157,7 @@ jobs:
 
       # ----------------------------------------------------------------------- Collect artifacts
       - name: Collect NuGet packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: matrix.collect-packages && steps.pack.outcome == 'success' && always()
         with:
           name: Packages${{matrix.artifacts-suffix}}
@@ -165,7 +165,7 @@ jobs:
           path: artifacts/package/${{matrix.configuration-lower}}/**
 
       - name: Collect portable zip
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: steps.create-portable-zip.outcome == 'success' && always()
         with:
           name: PortableZip${{matrix.artifacts-suffix}}
@@ -173,7 +173,7 @@ jobs:
           path: artifacts/Bonsai.zip
 
       - name: Collect installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: steps.create-installer.outcome == 'success' && always()
         with:
           name: Installer${{matrix.artifacts-suffix}}
@@ -192,17 +192,17 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # ----------------------------------------------------------------------- Setup tools
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       # ----------------------------------------------------------------------- Download packages for comparison
       - name: Download packages for comparison
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: Packages*
           path: artifacts
@@ -214,7 +214,7 @@ jobs:
 
       # ----------------------------------------------------------------------- Collect release manifest
       - name: Collect release manifest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: steps.compare-packages.outcome != 'skipped' && always()
         with:
           name: ReleaseManifest
@@ -240,42 +240,42 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           sparse-checkout: .github
           sparse-checkout-cone-mode: false
 
       # ----------------------------------------------------------------------- Setup tools
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       # ----------------------------------------------------------------------- Download artifacts
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Packages
           path: Packages
 
       - name: Download release manifest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ReleaseManifest
 
       - name: Download portable zip
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         if: github.event_name == 'release'
         with:
           name: PortableZip
 
       - name: Download installer
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         if: github.event_name == 'release'
         with:
           name: Installer
@@ -313,31 +313,31 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           sparse-checkout: .github
           sparse-checkout-cone-mode: false
 
       # ----------------------------------------------------------------------- Setup tools
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       # ----------------------------------------------------------------------- Download artifacts
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Packages
           path: Packages
 
       - name: Download release manifest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ReleaseManifest
 
@@ -384,7 +384,7 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: refs/heads/main
           ssh-key: ${{secrets.CI_DEPLOYMENT_KEY}}
@@ -429,7 +429,7 @@ jobs:
 
       # ----------------------------------------------------------------------- Close milestone
       - name: Close milestone
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         if: always()
         continue-on-error: true
         env:


### PR DESCRIPTION
GitHub Actions runners have deprecated Node 20, and the workflow's pinned action majors still target it, so every run prints the Node 20 deprecation warning while the actions are force-run on Node 24. This bumps each action to its latest major, all of which target the Node 24 runtime, so the declared runtime matches what the runner already uses and the warning clears.

### Version bumps

- `actions/checkout` v4 to v7
- `actions/setup-python` v5 to v6
- `actions/setup-dotnet` v4 to v5
- `actions/upload-artifact` v4 to v7
- `actions/download-artifact` v4 to v8
- `actions/github-script` v7 to v9
- `microsoft/setup-msbuild` v2 to v3
- `NuGet/setup-nuget` v2 to v4

### Notes

The artifact actions and `github-script` cross several majors, so this run is the real check that nothing in their newer majors changes how the workflow uses them; the checkout and setup bumps are largely runtime updates. `actions/upload-artifact` and `actions/download-artifact` are moved together to keep the upload and download pair compatible. The change is otherwise advisory, since the runner already forces these actions onto Node 24 today, so nothing was failing beforehand.