### PR TITLE
Add `OfType` and `Cast` operators

### DIFF
--- a/Bonsai.Core.Tests/CastTests.cs
+++ b/Bonsai.Core.Tests/CastTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reactive.Linq;
+using System.Text;
+using System.Xml;
+using Bonsai.Expressions;
+using Bonsai.Reactive;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Core.Tests
+{
+    [TestClass]
+    public class CastTests
+    {
+        [TestMethod]
+        public void Build_ObjectSequenceWithCompatibleElements_CastsElementsToTargetType()
+        {
+            var result = new TestWorkflow()
+                .AppendValue<object>("A")
+                .Append(new Cast { TypeMapping = new TypeMapping<string>() })
+                .AppendOutput()
+                .BuildObservable<string>()
+                .FirstAsync().Wait();
+            Assert.AreEqual("A", result);
+        }
+
+        [TestMethod]
+        public void Build_ObjectSequenceWithIncompatibleElements_ThrowsInvalidCastException()
+        {
+            var observable = new TestWorkflow()
+                .AppendValue<object>(1)
+                .Append(new Cast { TypeMapping = new TypeMapping<string>() })
+                .AppendOutput()
+                .BuildObservable<string>();
+            Assert.ThrowsException<InvalidCastException>(() => observable.FirstAsync().Wait());
+        }
+
+        [TestMethod]
+        public void Build_Int32SequenceCastToInt64_ThrowsInvalidCastException()
+        {
+            // consistent with Observable.Cast: boxed values only unbox to their exact type
+            var observable = new TestWorkflow()
+                .AppendValue(1)
+                .Append(new Cast { TypeMapping = new TypeMapping<long>() })
+                .AppendOutput()
+                .BuildObservable<long>();
+            Assert.ThrowsException<InvalidCastException>(() => observable.FirstAsync().Wait());
+        }
+
+        [TestMethod]
+        public void Build_NoTypeMapping_CastsElementsToObject()
+        {
+            var result = new TestWorkflow()
+                .AppendValue(1)
+                .Append(new Cast())
+                .AppendOutput()
+                .BuildObservable<object>()
+                .FirstAsync().Wait();
+            Assert.AreEqual(1, result);
+        }
+
+        [TestMethod]
+        public void Name_GenericTargetType_ReturnsTypeName()
+        {
+            INamedElement cast = new Cast { TypeMapping = new TypeMapping<List<int>>() };
+            Assert.AreEqual("Cast(List<Int32>)", cast.Name);
+        }
+
+        [TestMethod]
+        public void SerializeDeserialize_TypeMapping_RoundTripEqualsOriginal()
+        {
+            var workflow = new WorkflowBuilder();
+            workflow.Workflow.Add(new Cast { TypeMapping = new TypeMapping<double>() });
+            workflow.Workflow.Add(new Cast { TypeMapping = new TypeMapping<Tuple<int, string>>() });
+
+            var builder = new StringBuilder();
+            using (var writer = XmlWriter.Create(builder, new XmlWriterSettings { Indent = true }))
+            {
+                WorkflowBuilder.Serializer.Serialize(writer, workflow);
+            }
+
+            var xml = builder.ToString();
+            using (var reader = XmlReader.Create(new StringReader(xml)))
+            {
+                workflow = (WorkflowBuilder)WorkflowBuilder.Serializer.Deserialize(reader);
+            }
+
+            builder.Clear();
+            using (var writer = XmlWriter.Create(builder, new XmlWriterSettings { Indent = true }))
+            {
+                WorkflowBuilder.Serializer.Serialize(writer, workflow);
+            }
+            Assert.AreEqual(xml, builder.ToString());
+        }
+    }
+}

--- a/Bonsai.Core.Tests/OfTypeTests.cs
+++ b/Bonsai.Core.Tests/OfTypeTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Xml;
+using Bonsai.Expressions;
+using Bonsai.Reactive;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonsai.Core.Tests
+{
+    [TestClass]
+    public class OfTypeTests
+    {
+        class MixedObjectSource : Source<object>
+        {
+            public override IObservable<object> Generate()
+            {
+                return new object[] { 1, "two", null, 3.0, "four" }.ToObservable();
+            }
+        }
+
+        static IList<TResult> RunOfType<TResult>()
+        {
+            return new TestWorkflow()
+                .AppendCombinator(new MixedObjectSource())
+                .Append(new OfType { TypeMapping = new TypeMapping<TResult>() })
+                .AppendOutput()
+                .BuildObservable<TResult>()
+                .ToList().Wait();
+        }
+
+        [TestMethod]
+        public void Build_MixedObjectSequence_FiltersMatchingReferenceTypeElements()
+        {
+            var results = RunOfType<string>();
+            CollectionAssert.AreEqual(new[] { "two", "four" }, results.ToArray());
+        }
+
+        [TestMethod]
+        public void Build_MixedObjectSequence_FiltersMatchingValueTypeElements()
+        {
+            var results = RunOfType<int>();
+            CollectionAssert.AreEqual(new[] { 1 }, results.ToArray());
+        }
+
+        [TestMethod]
+        public void Build_NoTypeMapping_FiltersNullElements()
+        {
+            var results = new TestWorkflow()
+                .AppendCombinator(new MixedObjectSource())
+                .Append(new OfType())
+                .AppendOutput()
+                .BuildObservable<object>()
+                .ToList().Wait();
+            CollectionAssert.AreEqual(new object[] { 1, "two", 3.0, "four" }, results.ToArray());
+        }
+
+        [TestMethod]
+        public void SerializeDeserialize_TypeMapping_RoundTripEqualsOriginal()
+        {
+            var workflow = new WorkflowBuilder();
+            workflow.Workflow.Add(new OfType { TypeMapping = new TypeMapping<string>() });
+            workflow.Workflow.Add(new OfType { TypeMapping = new TypeMapping<List<Tuple<int, int>>>() });
+
+            var builder = new StringBuilder();
+            using (var writer = XmlWriter.Create(builder, new XmlWriterSettings { Indent = true }))
+            {
+                WorkflowBuilder.Serializer.Serialize(writer, workflow);
+            }
+
+            var xml = builder.ToString();
+            using (var reader = XmlReader.Create(new StringReader(xml)))
+            {
+                workflow = (WorkflowBuilder)WorkflowBuilder.Serializer.Deserialize(reader);
+            }
+
+            builder.Clear();
+            using (var writer = XmlWriter.Create(builder, new XmlWriterSettings { Indent = true }))
+            {
+                WorkflowBuilder.Serializer.Serialize(writer, workflow);
+            }
+            Assert.AreEqual(xml, builder.ToString());
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/Cast.cs
+++ b/Bonsai.Core/Reactive/Cast.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reactive.Linq;
+using System.Xml.Serialization;
+using Bonsai.Expressions;
+
+namespace Bonsai.Reactive
+{
+    /// <summary>
+    /// Represents an operator that casts each element of an observable sequence
+    /// into the specified type.
+    /// </summary>
+    [XmlType(Namespace = Constants.XmlNamespace)]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Casts each element of the sequence into the specified type.")]
+    public class Cast : SingleArgumentExpressionBuilder, ISerializableElement, INamedElement
+    {
+        /// <summary>
+        /// Gets or sets a type mapping specifying the type into which each element
+        /// of the sequence will be cast.
+        /// </summary>
+        [Browsable(false)]
+        public TypeMapping TypeMapping { get; set; }
+
+        object ISerializableElement.Element
+        {
+            get { return TypeMapping; }
+        }
+
+        string INamedElement.Name
+        {
+            get
+            {
+                var targetType = TypeMapping?.TargetType;
+                var displayName = GetElementDisplayName(GetType());
+                return targetType != null
+                    ? $"{displayName}({GetTypeName(targetType)})"
+                    : displayName;
+            }
+        }
+
+        internal static string GetTypeName(Type type)
+        {
+            var typeName = type.Name;
+            if (type.IsGenericType)
+            {
+                var separatorIndex = typeName.LastIndexOf('`');
+                if (separatorIndex >= 0) typeName = typeName.Substring(0, separatorIndex);
+                var typeArguments = string.Join(",", type.GetGenericArguments().Select(GetTypeName));
+                return $"{typeName}<{typeArguments}>";
+            }
+
+            return typeName;
+        }
+
+        /// <summary>
+        /// Generates an <see cref="Expression"/> node from a collection of input arguments.
+        /// The result can be chained with other builders in a workflow.
+        /// </summary>
+        /// <param name="arguments">
+        /// A collection of <see cref="Expression"/> nodes that represents the input arguments.
+        /// </param>
+        /// <returns>An <see cref="Expression"/> tree node.</returns>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            var source = arguments.First();
+            var sourceType = source.Type.GetGenericArguments()[0];
+            var targetType = TypeMapping?.TargetType ?? typeof(object);
+            var combinator = Expression.Constant(this);
+            return Expression.Call(
+                combinator,
+                nameof(Process),
+                new[] { sourceType, targetType },
+                source);
+        }
+
+        IObservable<TResult> Process<TSource, TResult>(IObservable<TSource> source)
+        {
+            var objectSource = source as IObservable<object> ?? source.Select(value => (object)value);
+            return objectSource.Cast<TResult>();
+        }
+    }
+}

--- a/Bonsai.Core/Reactive/OfType.cs
+++ b/Bonsai.Core/Reactive/OfType.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reactive.Linq;
+using System.Xml.Serialization;
+using Bonsai.Expressions;
+
+namespace Bonsai.Reactive
+{
+    /// <summary>
+    /// Represents an operator that filters the elements of an observable sequence
+    /// based on the specified type.
+    /// </summary>
+    [XmlType(Namespace = Constants.XmlNamespace)]
+    [WorkflowElementCategory(ElementCategory.Combinator)]
+    [Description("Filters the elements of the sequence based on the specified type.")]
+    public class OfType : SingleArgumentExpressionBuilder, ISerializableElement, INamedElement
+    {
+        /// <summary>
+        /// Gets or sets a type mapping specifying the type used to filter the elements
+        /// of the sequence.
+        /// </summary>
+        [Browsable(false)]
+        public TypeMapping TypeMapping { get; set; }
+
+        object ISerializableElement.Element
+        {
+            get { return TypeMapping; }
+        }
+
+        string INamedElement.Name
+        {
+            get
+            {
+                var targetType = TypeMapping?.TargetType;
+                var displayName = GetElementDisplayName(GetType());
+                return targetType != null
+                    ? $"{displayName}({Cast.GetTypeName(targetType)})"
+                    : displayName;
+            }
+        }
+
+        /// <summary>
+        /// Generates an <see cref="Expression"/> node from a collection of input arguments.
+        /// The result can be chained with other builders in a workflow.
+        /// </summary>
+        /// <param name="arguments">
+        /// A collection of <see cref="Expression"/> nodes that represents the input arguments.
+        /// </param>
+        /// <returns>An <see cref="Expression"/> tree node.</returns>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            var source = arguments.First();
+            var sourceType = source.Type.GetGenericArguments()[0];
+            var targetType = TypeMapping?.TargetType ?? typeof(object);
+            var combinator = Expression.Constant(this);
+            return Expression.Call(
+                combinator,
+                nameof(Process),
+                new[] { sourceType, targetType },
+                source);
+        }
+
+        IObservable<TResult> Process<TSource, TResult>(IObservable<TSource> source)
+        {
+            var objectSource = source as IObservable<object> ?? source.Select(value => (object)value);
+            return objectSource.OfType<TResult>();
+        }
+    }
+}

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.Designer.cs
@@ -31,6 +31,9 @@
             this.components = new System.ComponentModel.Container();
             this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.outputToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.createTypeOperatorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.castToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.ofTypeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.externalizeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
             this.subjectTypeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -73,6 +76,7 @@
             this.externalizeToolStripMenuItem,
             this.toolStripSeparator7,
             this.subjectTypeToolStripMenuItem,
+            this.createTypeOperatorToolStripMenuItem,
             this.createPropertySourceToolStripMenuItem,
             this.toolStripSeparator3,
             this.visualizerToolStripMenuItem,
@@ -112,9 +116,33 @@
             this.outputToolStripMenuItem.Name = "outputToolStripMenuItem";
             this.outputToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
             this.outputToolStripMenuItem.Text = "Output";
-            // 
+            //
+            // createTypeOperatorToolStripMenuItem
+            //
+            this.createTypeOperatorToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.castToolStripMenuItem,
+            this.ofTypeToolStripMenuItem});
+            this.createTypeOperatorToolStripMenuItem.Enabled = false;
+            this.createTypeOperatorToolStripMenuItem.Name = "createTypeOperatorToolStripMenuItem";
+            this.createTypeOperatorToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
+            this.createTypeOperatorToolStripMenuItem.Text = "Create Type Operator";
+            //
+            // castToolStripMenuItem
+            //
+            this.castToolStripMenuItem.Name = "castToolStripMenuItem";
+            this.castToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.castToolStripMenuItem.Text = "Cast";
+            this.castToolStripMenuItem.Click += new System.EventHandler(this.castToolStripMenuItem_Click);
+            //
+            // ofTypeToolStripMenuItem
+            //
+            this.ofTypeToolStripMenuItem.Name = "ofTypeToolStripMenuItem";
+            this.ofTypeToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.ofTypeToolStripMenuItem.Text = "OfType";
+            this.ofTypeToolStripMenuItem.Click += new System.EventHandler(this.ofTypeToolStripMenuItem_Click);
+            //
             // externalizeToolStripMenuItem
-            // 
+            //
             this.externalizeToolStripMenuItem.Enabled = false;
             this.externalizeToolStripMenuItem.Name = "externalizeToolStripMenuItem";
             this.externalizeToolStripMenuItem.Size = new System.Drawing.Size(249, 22);
@@ -420,6 +448,9 @@
         private System.Windows.Forms.ToolStripMenuItem visualizerToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem outputToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem createTypeOperatorToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem castToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem ofTypeToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
         private System.Windows.Forms.ToolStripMenuItem externalizeToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem createPropertySourceToolStripMenuItem;

--- a/Bonsai.Editor/GraphView/WorkflowGraphView.cs
+++ b/Bonsai.Editor/GraphView/WorkflowGraphView.cs
@@ -1321,6 +1321,46 @@ namespace Bonsai.Editor.GraphView
             return menuItem;
         }
 
+        private void InitializeTypeMappingMenuItems(Type memberType)
+        {
+            InitializeOutputMenuItem(createTypeOperatorToolStripMenuItem, string.Empty, memberType);
+            createTypeOperatorToolStripMenuItem.Enabled = true;
+        }
+
+        private void castToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            CreateTypeMappingGraphNode(memberType => new Bonsai.Reactive.Cast
+            {
+                TypeMapping = CreateTypeMapping(memberType)
+            });
+        }
+
+        private void ofTypeToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            CreateTypeMappingGraphNode(memberType => new Bonsai.Reactive.OfType
+            {
+                TypeMapping = CreateTypeMapping(memberType)
+            });
+        }
+
+        static TypeMapping CreateTypeMapping(Type targetType)
+        {
+            return (TypeMapping)Activator.CreateInstance(typeof(TypeMapping<>).MakeGenericType(targetType));
+        }
+
+        private void CreateTypeMappingGraphNode(Func<Type, ExpressionBuilder> builderFactory)
+        {
+            var selectedNode = selectionModel.SelectedNodes.FirstOrDefault();
+            if (selectedNode != null && createTypeOperatorToolStripMenuItem.Tag is Type memberType)
+            {
+                var builder = builderFactory(memberType);
+                var nodeType = Control.ModifierKeys.HasFlag(Keys.Shift)
+                    ? CreateGraphNodeType.Predecessor
+                    : CreateGraphNodeType.Successor;
+                Editor.CreateGraphNode(builder, selectedNode, nodeType, branch: Control.ModifierKeys.HasFlag(Keys.Alt));
+            }
+        }
+
         private void CreateSubjectTypeMenuItems(InspectBuilder inspectBuilder, ToolStripMenuItem ownerItem, Type memberType, GraphNode selectedNode)
         {
             if (inspectBuilder.Builder is SubscribeSubject subscribeBuilder)
@@ -1735,6 +1775,10 @@ namespace Bonsai.Editor.GraphView
                         CreateSubjectTypeMenuItems(inspectBuilder, subjectTypeToolStripMenuItem, inspectBuilder.ObservableType, selectedNode);
                         CreateExternalizeMenuItems(workflowElement, externalizeToolStripMenuItem, selectedNode);
                         CreatePropertySourceMenuItems(workflowElement, createPropertySourceToolStripMenuItem);
+                        if (inspectBuilder.ObservableType != null)
+                        {
+                            InitializeTypeMappingMenuItems(inspectBuilder.ObservableType);
+                        }
                     }
 
                     externalizeToolStripMenuItem.Enabled = externalizeToolStripMenuItem.DropDownItems.Count > 0;
@@ -1772,6 +1816,7 @@ namespace Bonsai.Editor.GraphView
             }
 
             outputToolStripMenuItem.Text = Resources.OutputMenuItemLabel;
+            createTypeOperatorToolStripMenuItem.Text = Resources.CreateTypeOperatorMenuItemLabel;
             subjectTypeToolStripMenuItem.Text = Resources.CreateSourceMenuItemLabel;
             visualizerToolStripMenuItem.Text = Resources.ShowVisualizerMenuItem;
             outputToolStripMenuItem.DropDownItems.Clear();

--- a/Bonsai.Editor/Properties/Resources.Designer.cs
+++ b/Bonsai.Editor/Properties/Resources.Designer.cs
@@ -213,6 +213,15 @@ namespace Bonsai.Editor.Properties {
                 return ResourceManager.GetString("CreateTypeNode_Error", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Create Type Operator.
+        /// </summary>
+        internal static string CreateTypeOperatorMenuItemLabel {
+            get {
+                return ResourceManager.GetString("CreateTypeOperatorMenuItemLabel", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.

--- a/Bonsai.Editor/Properties/Resources.resx
+++ b/Bonsai.Editor/Properties/Resources.resx
@@ -328,6 +328,9 @@ NOTE: You will have to restart Bonsai for any changes to take effect.</value>
   <data name="VisualizerLayoutOnNullWorkflow_Error" xml:space="preserve">
     <value>Cannot set visualizer layout with a null workflow.</value>
   </data>
+  <data name="CreateTypeOperatorMenuItemLabel" xml:space="preserve">
+    <value>Create Type Operator</value>
+  </data>
   <data name="CreateSourceMenuItemLabel" xml:space="preserve">
     <value>Create Source</value>
   </data>


### PR DESCRIPTION
Closes #2396.

## Summary

Adds two new operators to `Bonsai.Reactive`, mirroring the corresponding Rx operators:

- **`Cast`** (Transform) - casts each element of the sequence into a specified type (from https://learn.microsoft.com/en-us/previous-versions/dotnet/reactive-extensions/hh211842(v=vs.103))
- **`OfType`** (Combinator) - filters the sequence to elements of a specified type, silently dropping non-matching elements (including `null`). From (https://learn.microsoft.com/en-us/previous-versions/dotnet/reactive-extensions/hh229380(v=vs.103))

Both operators store/serialize their target type, and delegate at runtime to `Observable.Cast<TResult>` / `Observable.OfType<TResult>` so behavior is always consistent with Rx.

## Editor integration

Since these operators need type information provided at design time, the graph view context menu gains a new **Create Type Operator** submenu, sitting alongside *Create Source* and following the same type-aware creation semantics as subjects: right-clicking a node with inferred output type `T` shows `Create Type Operator (T) ▸ Cast / OfType`, and selecting an entry inserts the operator as a successor with its target type pre-set to `T`. The typical downcasting workflow is to create the operator from the node whose type you want to recover, then rewire it after the weakly-typed (e.g. `object`) stream.

## Design decision regarding Rx

`Cast` deliberately keeps Rx's boxed-cast semantics rather than C# conversion semantics. Rx's `Observable.Cast` operates on `IObservable<object>`: each element is a boxed value cast to the target type, and a boxed value type can only be **unboxed to its exact type**. This means `Cast` supports reference downcasts/upcasts and exact unboxing, but *not* representation-changing conversions - casting an `IObservable<int>` to `long` throws `InvalidCastException` at runtime, exactly as `Observable.Cast<long>` would. For most of these casts, we can use Bonsai's implicit casting engine (E.g: `Int`-> `Float` via an `InputMapping`)

An alternative implementation, could bypass the Rx method and instead use `Expression.Convert` and test it at compile-time. I rejected this for the sake of:

1. **Consistency with Rx** - an operator named `Cast` should not have different semantics from `Observable.Cast`.
2. **No overlap with existing operators** - conversion semantics are already available through `MemberSelector`/`InputMapping` with a `TypeMapping`, which seems to use `Expression.Convert` under the hood.
ping` element (including generic type arguments).

