### PR TITLE
Avoid caching serializer types on failure

### DIFF
--- a/Bonsai.Core.Tests/WorkflowBuilderTests.cs
+++ b/Bonsai.Core.Tests/WorkflowBuilderTests.cs
@@ -65,6 +65,28 @@ namespace Bonsai.Core.Tests
         }
 
         [TestMethod]
+        public void Serialize_FailedSerializerConstruction_SubsequentSerializationSuccessful()
+        {
+            // a workflow that cannot be serialized should not invalidate the serializer cache
+            // for any workflow serialized afterwards
+            var workflow = new WorkflowBuilder();
+            workflow.Workflow.Add(new CombinatorBuilder { Combinator = new DuplicateXmlTypeWithProperty() });
+            workflow.Workflow.Add(new CombinatorBuilder { Combinator = new OtherDuplicateXmlTypeWithProperty() });
+            Assert.ThrowsException<InvalidOperationException>(() => SerializeWorkflow(workflow));
+
+            var value = 5;
+            var validWorkflow = new WorkflowBuilder();
+            validWorkflow.Workflow.Add(new CombinatorBuilder
+            {
+                Combinator = new UniqueXmlTypeWithProperty { Property = value }
+            });
+            var xml = SerializeWorkflow(validWorkflow);
+            var roundTrip = DeserializeWorkflow(xml);
+            var combinator = (UniqueXmlTypeWithProperty)((CombinatorBuilder)roundTrip.Workflow.First().Value).Combinator;
+            Assert.AreEqual(value, combinator.Property);
+        }
+
+        [TestMethod]
         public void Serialize_NamespacePrefixClash_RoundTripSuccessful()
         {
             var value = 10;
@@ -119,6 +141,38 @@ namespace Bonsai.Core.Tests
             {
                 return expression;
             }
+        }
+    }
+
+    [XmlType("DuplicateXmlType", Namespace = Constants.XmlNamespace)]
+    public class DuplicateXmlTypeWithProperty : Combinator
+    {
+        public int Property { get; set; }
+
+        public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    [XmlType("DuplicateXmlType", Namespace = Constants.XmlNamespace)]
+    public class OtherDuplicateXmlTypeWithProperty : Combinator
+    {
+        public int Property { get; set; }
+
+        public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class UniqueXmlTypeWithProperty : Combinator
+    {
+        public int Property { get; set; }
+
+        public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
+        {
+            throw new NotImplementedException();
         }
     }
 

--- a/Bonsai.Core/WorkflowBuilder.cs
+++ b/Bonsai.Core/WorkflowBuilder.cs
@@ -407,12 +407,12 @@ namespace Bonsai
             {
                 if (serializerCache == null || !types.IsSubsetOf(serializerTypes))
                 {
-                    if (serializerTypes == null) serializerTypes = types;
-                    else serializerTypes.UnionWith(types);
+                    var updatedTypes = new HashSet<Type>(types);
+                    if (serializerTypes != null) updatedTypes.UnionWith(serializerTypes);
 
-                    genericTypeCache = new Dictionary<string, GenericTypeCode>();
+                    var updatedGenericTypes = new Dictionary<string, GenericTypeCode>();
                     XmlAttributeOverrides overrides = new XmlAttributeOverrides();
-                    foreach (var type in serializerTypes)
+                    foreach (var type in updatedTypes)
                     {
                         var xmlTypeDefined = Attribute.IsDefined(type, typeof(XmlTypeAttribute), inherit: false);
                         var attributes = new XmlAttributes();
@@ -432,17 +432,20 @@ namespace Bonsai
                             }
 
                             var typeName = codeProvider.GetTypeOutput(typeRef);
-                            genericTypeCache.Add(typeName, typeCode);
+                            updatedGenericTypes.Add(typeName, typeCode);
                             attributes.XmlType.TypeName = typeName;
                         }
                         attributes.XmlType.Namespace = GetXmlNamespace(type);
                         overrides.Add(type, attributes);
                     }
 
-                    var extraTypes = serializerTypes.Concat(SerializerExtraTypes).Concat(SerializerLegacyTypes).ToArray();
+                    var extraTypes = updatedTypes.Concat(SerializerExtraTypes).Concat(SerializerLegacyTypes).ToArray();
                     AddTypeAttributeOverrides(overrides, SerializerLegacyTypes);
                     var rootAttribute = new XmlRootAttribute(WorkflowNodeName) { Namespace = Constants.XmlNamespace };
-                    serializerCache = new XmlSerializer(typeof(ExpressionBuilderGraphDescriptor), overrides, extraTypes, rootAttribute, null);
+                    var serializer = new XmlSerializer(typeof(ExpressionBuilderGraphDescriptor), overrides, extraTypes, rootAttribute, null);
+                    serializerTypes = updatedTypes;
+                    genericTypeCache = updatedGenericTypes;
+                    serializerCache = serializer;
                 }
 
                 genericTypes = genericTypeCache;


### PR DESCRIPTION
The workflow serializer type set and generic type map are now assigned only after the serializer is successfully created. A workflow that cannot be serialized would otherwise leave the new types recorded against the previously cached serializer, so every later attempt in the same session would either reuse a serializer that knows nothing about them, or fail again while reporting types absent from the workflow being serialized.

The regression test builds a workflow with two operator types declaring the same XML type name, which cannot be serialized for reasons unrelated to any type argument, then checks that an unrelated workflow still serializes and round-trips afterwards.

Closes #2655
