### PR TITLE
Add netstandard2.0 target to Bonsai.Dsp, Bonsai.Osc and Bonsai.Vision

### DIFF
--- a/Bonsai.Dsp/Bonsai.Dsp.csproj
+++ b/Bonsai.Dsp/Bonsai.Dsp.csproj
@@ -3,7 +3,7 @@
     <Description>This package provides operators for real-time digital signal processing.</Description>
     <PackageTags>Bonsai Rx Dsp Signal Processing</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />

--- a/Bonsai.Osc/Bonsai.Osc.csproj
+++ b/Bonsai.Osc/Bonsai.Osc.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This package provides operators to communicate with devices implementing the Open Sound Control specification.</Description>
     <PackageTags>Bonsai Rx Osc</PackageTags>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.System\Bonsai.System.csproj" />

--- a/Bonsai.Vision/Bonsai.Vision.csproj
+++ b/Bonsai.Vision/Bonsai.Vision.csproj
@@ -2,10 +2,13 @@
   <PropertyGroup>
     <Description>This package provides operators for real-time computer vision and image processing.</Description>
     <PackageTags>Bonsai Rx Image Processing Computer Vision</PackageTags>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonsai.Dsp\Bonsai.Dsp.csproj" />


### PR DESCRIPTION
Adds a `netstandard2.0` target to Bonsai.Dsp, Bonsai.Osc, and Bonsai.Vision, making them usable from .NET packages. A conditional `System.Drawing.Common` reference was added to Bonsai.Vision for the non-.NET Framework target.

Closes #2663 