### PR TITLE
Bump template versions to 2.9.1

### DIFF
--- a/Bonsai.Player/README.md
+++ b/Bonsai.Player/README.md
@@ -8,7 +8,7 @@
 
 ```
 dotnet new tool-manifest
-dotnet tool install Bonsai.Player --version 2.9.0
+dotnet tool install Bonsai.Player --version 2.9.1
 ```
 
 ### Execution

--- a/Bonsai.Templates/Bonsai.LibraryTemplate/ProjectTemplate.csproj
+++ b/Bonsai.Templates/Bonsai.LibraryTemplate/ProjectTemplate.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Core" Version="2.9.0" />
+    <PackageReference Include="Bonsai.Core" Version="2.9.1" />
   </ItemGroup>
 
 </Project>

--- a/Bonsai.Templates/Bonsai.PackageTemplate/src/PackageTemplate/PackageTemplate.csproj
+++ b/Bonsai.Templates/Bonsai.PackageTemplate/src/PackageTemplate/PackageTemplate.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Core" Version="2.9.0" />
+    <PackageReference Include="Bonsai.Core" Version="2.9.1" />
   </ItemGroup>
 
 </Project>

--- a/Bonsai.Templates/Bonsai.WorkflowTemplate/WorkflowTemplate.bonsai
+++ b/Bonsai.Templates/Bonsai.WorkflowTemplate/WorkflowTemplate.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.9.0"
+<WorkflowBuilder Version="2.9.1"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>

--- a/Bonsai.Templates/README.md
+++ b/Bonsai.Templates/README.md
@@ -7,7 +7,7 @@
 ### Installation
 
 ```
-dotnet new install Bonsai.Templates::2.9.0
+dotnet new install Bonsai.Templates::2.9.1
 ```
 
 ### Creating a Package Project


### PR DESCRIPTION
This updates the hand-maintained version references on the templates package and its README files, so a newly scaffolded project builds against the current Bonsai.Core and the README install commands install the current packages.

### Changes

- `Bonsai.WorkflowTemplate/WorkflowTemplate.bonsai`: workflow format version 2.9.0 to 2.9.1
- `Bonsai.PackageTemplate` and `Bonsai.LibraryTemplate`: `Bonsai.Core` reference 2.9.0 to 2.9.1
- `Bonsai.Templates` and `Bonsai.Player` readmes: install command version 2.9.0 to 2.9.1