### PR TITLE
Sign release artifacts when publishing

### DIFF
--- a/.github/workflows/Bonsai.yml
+++ b/.github/workflows/Bonsai.yml
@@ -59,9 +59,24 @@ jobs:
       matrix: ${{fromJSON(needs.create-build-matrix.outputs.matrix)}}
     name: ${{matrix.platform.name}} ${{matrix.configuration}}
     runs-on: ${{matrix.platform.os}}
+    # Only the target which creates the installer signs anything, so it is the only one which needs the signing credentials and the release approval
+    # The condition is spelled out here rather than reusing WillPublishPackages below because the environment key is evaluated before any step runs
+    environment: >-
+      ${{matrix.create-installer
+      && (github.event_name == 'release'
+      || (github.event_name == 'workflow_dispatch'
+      && github.event.inputs.will_publish_packages == 'true'
+      && github.event.inputs.version != ''))
+      && 'PublicRelease' || ''}}
     env:
       IsReferenceDummyBuild: ${{matrix.dummy-build}}
       UseRepackForBootstrapperPackage: ${{matrix.collect-packages && !matrix.dummy-build}}
+      # This should be kept in sync with publish-packages-nuget-org
+      WillPublishPackages: >-
+        ${{github.event_name == 'release'
+        || (github.event_name == 'workflow_dispatch'
+        && github.event.inputs.will_publish_packages == 'true'
+        && github.event.inputs.version != '')}}
     steps:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout
@@ -115,6 +130,18 @@ jobs:
         if: matrix.create-installer || env.UseRepackForBootstrapperPackage == 'true'
         run: dotnet build Bonsai --no-restore --configuration ${{matrix.configuration}} -t:Repack -p:TargetFramework=net48
 
+      # ----------------------------------------------------------------------- Sign bootstrapper
+      # Signing here means a single signature covers every copy of the bootstrapper
+      - name: Sign bootstrapper
+        if: matrix.create-installer && env.WillPublishPackages == 'true'
+        uses: bonsai-rx/sign@c8502c075cfa2f3133607b8a6de308347f8beda2 # v1.0.0
+        with:
+          files: artifacts/bin/Bonsai/${{matrix.configuration-lower}}-repacked/Bonsai.exe
+          username: ${{secrets.ES_USERNAME}}
+          password: ${{secrets.ES_PASSWORD}}
+          credential-id: ${{secrets.ES_CREDENTIAL_ID}}
+          totp-secret: ${{secrets.ES_TOTP_SECRET}}
+
       # ----------------------------------------------------------------------- Pack
       # Since packages are core to Bonsai functionality we always pack them even if they won't be collected
       - name: Pack
@@ -139,8 +166,7 @@ jobs:
         run: python .github/workflows/create-portable-zip.py artifacts/Bonsai.zip ${{matrix.configuration}}
         env:
           NUGET_API_URL: ${{vars.NUGET_API_URL}}
-          # This should be kept in sync with publish-packages-nuget-org
-          IS_FULL_RELEASE: ${{github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.will_publish_packages == 'true' && github.event.inputs.version != '')}}
+          IS_FULL_RELEASE: ${{env.WillPublishPackages}}
 
       # ----------------------------------------------------------------------- Build setup
       - name: Restore setup
@@ -150,10 +176,60 @@ jobs:
           nuget restore Bonsai.Setup/packages.config -SolutionDir .
           nuget restore Bonsai.Setup.Bootstrapper/packages.config -SolutionDir .
 
-      - name: Build Setup
+      # The MSI and the bundle are built one at a time so the MSI can be signed before the bundle embeds it
+      - name: Build MSI
+        if: matrix.create-installer
+        run: msbuild /nologo /maxCpuCount Bonsai.Setup/Bonsai.Setup.wixproj /p:Configuration=${{matrix.configuration}} /p:Platform=x86
+
+      - name: Sign MSI
+        if: matrix.create-installer && env.WillPublishPackages == 'true'
+        uses: bonsai-rx/sign@c8502c075cfa2f3133607b8a6de308347f8beda2 # v1.0.0
+        with:
+          files: artifacts/bin/Bonsai.Setup/${{matrix.configuration-lower}}-x86/Bonsai.Setup.msi
+          username: ${{secrets.ES_USERNAME}}
+          password: ${{secrets.ES_PASSWORD}}
+          credential-id: ${{secrets.ES_CREDENTIAL_ID}}
+          totp-secret: ${{secrets.ES_TOTP_SECRET}}
+
+      # Project references are not built so the bundle embeds the MSI produced above instead of relinking it, which would discard its signature
+      # The bundle file name carries the version, so it is resolved once here for the signing steps below
+      - name: Build installer
         id: create-installer
         if: matrix.create-installer
-        run: msbuild /nologo /maxCpuCount Bonsai.Setup.sln /p:Configuration=${{matrix.configuration}}
+        run: |
+          msbuild /nologo /maxCpuCount Bonsai.Setup.Bootstrapper/Bonsai.Setup.Bootstrapper.wixproj /p:Configuration=${{matrix.configuration}} /p:Platform=x86 /p:BuildProjectReferences=false
+          $bundle = Get-Item artifacts/bin/Bonsai.Setup.Bootstrapper/${{matrix.configuration-lower}}-x86/Bonsai-*.exe
+          "BundlePath=$($bundle.FullName)" >> $env:GITHUB_ENV
+
+      # ----------------------------------------------------------------------- Sign installer
+      # A Burn bundle takes two signatures: the engine is detached from the bundle, signed, and reattached, and only then can the bundle itself be signed
+      - name: Detach engine
+        if: matrix.create-installer && env.WillPublishPackages == 'true'
+        run: packages/wix.3.14.1/tools/insignia.exe -nologo -ib ${{env.BundlePath}} -o artifacts/BundleEngine.exe
+
+      - name: Sign engine
+        if: matrix.create-installer && env.WillPublishPackages == 'true'
+        uses: bonsai-rx/sign@c8502c075cfa2f3133607b8a6de308347f8beda2 # v1.0.0
+        with:
+          files: artifacts/BundleEngine.exe
+          username: ${{secrets.ES_USERNAME}}
+          password: ${{secrets.ES_PASSWORD}}
+          credential-id: ${{secrets.ES_CREDENTIAL_ID}}
+          totp-secret: ${{secrets.ES_TOTP_SECRET}}
+
+      - name: Reattach engine
+        if: matrix.create-installer && env.WillPublishPackages == 'true'
+        run: packages/wix.3.14.1/tools/insignia.exe -nologo -ab artifacts/BundleEngine.exe ${{env.BundlePath}} -o ${{env.BundlePath}}
+
+      - name: Sign installer
+        if: matrix.create-installer && env.WillPublishPackages == 'true'
+        uses: bonsai-rx/sign@c8502c075cfa2f3133607b8a6de308347f8beda2 # v1.0.0
+        with:
+          files: ${{env.BundlePath}}
+          username: ${{secrets.ES_USERNAME}}
+          password: ${{secrets.ES_PASSWORD}}
+          credential-id: ${{secrets.ES_CREDENTIAL_ID}}
+          totp-secret: ${{secrets.ES_TOTP_SECRET}}
 
       # ----------------------------------------------------------------------- Collect artifacts
       - name: Collect NuGet packages
@@ -311,7 +387,8 @@ jobs:
       # Needed to check out the workflow scripts and download build artifacts
       contents: read
       actions: read
-    needs: [build-and-test, determine-changed-packages]
+    # The push to NuGet.org cannot be undone, so we wait until every reversible part of the release has succeeded
+    needs: [build-and-test, determine-changed-packages, publish-github]
     # Release builds always publish packages to NuGet.org
     # Workflow dispatch builds will only publish packages if enabled and an explicit version number is given
     # This should be kept in sync with create-portable-zip
@@ -351,21 +428,17 @@ jobs:
       - name: Filter NuGet packages
         run: python .github/workflows/filter-release-packages.py ReleaseManifest Packages
 
-      # ----------------------------------------------------------------------- Push to NuGet.org
+      # ----------------------------------------------------------------------- Log in to NuGet.org
+      # Logging in before the docs update means a misconfigured trusted publishing policy stops the release before anything else moves
       - name: Log in to NuGet.org with OIDC
         uses: NuGet/login@v1
         id: nuget-login
         with:
           user: ${{secrets.NUGET_USER}}
 
-      - name: Push to NuGet.org
-        run: dotnet nuget push "Packages/*.nupkg" --api-key ${{steps.nuget-login.outputs.NUGET_API_KEY}} --source ${{vars.NUGET_API_URL}}
-        env:
-          # This is a workaround for https://github.com/NuGet/Home/issues/9775
-          DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER: 0
-
       # ----------------------------------------------------------------------- Dispatch docs repo update
       # This might seem like an odd spot to do this, but we need access to the PublicRelease environment for our secrets and using it in two jobs means two approvals are needed
+      # It runs before the push because the push cannot be undone, so a credential failure here should stop the release rather than strand it half published
       - name: Update version and submodule in ${{vars.DOCS_REPO}}
         if: github.event_name == 'release' && github.event.release.prerelease == false
         run: gh workflow run --repo "$DOCS_REPO" version-bump.yml --raw-field "project=$PROJECT" --raw-field "version=$VERSION" --raw-field "project-fork-url=$PROJECT_FORK_URL"
@@ -375,6 +448,14 @@ jobs:
           PROJECT: bonsai
           VERSION: ${{github.event.release.tag_name}}
           PROJECT_FORK_URL: ${{github.server_url}}/${{github.repository}}.git
+
+      # ----------------------------------------------------------------------- Push to NuGet.org
+      # This is the only step of the release which cannot be undone, so it goes last
+      - name: Push to NuGet.org
+        run: dotnet nuget push "Packages/*.nupkg" --api-key ${{steps.nuget-login.outputs.NUGET_API_KEY}} --source ${{vars.NUGET_API_URL}}
+        env:
+          # This is a workaround for https://github.com/NuGet/Home/issues/9775
+          DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER: 0
 
   # =====================================================================================================================================================================
   # Finish up release

--- a/tooling/Common.wixproj.props
+++ b/tooling/Common.wixproj.props
@@ -1,3 +1,8 @@
 <Project>
   <Import Project="Versioning.props" />
+
+  <!-- Solution properties are unused and warn when these projects are built on their own -->
+  <PropertyGroup>
+    <DefineSolutionProperties>false</DefineSolutionProperties>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Smart App Control now blocks unsigned executables with no option to "run anyway", so an unsigned installer is unusable on some modern releases of Windows 11. Here we sign executable release artifacts with the Bonsai Foundation code-signing certificate, through the reusable `bonsai-rx/sign` action over SSL.com eSigner cloud signing.

## Signing order

Signatures are applied in dependency order, because each later artifact carries a copy of an earlier one.

* The repacked `Bonsai.exe` is signed straight after the repack step. One signature there covers three consumers: the copy packed into the `Bonsai` package, the copy in `Bonsai.zip`, and the copy the MSI installs. Those three copies have to stay identical, since a local environment verifies whichever copy it finds against a [single recorded checksum per version](https://github.com/bonsai-rx/bonsai/blob/55df51f5b673950e9169d92d83ff28512c60a834/Bonsai.Configuration/EnvironmentSelector.cs#L158).
* The MSI is signed after it is built and before the bundle is built, since the bundle embeds it and records its hash.
* The bundle takes two signatures. A Burn bundle cannot be signed in one pass, because bundling rebuilds and reattaches the engine, so `insignia` detaches the engine, the engine is signed, `insignia` reattaches it, and the bundle is signed last.

CodeSignTool applies an RFC 3161 timestamp to each signature.

## Where the signing runs

The signature has to be applied while the build is still running, before the package, the portable zip and the MSI take their copies, so `build-and-test` now carries a conditional environment scoped to the single build matrix target that signs. On a publishing run the target that creates the installer runs in `PublicRelease`, and every other target runs in no environment at all. The signing credentials therefore live as environment secrets and are only reachable from an approved deployment, rather than being available to every run on every branch.

Releases now request two approvals for that environment, one for the signed installer target and the existing one for the NuGet push.

## Release ordering

The push to NuGet.org is the only step of a release that cannot be undone. A version can be deleted from nuget.org but never published again, whereas release assets can be replaced, the `latest` tag can be moved, the milestone can be reopened and the documentation site can be redeployed. So the push now waits for `publish-github`, and inside its own job it runs after the NuGet.org login and after the documentation dispatch.

The effect is that an expired documentation token now fails a job that has done nothing irreversible, and a re-run after replacing the token completes the release. Previously the same failure would leave packages published while the tag move, the version bump and the milestone close were all skipped.

This also narrows what #2635 has to solve. With the documentation dispatch now ahead of the push, an expired documentation token fails the release before anything irreversible has happened, so re-running the failed job becomes a safe recovery rather than a second attempt at an already completed push, which was the objection when re-running was discussed there. The only release credential whose failure can still occur after the irreversible step is the deploy key used by `finish-up-release`, and recovering from that by hand means moving a tag, bumping a version and closing a milestone rather than repairing a partially published release.

Closes #2641