### PR TITLE
Add bootstrapper checksums for 2.9.0 and 2.9.1

### DIFF
--- a/Bonsai.Configuration/EnvironmentSelector.cs
+++ b/Bonsai.Configuration/EnvironmentSelector.cs
@@ -30,6 +30,8 @@ public static class EnvironmentSelector
     static readonly BootstrapperInfo defaultBootstrapper = GetDefaultBootstrapper();
     static readonly Dictionary<string, string> knownChecksums = new()
     {
+        { "2.9.1", "f4ad11e95a5138fe339d6796b618ac94d597d1e95cdaaf2b00a2e2aab9f05d80" },
+        { "2.9.0", "61dfb52a8ce2bb4e1581588593218e3db93bf76ed742b850fc9f3610450a6d08" },
         { "2.8.5", "30293da62cf6df08581235b5d9a468c9005007bf4b6315b8a79eedc34080f192" },
         { "2.8.4", "ee63d29dd6eabf5743019ed91ed2319855a88fd4725608853cb0d277a2ef96bc" },
         { "2.8.3", "db68236020581cd8835033de468c60619e6ba3d3e0a868ededb2a6b766f4914b" },


### PR DESCRIPTION
The `knownChecksums` table in `EnvironmentSelector` had static entries only up to 2.8.5, plus a dynamic entry for the version of the running launcher. A local environment pinned to a released version with no entry is rejected outright, so opening a workflow in a project pinned to 2.9.0 would fail with an unhandled `ApplicationException` under the 2.9.1 launcher. Adding the two entries makes those environments start their own bootstrapper again, downloading it first when the executable is not already present.

### How the values were obtained

Each value is the SHA256 of the `Bonsai.exe` inside the `Bonsai.zip` release asset for that version, which is the file [`DownloadBootstrapperExecutableAsync` compares against](https://github.com/bonsai-rx/bonsai/blob/87fa801597d22b5ca0246f2e936ceda287dc8cc8/Bonsai.Configuration/EnvironmentSelector.cs#L193-L198) after extracting the archive. To reproduce, per version:

```
curl -L -o Bonsai.zip https://github.com/bonsai-rx/bonsai/releases/download/2.9.0/Bonsai.zip
unzip -o Bonsai.zip Bonsai.exe
sha256sum Bonsai.exe
```

`bonsai --info` prints the resolved bootstrapper path, version and checksum for the current directory without launching or downloading anything. To check the behaviour, run this command in a project whose `.bonsai/Bonsai.config` pins 2.9.0. The bootstrapper will report an empty checksum before this change and the new value after.

### What this does not fix

Launchers already installed at 2.9.1 carry the incomplete table, so they keep rejecting 2.9.0 environments until they are updated. The workaround in the meantime is to place the 2.9.0 `Bonsai.exe` in the `.bonsai` folder and run it directly rather than through the installed launcher.

Closes #2649