### PR TITLE
Fix operator docs redirecting to operand property type

### DIFF
--- a/Bonsai.Editor/EditorForm.cs
+++ b/Bonsai.Editor/EditorForm.cs
@@ -2428,7 +2428,8 @@ namespace Bonsai.Editor
         {
             var selectedElement = ExpressionBuilder.GetWorkflowElement(builder);
             if (selectedElement is ICustomTypeDescriptor typeDescriptor &&
-                typeDescriptor.GetPropertyOwner(null) is object selectedOperator)
+                typeDescriptor.GetPropertyOwner(null) is object selectedOperator &&
+                selectedOperator is not WorkflowProperty)
             {
                 selectedElement = selectedOperator;
             }


### PR DESCRIPTION
## Summary

Fixes #2552

Pressing F1 on operators derived from `BinaryOperatorBuilder` (e.g. `Prepend`, `Append`, and the arithmetic/comparison operators) opened the documentation page for the underlying operand property type (e.g. `IntProperty`) instead of the operator itself.

## Cause

`OpenDocumentationAsync` redirects the docs lookup to the object returned by `ICustomTypeDescriptor.GetPropertyOwner(null)`, added in #1369 to support indexing documentation on polymorphic operators.

`BinaryOperatorBuilder` also implements `ICustomTypeDescriptor`, but its property owner is the operand `WorkflowProperty`, which is lazily instantiated the first time the workflow builds with a connected input. This explains the behavior in the repro: before the workflow compiles the operand is null and F1 resolves the correct page, but once an input is connected the operand is created and F1 redirects to its type instead.

## Fix

Exclude `WorkflowProperty` owners from the redirect. The operand is a value container created implicitly by the builder rather than a user-selected polymorphic instance, so documentation should always target the operator itself not the underlying type of the value. Note that polymorphic operators (e.g. `CreateMessage` in Bonsai.Harp) are unaffected by this change since they resolve to regular operator classes.
