### PR TITLE
Avoid XML type name clashes between type arguments

### DIFF
--- a/Bonsai.Core.Tests/WorkflowBuilderTests.cs
+++ b/Bonsai.Core.Tests/WorkflowBuilderTests.cs
@@ -65,6 +65,46 @@ namespace Bonsai.Core.Tests
         }
 
         [TestMethod]
+        public void Serialize_SameNameTypeArgumentsFromDifferentNamespaces_RoundTripSuccessful()
+        {
+            // identically named types from different namespaces are qualified by their CLR
+            // namespace when used as type arguments, so both operands can be serialized
+            var workflow = new WorkflowBuilder();
+            workflow.Workflow.Add(new HasFlagBuilder
+            {
+                Operand = new WorkflowProperty<FirstNamespace.ValueKind> { Value = FirstNamespace.ValueKind.Second }
+            });
+            workflow.Workflow.Add(new HasFlagBuilder
+            {
+                Operand = new WorkflowProperty<SecondNamespace.ValueKind> { Value = SecondNamespace.ValueKind.First }
+            });
+            var xml = SerializeWorkflow(workflow);
+            var roundTrip = DeserializeWorkflow(xml);
+            var operandTypes = roundTrip.Workflow.Select(node => ((HasFlagBuilder)node.Value).Operand.GetType());
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
+                    typeof(WorkflowProperty<FirstNamespace.ValueKind>),
+                    typeof(WorkflowProperty<SecondNamespace.ValueKind>)
+                },
+                operandTypes.ToArray());
+        }
+
+        [TestMethod]
+        public void Serialize_PrimitiveTypeArgument_RoundTripSuccessful()
+        {
+            // type arguments mapped to XML schema built-in types cannot be assigned any XML
+            // attributes, so they must be left unqualified
+            var value = 10L;
+            var workflow = new WorkflowBuilder();
+            workflow.Workflow.Add(new HasFlagBuilder { Operand = new WorkflowProperty<long> { Value = value } });
+            var xml = SerializeWorkflow(workflow);
+            var roundTrip = DeserializeWorkflow(xml);
+            var operand = (WorkflowProperty<long>)((HasFlagBuilder)roundTrip.Workflow.First().Value).Operand;
+            Assert.AreEqual(value, operand.Value);
+        }
+
+        [TestMethod]
         public void Serialize_FailedSerializerConstruction_SubsequentSerializationSuccessful()
         {
             // a workflow that cannot be serialized should not invalidate the serializer cache
@@ -141,6 +181,24 @@ namespace Bonsai.Core.Tests
             {
                 return expression;
             }
+        }
+    }
+
+    namespace FirstNamespace
+    {
+        public enum ValueKind
+        {
+            First = 1,
+            Second = 2
+        }
+    }
+
+    namespace SecondNamespace
+    {
+        public enum ValueKind
+        {
+            First = 1,
+            Second = 2
         }
     }
 

--- a/Bonsai.Core.Tests/WorkflowBuilderTests.cs
+++ b/Bonsai.Core.Tests/WorkflowBuilderTests.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
+using System.Xml.Linq;
 using System.Xml.Serialization;
 using Bonsai;
 using Bonsai.Expressions;
@@ -94,14 +95,89 @@ namespace Bonsai.Core.Tests
         public void Serialize_PrimitiveTypeArgument_RoundTripSuccessful()
         {
             // type arguments mapped to XML schema built-in types cannot be assigned any XML
-            // attributes, so they must be left unqualified
+            // attributes, either directly or through a nullable wrapper
             var value = 10L;
             var workflow = new WorkflowBuilder();
             workflow.Workflow.Add(new HasFlagBuilder { Operand = new WorkflowProperty<long> { Value = value } });
+            workflow.Workflow.Add(new HasFlagBuilder { Operand = new WorkflowProperty<int?>() });
             var xml = SerializeWorkflow(workflow);
             var roundTrip = DeserializeWorkflow(xml);
             var operand = (WorkflowProperty<long>)((HasFlagBuilder)roundTrip.Workflow.First().Value).Operand;
             Assert.AreEqual(value, operand.Value);
+        }
+
+        [TestMethod]
+        public void Serialize_SameNameNullableTypeArguments_RoundTripSuccessful()
+        {
+            // a nullable argument is named from its underlying type, so it is the underlying
+            // type which needs to be qualified
+            var workflow = new WorkflowBuilder();
+            workflow.Workflow.Add(new HasFlagBuilder { Operand = new WorkflowProperty<FirstNamespace.NullableKind?>() });
+            workflow.Workflow.Add(new HasFlagBuilder { Operand = new WorkflowProperty<SecondNamespace.NullableKind?>() });
+            var xml = SerializeWorkflow(workflow);
+            var roundTrip = DeserializeWorkflow(xml);
+            var operandTypes = roundTrip.Workflow.Select(node => ((HasFlagBuilder)node.Value).Operand.GetType());
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
+                    typeof(WorkflowProperty<FirstNamespace.NullableKind?>),
+                    typeof(WorkflowProperty<SecondNamespace.NullableKind?>)
+                },
+                operandTypes.ToArray());
+        }
+
+        [TestMethod]
+        public void Serialize_SameNameArrayTypeArguments_RoundTripSuccessful()
+        {
+            // an array argument is named from its element type, which is not included in the
+            // generic arguments of the declaring type
+            var workflow = new WorkflowBuilder();
+            workflow.Workflow.Add(new HasFlagBuilder { Operand = new WorkflowProperty<FirstNamespace.ArrayKind[]>() });
+            workflow.Workflow.Add(new HasFlagBuilder { Operand = new WorkflowProperty<SecondNamespace.ArrayKind[]>() });
+            var xml = SerializeWorkflow(workflow);
+            var roundTrip = DeserializeWorkflow(xml);
+            var operandTypes = roundTrip.Workflow.Select(node => ((HasFlagBuilder)node.Value).Operand.GetType());
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
+                    typeof(WorkflowProperty<FirstNamespace.ArrayKind[]>),
+                    typeof(WorkflowProperty<SecondNamespace.ArrayKind[]>)
+                },
+                operandTypes.ToArray());
+        }
+
+        [TestMethod]
+        public void Serialize_SelfDescribingTypeArgument_RoundTripSuccessful()
+        {
+            // type arguments which provide their own schema, or which are represented directly
+            // as XML nodes, reject any assigned XML attributes
+            var workflow = new WorkflowBuilder();
+            workflow.Workflow.Add(new HasFlagBuilder { Operand = new WorkflowProperty<XElement>() });
+            workflow.Workflow.Add(new HasFlagBuilder { Operand = new WorkflowProperty<XmlElement>() });
+            var xml = SerializeWorkflow(workflow);
+            var roundTrip = DeserializeWorkflow(xml);
+            var operandTypes = roundTrip.Workflow.Select(node => ((HasFlagBuilder)node.Value).Operand.GetType());
+            CollectionAssert.AreEquivalent(
+                new[] { typeof(WorkflowProperty<XElement>), typeof(WorkflowProperty<XmlElement>) },
+                operandTypes.ToArray());
+        }
+
+        [TestMethod]
+        public void Serialize_NestedTypeArgumentNamespaces_QualifiedTypeArguments()
+        {
+            // type arguments reachable only through a wrapper or a nested generic type still
+            // need their namespace declared, so encoded type arguments can be resolved on load
+            var workflow = new WorkflowBuilder();
+            workflow.Workflow.Add(new HasFlagBuilder { Operand = new WorkflowProperty<FirstNamespace.ValueKind?>() });
+            workflow.Workflow.Add(new HasFlagBuilder { Operand = new WorkflowProperty<FirstNamespace.ValueKind[]>() });
+            workflow.Workflow.Add(new SubscribeSubject<List<FirstNamespace.ValueKind>>());
+            var xml = SerializeWorkflow(workflow);
+            var prefix = Regex.Match(xml, @"xmlns:(\w+)=""clr-namespace:Bonsai\.Core\.Tests\.FirstNamespace;").Groups[1].Value;
+            Assert.IsFalse(string.IsNullOrEmpty(prefix));
+            StringAssert.Contains(xml, $"TypeArguments=\"sys:Nullable({prefix}:ValueKind)\"");
+            StringAssert.Contains(xml, $"TypeArguments=\"{prefix}:ValueKind[]\"");
+            StringAssert.Contains(xml, $"TypeArguments=\"scg:List({prefix}:ValueKind)\"");
+            DeserializeWorkflow(xml);
         }
 
         [TestMethod]
@@ -191,11 +267,35 @@ namespace Bonsai.Core.Tests
             First = 1,
             Second = 2
         }
+
+        public enum NullableKind
+        {
+            First = 1,
+            Second = 2
+        }
+
+        public enum ArrayKind
+        {
+            First = 1,
+            Second = 2
+        }
     }
 
     namespace SecondNamespace
     {
         public enum ValueKind
+        {
+            First = 1,
+            Second = 2
+        }
+
+        public enum NullableKind
+        {
+            First = 1,
+            Second = 2
+        }
+
+        public enum ArrayKind
         {
             First = 1,
             Second = 2

--- a/Bonsai.Core/WorkflowBuilder.cs
+++ b/Bonsai.Core/WorkflowBuilder.cs
@@ -265,6 +265,19 @@ namespace Bonsai
         static readonly string SystemCollectionsGenericNamespace = GetXmlNamespace(typeof(IEnumerable<>));
         static readonly Type[] SerializerExtraTypes = GetDefaultSerializerTypes().ToArray();
         static readonly Type[] SerializerLegacyTypes = GetSerializerLegacyTypes().ToArray();
+        static readonly HashSet<Type> XmlPrimitiveTypes = GetXmlPrimitiveTypes();
+
+        static HashSet<Type> GetXmlPrimitiveTypes()
+        {
+            return new HashSet<Type>
+            {
+                typeof(bool), typeof(byte), typeof(sbyte), typeof(short), typeof(ushort),
+                typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float),
+                typeof(double), typeof(decimal), typeof(char), typeof(string),
+                typeof(DateTime), typeof(TimeSpan), typeof(DateTimeOffset), typeof(Guid),
+                typeof(XmlQualifiedName), typeof(byte[])
+            };
+        }
 
         static IEnumerable<Type> GetDefaultSerializerTypes()
         {
@@ -370,6 +383,51 @@ namespace Bonsai
             }
         }
 
+        static void AddTypeArgumentOverrides(XmlAttributeOverrides overrides, IEnumerable<Type> types)
+        {
+            foreach (var type in types)
+            {
+                AddTypeArgumentOverrides(overrides, type);
+            }
+        }
+
+        static void AddTypeArgumentOverrides(XmlAttributeOverrides overrides, Type type)
+        {
+            if (!type.IsGenericType) return;
+            var typeArguments = type.GetGenericArguments();
+            for (int i = 0; i < typeArguments.Length; i++)
+            {
+                AddTypeNamespaceOverride(overrides, typeArguments[i]);
+            }
+        }
+
+        static bool SupportsXmlTypeOverride(Type type)
+        {
+            return !XmlPrimitiveTypes.Contains(type)
+                && !typeof(XmlNode).IsAssignableFrom(type)
+                && !typeof(IXmlSerializable).IsAssignableFrom(type);
+        }
+
+        static void AddTypeNamespaceOverride(XmlAttributeOverrides overrides, Type type)
+        {
+            if (!SupportsXmlTypeOverride(type)) return;
+            var elementType = Nullable.GetUnderlyingType(type) ?? (type.IsArray ? type.GetElementType() : null);
+            if (elementType != null)
+            {
+                AddTypeNamespaceOverride(overrides, elementType);
+                return;
+            }
+
+            if (overrides[type] != null) return;
+            var xmlType = (XmlTypeAttribute)Attribute.GetCustomAttribute(type, typeof(XmlTypeAttribute), inherit: false);
+            if (xmlType == null) xmlType = new XmlTypeAttribute();
+            else if (!string.IsNullOrEmpty(xmlType.Namespace)) return;
+
+            xmlType.Namespace = GetXmlNamespace(type);
+            overrides.Add(type, new XmlAttributes { XmlType = xmlType });
+            AddTypeArgumentOverrides(overrides, type);
+        }
+
         static XmlSerializer GetXmlSerializerLegacy(HashSet<Type> serializerTypes)
         {
             var overrides = new XmlAttributeOverrides();
@@ -441,6 +499,7 @@ namespace Bonsai
 
                     var extraTypes = updatedTypes.Concat(SerializerExtraTypes).Concat(SerializerLegacyTypes).ToArray();
                     AddTypeAttributeOverrides(overrides, SerializerLegacyTypes);
+                    AddTypeArgumentOverrides(overrides, updatedTypes);
                     var rootAttribute = new XmlRootAttribute(WorkflowNodeName) { Namespace = Constants.XmlNamespace };
                     var serializer = new XmlSerializer(typeof(ExpressionBuilderGraphDescriptor), overrides, extraTypes, rootAttribute, null);
                     serializerTypes = updatedTypes;

--- a/Bonsai.Core/WorkflowBuilder.cs
+++ b/Bonsai.Core/WorkflowBuilder.cs
@@ -319,16 +319,31 @@ namespace Bonsai
             return ClrNamespace.FromType(type).ToString();
         }
 
+        static IEnumerable<Type> GetTypeArgumentClosure(Type type)
+        {
+            while (type.IsArray)
+            {
+                type = type.GetElementType();
+                yield return type;
+            }
+
+            if (!type.IsGenericType) yield break;
+            var typeArguments = type.GetGenericArguments();
+            for (int i = 0; i < typeArguments.Length; i++)
+            {
+                yield return typeArguments[i];
+                foreach (var nestedArgument in GetTypeArgumentClosure(typeArguments[i]))
+                {
+                    yield return nestedArgument;
+                }
+            }
+        }
+
         static void GetClrNamespaces(Type type, Dictionary<ClrNamespace, Assembly> clrNamespaces)
         {
-            clrNamespaces[ClrNamespace.FromType(type)] = type.Assembly;
-            if (type.IsGenericType)
+            foreach (var closureType in GetTypeArgumentClosure(type).Prepend(type))
             {
-                var typeArguments = type.GetGenericArguments();
-                for (int i = 0; i < typeArguments.Length; i++)
-                {
-                    GetClrNamespaces(typeArguments[i], clrNamespaces);
-                }
+                clrNamespaces[ClrNamespace.FromType(closureType)] = closureType.Assembly;
             }
         }
 
@@ -393,11 +408,9 @@ namespace Bonsai
 
         static void AddTypeArgumentOverrides(XmlAttributeOverrides overrides, Type type)
         {
-            if (!type.IsGenericType) return;
-            var typeArguments = type.GetGenericArguments();
-            for (int i = 0; i < typeArguments.Length; i++)
+            foreach (var typeArgument in GetTypeArgumentClosure(type))
             {
-                AddTypeNamespaceOverride(overrides, typeArguments[i]);
+                AddTypeNamespaceOverride(overrides, typeArgument);
             }
         }
 
@@ -411,21 +424,22 @@ namespace Bonsai
         static void AddTypeNamespaceOverride(XmlAttributeOverrides overrides, Type type)
         {
             if (!SupportsXmlTypeOverride(type)) return;
-            var elementType = Nullable.GetUnderlyingType(type) ?? (type.IsArray ? type.GetElementType() : null);
-            if (elementType != null)
-            {
-                AddTypeNamespaceOverride(overrides, elementType);
-                return;
-            }
-
             if (overrides[type] != null) return;
-            var xmlType = (XmlTypeAttribute)Attribute.GetCustomAttribute(type, typeof(XmlTypeAttribute), inherit: false);
-            if (xmlType == null) xmlType = new XmlTypeAttribute();
-            else if (!string.IsNullOrEmpty(xmlType.Namespace)) return;
+            var xmlType = GetXmlTypeAttribute(type);
+            if (!string.IsNullOrEmpty(xmlType.Namespace)) return;
+            AddXmlTypeOverride(overrides, type, xmlType);
+        }
 
+        static XmlTypeAttribute GetXmlTypeAttribute(Type type)
+        {
+            var xmlType = (XmlTypeAttribute)Attribute.GetCustomAttribute(type, typeof(XmlTypeAttribute), inherit: false);
+            return xmlType ?? new XmlTypeAttribute();
+        }
+
+        static void AddXmlTypeOverride(XmlAttributeOverrides overrides, Type type, XmlTypeAttribute xmlType)
+        {
             xmlType.Namespace = GetXmlNamespace(type);
             overrides.Add(type, new XmlAttributes { XmlType = xmlType });
-            AddTypeArgumentOverrides(overrides, type);
         }
 
         static XmlSerializer GetXmlSerializerLegacy(HashSet<Type> serializerTypes)
@@ -472,29 +486,23 @@ namespace Bonsai
                     XmlAttributeOverrides overrides = new XmlAttributeOverrides();
                     foreach (var type in updatedTypes)
                     {
-                        var xmlTypeDefined = Attribute.IsDefined(type, typeof(XmlTypeAttribute), inherit: false);
-                        var attributes = new XmlAttributes();
-                        attributes.XmlType = xmlTypeDefined
-                            ? (XmlTypeAttribute)Attribute.GetCustomAttribute(type, typeof(XmlTypeAttribute))
-                            : new XmlTypeAttribute();
-                        
+                        var xmlType = GetXmlTypeAttribute(type);
                         if (type.IsGenericType)
                         {
                             var typeRef = new CodeTypeReference(type);
                             var typeCode = GenericTypeCode.FromType(type);
                             var genericSeparatorIndex = type.Name.LastIndexOf('`');
-                            if (xmlTypeDefined && !string.IsNullOrEmpty(attributes.XmlType.TypeName))
+                            if (!string.IsNullOrEmpty(xmlType.TypeName))
                             {
-                                typeRef.BaseType = type.Namespace + "." + attributes.XmlType.TypeName + type.Name.Substring(genericSeparatorIndex);
-                                typeCode.Name = attributes.XmlType.TypeName;
+                                typeRef.BaseType = type.Namespace + "." + xmlType.TypeName + type.Name.Substring(genericSeparatorIndex);
+                                typeCode.Name = xmlType.TypeName;
                             }
 
                             var typeName = codeProvider.GetTypeOutput(typeRef);
                             updatedGenericTypes.Add(typeName, typeCode);
-                            attributes.XmlType.TypeName = typeName;
+                            xmlType.TypeName = typeName;
                         }
-                        attributes.XmlType.Namespace = GetXmlNamespace(type);
-                        overrides.Add(type, attributes);
+                        AddXmlTypeOverride(overrides, type, xmlType);
                     }
 
                     var extraTypes = updatedTypes.Concat(SerializerExtraTypes).Concat(SerializerLegacyTypes).ToArray();


### PR DESCRIPTION
Identically named types from different assemblies would collide when used as generic type arguments of a workflow element type, so e.g. a workflow using `HasFlag` on the digital inputs of two different Harp devices could not be saved, as described in #2654. `HasFlag` is not itself a generic operator, but it stores its operand in a `WorkflowProperty<T>`, and it is the closed instantiation of that core type, here `WorkflowProperty<DigitalInputs>`, which reaches the serializer as a workflow element type.

Element types have their XML type namespace assigned from their CLR namespace [when the serializer overrides are built](https://github.com/bonsai-rx/bonsai/blob/ba3abbcb07d7f64aff63aca613587a71858bd806/Bonsai.Core/WorkflowBuilder.cs#L415-L439), and base types were brought into the same scheme by [the base type walk](https://github.com/bonsai-rx/bonsai/blob/ba3abbcb07d7f64aff63aca613587a71858bd806/Bonsai.Core/WorkflowBuilder.cs#L495-L501) added when #1056 was fixed. Type arguments were never assigned a namespace of their own, so the serializer named them from the namespace of the declaring type, which for the generic element types defined in `Bonsai.Core` is the workflow namespace. Two enums named `DigitalInputs` from different device packages therefore ended up sharing an XML type name. Type arguments are now qualified with their CLR namespace when the argument declares no XML namespace of its own, in the same way element types already are.

Nullable and array arguments reach the same collision, which had not been reported and came up while investigating this issue. The type argument closure reaches through them to the underlying element type, since that is the type the mapping is named from, and arguments that are themselves generic, e.g. `WorkflowProperty<List<DigitalInputs>>`, are covered recursively.

This PR also removes the divergence that made this possible in the first place. The namespace prefix declarations and the XML type overrides were each walking the generic arguments of an element type with their own recursion, and this bug was those two walks disagreeing, since the declarations covered type arguments while the overrides did not. Both now derive from a single type argument closure, so they cover the same types by construction, and each of the exclusions above is covered by a test.

Two review notes. An argument that declares its own `[XmlType]` namespace keeps it, which is deliberately narrower than the treatment of element types, where the namespace is reassigned unconditionally. This leaves one case unresolved, which is two same-named types that both declare an XML type name without a namespace. The legacy serializer used for workflows carrying pre-2.4 extension type markup keeps the original behavior, since the packages where this occurs are much more recent than that format.

Closes #2654